### PR TITLE
[FIX] use matching operator to get patner from email in mail_thread.

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -477,9 +477,9 @@ class mail_thread(osv.AbstractModel):
         partner_ids = []
         s = ', '.join([decode(message.get(h)) for h in header_fields if message.get(h)])
         for email_address in tools.email_split(s):
-            related_partners = partner_obj.search(cr, uid, [('email', 'ilike', email_address), ('user_ids', '!=', False)], limit=1, context=context)
+            related_partners = partner_obj.search(cr, uid, [('email', '=ilike', email_address), ('user_ids', '!=', False)], limit=1, context=context)
             if not related_partners:
-                related_partners = partner_obj.search(cr, uid, [('email', 'ilike', email_address)], limit=1, context=context)
+                related_partners = partner_obj.search(cr, uid, [('email', '=ilike', email_address)], limit=1, context=context)
             partner_ids += related_partners
         return partner_ids
 


### PR DESCRIPTION
Fix issue #856.

The current operator to match email and partner is ilike but it add wildcards around right criteria so we can have false positive.

eg I'v got an email in my customer base like a_mail@provider.com

If I recive a mail from mail@provider.com as ilike operator uses wildcards a_mail@provider.com can potentially be matched.
