### PR TITLE
Revert "[fix] the added new constraint for account (via OPW)"

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -1668,40 +1668,8 @@ class account_move_reconcile(osv.osv):
                     return False
         return True
 
-    # To reconcile journal items must have same account
-    def _check_same_account(self,cr,uid,ids,context=None):
-        for rec_line in self.browse(cr, uid, ids, context=context):
-            move_lines  = []
-            if not rec_line.opening_reconciliation:
-                if rec_line.line_id:
-                    first_account = rec_line.line_id[0].account_id.id
-                    move_lines = rec_line.line_id
-                elif rec_line.line_partial_ids:
-                    first_account = rec_line.line_partial_ids[0].account_id.id
-                    move_lines = rec_line.line_partial_ids
-                for line in move_lines:
-                    if line.account_id.id != first_account:
-                        return False
-        return True
-        
-    # To reconcile allow reconcilation must be True in account
-    def _check_allow_reconcile(self, cr, uid, ids, context=None):
-        for move_line in self.browse(cr ,uid ,ids ,context=context):
-            lines = []
-            if not move_line.opening_reconciliation:
-                if move_line.line_id:
-                    lines = move_line.line_id
-                elif move_line.line_partial_ids:
-                    lines = move_line.line_partial_ids
-                for line in lines:
-                    if not line.account_id.reconcile:
-                        return False
-        return True
-            
     _constraints = [
         (_check_same_partner, 'You can only reconcile journal items with the same partner.', ['line_id']),
-        (_check_same_account, 'You can only reconcile journal items with the same account.',['line_id']),
-        (_check_allow_reconcile,'To reconcile , allow reconcilation must be true in account.',['line_id']),
     ]
     
     def reconcile_partial_check(self, cr, uid, ids, type='auto', context=None):

--- a/addons/account/demo/account_minimal.xml
+++ b/addons/account/demo/account_minimal.xml
@@ -112,7 +112,6 @@
             <field name="name">Cash - (test)</field>
             <field ref="cas" name="parent_id"/>
             <field name="type">liquidity</field>
-            <field eval="True" name="reconcile"/>
             <field name="user_type" ref="data_account_type_asset"/>
         </record>
 

--- a/addons/account/wizard/account_reconcile.py
+++ b/addons/account/wizard/account_reconcile.py
@@ -154,6 +154,7 @@ class account_move_line_reconcile_writeoff(osv.osv_memory):
         ids = period_obj.find(cr, uid, dt=date, context=context)
         if ids:
             period_id = ids[0]
+
         account_move_line_obj.reconcile(cr, uid, context['active_ids'], 'manual', account_id,
                 period_id, journal_id, context=context)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
This reverts commit 8e83f2af9d41e68007fcd337b697138ba237d0b0.

This has been resolved upstream: 
https://bugs.launchpad.net/openobject-addons/+bug/1215897/comments/5
https://github.com/odoo/odoo/commit/cc5d5bb2bf4a84a27edf998cee22c8602c9a78e0
