### PR TITLE
[FIX] Sync purchase orders on requistition unlink/cancel

### DIFF
--- a/addons/purchase_requisition/test/cancel_purchase_requisition.yml
+++ b/addons/purchase_requisition/test/cancel_purchase_requisition.yml
@@ -2,25 +2,25 @@
   I cancel requisition.
 -
   !python {model: purchase.requisition}: |
-    self.tender_cancel(cr, uid, [ref("requisition1")])
+    self.tender_cancel(cr, uid, [ref("requisition2")])
 -
   I check requisition after cancelled.
 -
-  !assert {model: purchase.requisition, id: requisition1}:
+  !assert {model: purchase.requisition, id: requisition2}:
     - state == 'cancel'
 -
   I reset requisition as "New".
 -
   !python {model: purchase.requisition}: |
-    self.tender_reset(cr, uid, [ref('requisition1')])
+    self.tender_reset(cr, uid, [ref('requisition2')])
 -
   I duplicate requisition.
 -
   !python {model: purchase.requisition}: |
-    self.copy(cr, uid, ref('requisition1'))
+    self.copy(cr, uid, ref('requisition2'))
 -
   I delete requisition.
 -
-  !python {model: purchase.order}: |
-    self.unlink(cr, uid, [ref("requisition1")])
+  !python {model: purchase.requisition}: |
+    self.unlink(cr, uid, [ref("requisition2")])
 

--- a/addons/purchase_requisition/test/purchase_requisition.yml
+++ b/addons/purchase_requisition/test/purchase_requisition.yml
@@ -88,3 +88,14 @@
     (data, format) = netsvc.LocalService('report.purchase.requisition').create(cr, uid, [ref('purchase_requisition.requisition1')], {}, {})
     if tools.config['test_report_directory']:
         file(os.path.join(tools.config['test_report_directory'], 'purchase_requisition-purchase_requisition_report.'+format), 'wb+').write(data)
+-
+  I check that I cannot cancel the requisision
+-
+  !python {model: purchase.requisition}: |
+    from openerp.osv.osv import except_osv
+    try:
+        self.tender_cancel(cr, uid, [ref("requisition1")])
+    except except_osv, exc:
+        assert exc.args == (u'Unable to cancel this purchase order.', u'First cancel all receptions related to this purchase order.')
+    else:
+        assert False, 'tender_cancel should have failed'

--- a/addons/purchase_requisition/test/purchase_requisition_demo.yml
+++ b/addons/purchase_requisition/test/purchase_requisition_demo.yml
@@ -7,4 +7,10 @@
       - product_id: product.product_product_9
         product_qty: 10.0
         product_uom_id: product.product_uom_unit
-  
+-
+  !record {model: purchase.requisition, id: requisition2}:
+    exclusive: exclusive
+    line_ids:
+      - product_id: product.product_product_13
+        product_qty: 10.0
+        product_uom_id: product.product_uom_unit


### PR DESCRIPTION
Port of https://code.launchpad.net/~camptocamp/openobject-addons/7.0-fix_1220716-rha+srt+afe, as the remaining part of the failed merge of http://bazaar.launchpad.net/~ocb/ocb-addons/7.0/revision/9628 during the lp@gh migration (other changes are included in the upstream commit http://bazaar.launchpad.net/~openerp/openobject-addons/7.0/revision/9651.

Upstream PR https://github.com/odoo/odoo/pull/1152
