### PR TITLE
Fix regression: crashed when budget position has no accounts. Fixes OCA/OCB#14

### DIFF
--- a/addons/account_budget/account_budget.py
+++ b/addons/account_budget/account_budget.py
@@ -117,9 +117,9 @@ class crossovered_budget_lines(osv.osv):
         account_obj = self.pool.get('account.account')
         for line in self.browse(cr, uid, ids, context=context):
             acc_ids = [x.id for x in line.general_budget_id.account_ids]
-            acc_ids = account_obj._get_children_and_consol(cr, uid, acc_ids, context=context)
             if not acc_ids:
                 raise osv.except_osv(_('Error!'),_("The Budget '%s' has no accounts!") % ustr(line.general_budget_id.name))
+            acc_ids = account_obj._get_children_and_consol(cr, uid, acc_ids, context=context)
             date_to = line.date_to
             date_from = line.date_from
             if context.has_key('wizard_date_from'):


### PR DESCRIPTION
This is a regression introduced in OCB when budgets were extended to include sub-accounts because the method called is not empty-list-proof.
