### PR TITLE
prevent the constraint to be recreated on update

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -557,8 +557,10 @@ class account_move_line(osv.osv):
     }
     _order = "date desc, id desc"
     _sql_constraints = [
-        ('credit_debit1', 'CHECK (credit*debit=0)',  'Wrong credit or debit value in accounting entry !'),
-        ('credit_debit2', 'CHECK (credit+debit>=0)', 'Wrong credit or debit value in accounting entry !'),
+        ('credit_debit1', 'CHECK ((credit * debit) = 0::numeric)',
+         'Wrong credit or debit value in accounting entry !'),
+        ('credit_debit2', 'CHECK ((credit + debit) >= 0::numeric)',
+         'Wrong credit or debit value in accounting entry !'),
     ]
 
     def _auto_init(self, cr, context=None):


### PR DESCRIPTION
This fixes https://github.com/odoo/odoo/issues/2112 at least for move
lines. If the constraint is not written exactly like that, the next time
we update the module OpenERP does not recognize it and drops and
recreates the constraint. This is dangerous, and takes a long time in a
big table.
