### PR TITLE
[FIX] Removes the limit of 64 characters from additional text fields added via the interface

### DIFF
--- a/openerp/addons/base/ir/ir.xml
+++ b/openerp/addons/base/ir/ir.xml
@@ -1130,7 +1130,7 @@
                                                                           'readonly': [('ttype','not in', ['many2one','one2many','many2many'])]}"/>
                                 <field name="relation_field" attrs="{'required': [('ttype','=','one2many')], 'readonly': [('ttype','!=','one2many')]}"/>
                                 <field name="selection" attrs="{'required': [('ttype','in',['selection','reference'])], 'readonly': [('ttype','not in',['selection','reference'])]}"/>
-                                <field name="size" attrs="{'required': [('ttype','in',['char','reference'])], 'readonly': [('ttype','not in',['char','reference'])]}"/>
+                                <field name="size" attrs="{'invisible': [('ttype','not in',['char','text','reference'])]}"/>
                                 <field name="domain" attrs="{'readonly': [('relation','=','')]}"/>
                                 <field name="serialization_field_id" attrs="{'readonly': [('state','=','base')]}" domain = "[('ttype','=','serialized'), ('model_id', '=', model_id)]"/>
                             </group>

--- a/openerp/addons/base/ir/ir_model.py
+++ b/openerp/addons/base/ir/ir_model.py
@@ -233,7 +233,6 @@ class ir_model_fields(osv.osv):
         'state': lambda self,cr,uid,ctx={}: (ctx and ctx.get('manual',False)) and 'manual' or 'base',
         'on_delete': 'set null',
         'select_level': '0',
-        'size': 64,
         'field_description': '',
         'selectable': 1,
     }
@@ -263,10 +262,10 @@ class ir_model_fields(osv.osv):
         return True
 
     def _size_gt_zero_msg(self, cr, user, ids, context=None):
-        return _('Size of the field can never be less than 1 !')
+        return _('Size of the field can never be less than 0 !')
 
     _sql_constraints = [
-        ('size_gt_zero', 'CHECK (size>0)',_size_gt_zero_msg ),
+        ('size_gt_zero', 'CHECK (size>=0)',_size_gt_zero_msg ),
     ]
 
     def unlink(self, cr, user, ids, context=None):

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1025,7 +1025,7 @@ class BaseModel(object):
                     'required': bool(field['required']),
                     'readonly': bool(field['readonly']),
                     'domain': eval(field['domain']) if field['domain'] else None,
-                    'size': field['size'],
+                    'size': field['size'] or None,
                     'ondelete': field['on_delete'],
                     'translate': (field['translate']),
                     'manual': True,


### PR DESCRIPTION
[FIX] Removes the limit of 64 characters from additional text fields added via the interface

https://bugs.launchpad.net/openobject-server/+bug/1053511

This change is the same as done in:
http://bazaar.launchpad.net/~openerp-dev/openobject-server/7.0-opw-582876-cbi/revision/4908
