### PR TITLE
[FIX] Translate description in chatter widget (7.0 lp:1262000)

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -253,7 +253,7 @@ class mail_thread(osv.AbstractModel):
 
         # automatic logging unless asked not to (mainly for various testing purpose)
         if not context.get('mail_create_nolog'):
-            self.message_post(cr, uid, thread_id, body=_('%s created') % (self._description), context=context)
+            self.message_post(cr, uid, thread_id, body=_('%s created') % (_(self._description)), context=context)
 
         # auto_subscribe: take values and defaults into account
         create_values = dict(values)

--- a/openerp/tools/translate.py
+++ b/openerp/tools/translate.py
@@ -778,6 +778,11 @@ def trans_generate(lang, modules, cr):
                 except (IOError, etree.XMLSyntaxError):
                     _logger.exception("couldn't export translation for report %s %s %s", name, report_type, fname)
 
+        elif model == 'ir.model':
+            model_pool = pool.get(obj.model)
+            if model_pool:
+                push_translation(module, 'code', '_description', 0, model_pool._description)
+
         for field_name,field_def in obj._table._columns.items():
             if field_def.translate:
                 name = model + "," + field_name


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/20

Fix https://bugs.launchpad.net/openobject-addons/+bug/1262000 :
    When an object which inherits mail.thread with description OBJECT is
    created, a message is posted saying:
        OBJECT created.
    In french, this is translated as:
        OBJECT créé(e).
    The problem is that OBJECT isn't translated.

Add _description to translation exports
Translate _description in mail_thread on create with current user's
context which matches the rest of the create string '%s created'
