### PR TITLE
Multiple Price different move from anglo saxon module

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -133,7 +133,7 @@ class account_invoice(osv.osv):
                     result[invoice.id] = new_value
 
             #prevent the residual amount on the invoice to be less than 0
-            result[invoice.id] = max(result[invoice.id], 0.0)            
+            result[invoice.id] = max(result[invoice.id], 0.0)
         return result
 
     # Give Journal Items related to the payment reconciled to this invoice
@@ -1566,6 +1566,7 @@ class account_invoice_line(osv.osv):
         company_currency = self.pool['res.company'].browse(cr, uid, inv.company_id.id).currency_id.id
         for line in inv.invoice_line:
             mres = self.move_line_get_item(cr, uid, line, context)
+            mres['invl_id'] = line.id
             if not mres:
                 continue
             res.append(mres)

--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -133,7 +133,7 @@ class account_invoice(osv.osv):
                     result[invoice.id] = new_value
 
             #prevent the residual amount on the invoice to be less than 0
-            result[invoice.id] = max(result[invoice.id], 0.0)
+            result[invoice.id] = max(result[invoice.id], 0.0)            
         return result
 
     # Give Journal Items related to the payment reconciled to this invoice

--- a/addons/account_anglo_saxon/invoice.py
+++ b/addons/account_anglo_saxon/invoice.py
@@ -1,8 +1,8 @@
 ##############################################################################
-#    
+#
 #    OpenERP, Open Source Management Solution
-#    Copyright (C) 
-#    2004-2010 Tiny SPRL (<http://tiny.be>). 
+#    Copyright (C)
+#    2004-2010 Tiny SPRL (<http://tiny.be>).
 #    2009-2010 Veritos (http://veritos.nl).
 #    All Rights Reserved
 #
@@ -17,7 +17,7 @@
 #    GNU Affero General Public License for more details.
 #
 #    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.     
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 
@@ -115,6 +115,8 @@ class account_invoice_line(osv.osv):
                         diff_res = []
                         # calculate and write down the possible price difference between invoice price and product price
                         for line in res:
+                            if line.get('invl_id', False) != i_line.id:
+                                continue
                             if a == line['account_id'] and i_line.product_id.id == line['product_id']:
                                 uom = i_line.product_id.uos_id or i_line.product_id.uom_id
                                 standard_price = self.pool.get('product.uom')._compute_price(cr, uid, uom.id, i_line.product_id.standard_price, i_line.uos_id.id)

--- a/addons/account_anglo_saxon/invoice.py
+++ b/addons/account_anglo_saxon/invoice.py
@@ -115,7 +115,7 @@ class account_invoice_line(osv.osv):
                         diff_res = []
                         # calculate and write down the possible price difference between invoice price and product price
                         for line in res:
-                            if line.get('invl_id', False) != i_line.id:
+                            if line.get('invl_id') != i_line.id:
                                 continue
                             if a == line['account_id'] and i_line.product_id.id == line['product_id']:
                                 uom = i_line.product_id.uos_id or i_line.product_id.uom_id

--- a/addons/account_anglo_saxon/invoice.py
+++ b/addons/account_anglo_saxon/invoice.py
@@ -1,8 +1,8 @@
 ##############################################################################
-#
+#    
 #    OpenERP, Open Source Management Solution
-#    Copyright (C)
-#    2004-2010 Tiny SPRL (<http://tiny.be>).
+#    Copyright (C) 
+#    2004-2010 Tiny SPRL (<http://tiny.be>). 
 #    2009-2010 Veritos (http://veritos.nl).
 #    All Rights Reserved
 #
@@ -17,7 +17,7 @@
 #    GNU Affero General Public License for more details.
 #
 #    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.     
 #
 ##############################################################################
 


### PR DESCRIPTION
Upstream PR: https://github.com/odoo/odoo/pull/704
## Bug In case of Same product appears more than one time in single supplier invoice. 

**Possibility are when / Step to reproduce.**
- Pre-Configuration required in category/product Price different account, Stock valuation Account, Stock Input Account, Stock Output Account. account_anglo_saxon module is installed.
- We have purchase order with unit price different than Cost price and QTY 500.
- Invoicing Control = Based on incoming shipments
- We have 5 lots when receive products from supplier So Split lines into 5 lines.
- Create invoice from the Incoming Shipment.
- It will create Supplier invoice with 5 Lines with same product .
- Validate Supplier Invoice.
  It will create 5 move line for product account with cost price, Tax line (if any), Total creditor account, and 5*5 = 25 Price different move lines. 

**Here the bug is it has to have only 5 price different move lines.**

Cause is in  account_anglo_saxon/invoice.py it is comparing move lines (provided by move_line_get method ) and invoice line with account_id and product_id.
So for all 5 lines account_id and product_id are same so it is creating lines n times for each invoice line.

**Changes done.**
- Add Line Id from move line get in account/account_invoice.py
- Add condition while generating price difference move account_anglo_saxon/invoice.py.
