### PR TITLE
[FIX] Resolve default_composition_mode key missing

### DIFF
--- a/addons/email_template/email_template.py
+++ b/addons/email_template/email_template.py
@@ -341,7 +341,7 @@ class email_template(osv.osv):
             service = netsvc.LocalService(report_service)
             (result, format) = service.create(cr, uid, [res_id], {'model': template.model}, ctx)
             # TODO in trunk, change return format to binary to match message_post expected format
-            if not ctx['default_composition_mode'] == 'mass_mail':
+            if not ctx.get('default_composition_mode', False) == 'mass_mail':
                 result = base64.b64encode(result)
             if not report_name:
                 report_name = report_service


### PR DESCRIPTION
Email previews were being prevented when default_composition_mode key was not available in context.
