### PR TITLE
[IMP] Show the button 'view delivery order' as soon as a picking exists

### DIFF
--- a/addons/purchase/stock_view.xml
+++ b/addons/purchase/stock_view.xml
@@ -45,9 +45,11 @@
             <field name="arch" type="xml">
                  <xpath expr="//div[contains(@class, 'oe_title')]" position="before">
                     <div class="oe_right oe_button_box" name="buttons">
+                        <field name="picking_ids" invisible="1"/>
                         <button type="object"
                             name="view_picking"
-                            string="Incoming Shipments" states="approved"/>
+                            string="Incoming Shipments"
+                            attrs="{'invisible': ['|',('picking_ids','=',False),('picking_ids','=',[])]}"/>
                         <button type="object"  name="invoice_open"
                             string="Invoices" attrs="{'invisible': [('state', '=', 'draft')]}"/> 
                     </div>

--- a/addons/sale_stock/sale_stock_view.xml
+++ b/addons/sale_stock/sale_stock_view.xml
@@ -40,7 +40,7 @@
                    <xpath expr="//button[@name='action_view_invoice']" position="after">
                        <field name="picking_ids" invisible="1"/>
                        <button name="action_view_delivery" string="View Delivery Order" type="object" class="oe_highlight"
-                           attrs="{'invisible': ['|','|','|',('picking_ids','=',False),('picking_ids','=',[]), ('state', 'not in', ('progress','manual')),('shipped','=',True)]}" groups="base.group_user"/>
+                           attrs="{'invisible': ['|',('picking_ids','=',False),('picking_ids','=',[])]}" groups="base.group_user"/>
                    </xpath>
                     <xpath expr="//button[@name='action_cancel']" position="after">
                         <button name="ship_cancel" states="shipping_except" string="Cancel Order"/>


### PR DESCRIPTION
The button should appear no matter the state of the sale order, to be consistent with the rest of the application.
This makes it much faster for the sales person to find out about orders in shipping exceptions

Already fixed in v8:
Sales: https://github.com/odoo/odoo/commit/57ad75b
Purchases: https://github.com/odoo/odoo/commit/cea4861
