### PR TITLE
consider entries on inactive journals for the general ledger report

### DIFF
--- a/addons/account/wizard/account_report_common.py
+++ b/addons/account/wizard/account_report_common.py
@@ -138,7 +138,7 @@ class account_common_report(osv.osv_memory):
     def _get_all_journal(self, cr, uid, context=None):
         # The 'active_test' context is used, because reports must
         # return entries created on inactive journals.
-        return self.pool.get('account.journal').search(
+        return self.pool['account.journal'].search(
             cr, uid, [], context=dict(context or {}, active_test=False)
         )
 
@@ -178,7 +178,12 @@ class account_common_report(osv.osv_memory):
         data = {}
         data['ids'] = context.get('active_ids', [])
         data['model'] = context.get('active_model', 'ir.ui.menu')
-        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to', 'fiscalyear_id', 'period_from', 'period_to', 'filter', 'chart_account_id', 'target_move'], context=context)[0]
+        data['form'] = self.read(
+            cr, uid, ids,
+            [
+                'date_from', 'date_to', 'fiscalyear_id', 'period_from',
+                'period_to', 'filter', 'chart_account_id', 'target_move'
+            ], context=context)[0]
         # The 'active_test' context is used, because reports must
         # return entries created on inactive journals.
         data['form']['journal_ids'] = self.read(

--- a/addons/account/wizard/account_report_common.py
+++ b/addons/account/wizard/account_report_common.py
@@ -136,7 +136,12 @@ class account_common_report(osv.osv_memory):
         return fiscalyears and fiscalyears[0] or False
 
     def _get_all_journal(self, cr, uid, context=None):
-        return self.pool.get('account.journal').search(cr, uid ,[])
+        # The 'active_test' context is used, because reports must
+        # return entries created on inactive journals.
+        return self.pool.get('account.journal').search(cr, uid, [],
+                                                       context={
+                                                         'active_test': False
+                                                       })
 
     _defaults = {
             'fiscalyear_id': _get_fiscalyear,
@@ -174,7 +179,17 @@ class account_common_report(osv.osv_memory):
         data = {}
         data['ids'] = context.get('active_ids', [])
         data['model'] = context.get('active_model', 'ir.ui.menu')
-        data['form'] = self.read(cr, uid, ids, ['date_from',  'date_to',  'fiscalyear_id', 'journal_ids', 'period_from', 'period_to',  'filter',  'chart_account_id', 'target_move'], context=context)[0]
+        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to',
+                                                'fiscalyear_id', 'period_from',
+                                                'period_to', 'filter',
+                                                'chart_account_id',
+                                                'target_move'])[0]
+        # The 'active_test' context is used, because reports must
+        # return entries created on inactive journals.
+        data['form']['journal_ids'] = self.read(cr, uid, ids, ['journal_ids'],
+                                                context={
+                                                    'active_test': False
+                                                })[0]['journal_ids']
         for field in ['fiscalyear_id', 'chart_account_id', 'period_from', 'period_to']:
             if isinstance(data['form'][field], tuple):
                 data['form'][field] = data['form'][field][0]

--- a/addons/account/wizard/account_report_common.py
+++ b/addons/account/wizard/account_report_common.py
@@ -138,10 +138,9 @@ class account_common_report(osv.osv_memory):
     def _get_all_journal(self, cr, uid, context=None):
         # The 'active_test' context is used, because reports must
         # return entries created on inactive journals.
-        return self.pool.get('account.journal').search(cr, uid, [],
-                                                       context={
-                                                         'active_test': False
-                                                       })
+        return self.pool.get('account.journal').search(
+            cr, uid, [], context=dict(context or {}, active_test=False)
+        )
 
     _defaults = {
             'fiscalyear_id': _get_fiscalyear,
@@ -179,17 +178,12 @@ class account_common_report(osv.osv_memory):
         data = {}
         data['ids'] = context.get('active_ids', [])
         data['model'] = context.get('active_model', 'ir.ui.menu')
-        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to',
-                                                'fiscalyear_id', 'period_from',
-                                                'period_to', 'filter',
-                                                'chart_account_id',
-                                                'target_move'])[0]
+        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to', 'fiscalyear_id', 'period_from', 'period_to', 'filter', 'chart_account_id', 'target_move'])[0]
         # The 'active_test' context is used, because reports must
         # return entries created on inactive journals.
-        data['form']['journal_ids'] = self.read(cr, uid, ids, ['journal_ids'],
-                                                context={
-                                                    'active_test': False
-                                                })[0]['journal_ids']
+        data['form']['journal_ids'] = self.read(
+            cr, uid, ids, ['journal_ids'], context=dict(context or {}, active_test=False)
+        )[0]['journal_ids']
         for field in ['fiscalyear_id', 'chart_account_id', 'period_from', 'period_to']:
             if isinstance(data['form'][field], tuple):
                 data['form'][field] = data['form'][field][0]

--- a/addons/account/wizard/account_report_common.py
+++ b/addons/account/wizard/account_report_common.py
@@ -178,7 +178,7 @@ class account_common_report(osv.osv_memory):
         data = {}
         data['ids'] = context.get('active_ids', [])
         data['model'] = context.get('active_model', 'ir.ui.menu')
-        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to', 'fiscalyear_id', 'period_from', 'period_to', 'filter', 'chart_account_id', 'target_move'])[0]
+        data['form'] = self.read(cr, uid, ids, ['date_from', 'date_to', 'fiscalyear_id', 'period_from', 'period_to', 'filter', 'chart_account_id', 'target_move'], context=context)[0]
         # The 'active_test' context is used, because reports must
         # return entries created on inactive journals.
         data['form']['journal_ids'] = self.read(


### PR DESCRIPTION
On a customer's instance, the entries that used an inactive journal (before
it was deactivated) were not considered in the general ledger; this fixes
the behaviour.
