### PR TITLE
[FIX] Add context propagation for m2m list view

### DIFF
--- a/addons/web/static/src/js/view_list.js
+++ b/addons/web/static/src/js/view_list.js
@@ -1073,7 +1073,7 @@ instance.web.ListView.List = instance.web.Class.extend( /** @lends instance.web.
                     ids = value;
                 }
                 new instance.web.Model(column.relation)
-                    .call('name_get', [ids]).done(function (names) {
+                    .call('name_get', [ids, this.dataset.context]).done(function (names) {
                         // FIXME: nth horrible hack in this poor listview
                         record.set(column.id + '__display',
                                    _(names).pluck(1).join(', '));


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/17

Fix bug https://bugs.launchpad.net/openerp-web/+bug/1279885 :
    Many2many fields in Tree views will not get translated.
    If you check the context for a name_get of a m2m field, it is passed as
    None.

Add context propagation to m2m fields in list views.
Fix translation issues when viewing a a many2many field in a Tree view.
