### PR TITLE
[IMP] Avoid to recatch error when OpenERP/Odoo is starting with the opti...

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -2261,6 +2261,7 @@ class BaseModel(object):
                 view = getattr(self, '_get_default_%s_view' % view_type)(
                     cr, user, context)
             except AttributeError:
+                if config['debug_mode']: raise
                 # what happens here, graph case?
                 raise except_orm(_('Invalid Architecture!'), _("There is no view of type '%s' defined for the structure!") % view_type)
 

--- a/openerp/osv/osv.py
+++ b/openerp/osv/osv.py
@@ -35,6 +35,7 @@ import openerp.sql_db as sql_db
 from openerp.tools.translate import translate
 from openerp.osv.orm import MetaModel, Model, TransientModel, AbstractModel
 import openerp.exceptions
+from openerp.tools.config import config
 
 import time
 import random
@@ -142,11 +143,13 @@ class object_proxy(object):
                     _logger.info("%s, retry %d/%d in %.04f sec..." % (errorcodes.lookup(e.pgcode), tries, MAX_TRIES_ON_CONCURRENCY_FAILURE, wait_time))
                     time.sleep(wait_time)
                 except orm.except_orm, inst:
+                    if config['debug_mode']: raise
                     _, _, tb = sys.exc_info()
                     raise except_osv(inst.name, inst.value), None, tb
                 except except_osv:
                     raise
                 except IntegrityError, inst:
+                    if config['debug_mode']: raise
                     osv_pool = pooler.get_pool(dbname)
                     for key in osv_pool._sql_error.keys():
                         if key in inst[0]:


### PR DESCRIPTION
Hi all
This change only impact OpenERP/Odoo when it's started in debug mode (so it's only usefull for dev)
The idea is to avoid the "recatch" of error when we start OpenERP in debug mode. It help me a lot to debug OpenERP so I share it (I remember some tricky bug, where view was corrupted after an update, as OpenERP was recatching the bug, it was imposible to understand without removing the recatch) . I do not ask a PR to official as OpenERP SA think it's useless (https://code.launchpad.net/~sebastien.beau/openobject-server/openobject-server-debug-mode/+merge/113996).

But if community is interrested than we can merge it. (If you have an other solution tell me)
