### PR TITLE
Correctly hide "Add to Dashboard" option in non-supported view (ex: "My Current Timesheet")

### DIFF
--- a/addons/board/static/src/js/dashboard.js
+++ b/addons/board/static/src/js/dashboard.js
@@ -424,7 +424,7 @@ instance.web.SearchView.include({
     add_common_inputs: function() {
         this._super();
         var vm = this.getParent().getParent();
-        if (vm.inner_action && vm.inner_action.views) {
+        if (vm.inner_action && vm.inner_action.id && vm.inner_action.views) {
             (new instance.board.AddToDashboard(this));
         }
     }


### PR DESCRIPTION
This is taken from the main Odoo 7.0 branch
