### PR TITLE
7.0 [IMP] product: improve store for field name_template

### DIFF
--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -534,10 +534,9 @@ class product_product(osv.osv):
 
     def _get_name_template_ids(self, cr, uid, ids, context=None):
         result = set()
-        for template in self.browse(cr, uid, ids, context=context):
-            template_ids = self.pool.get('product.product').search(cr, uid, [('product_tmpl_id','=',template.id)])
-            for el in template_ids:
-                result.add(el)
+        template_ids = self.pool.get('product.product').search(cr, uid, [('product_tmpl_id', 'in', ids)])
+        for el in template_ids:
+            result.add(el)
         return list(result)
 
     _defaults = {

--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -532,6 +532,14 @@ class product_product(osv.osv):
     def _set_image(self, cr, uid, id, name, value, args, context=None):
         return self.write(cr, uid, [id], {'image': tools.image_resize_image_big(value)}, context=context)
 
+    def _get_name_template_ids(self, cr, uid, ids, context=None):
+        result = set()
+        for template in self.browse(cr, uid, ids, context=context):
+            template_ids = self.pool.get('product.product').search(cr, uid, [('product_tmpl_id','=',template.id)])
+            for el in template_ids:
+                result.add(el)
+        return list(result)
+
     _defaults = {
         'active': lambda *a: 1,
         'price_extra': lambda *a: 0.0,
@@ -563,7 +571,11 @@ class product_product(osv.osv):
         'price_extra': fields.float('Variant Price Extra', digits_compute=dp.get_precision('Product Price')),
         'price_margin': fields.float('Variant Price Margin', digits_compute=dp.get_precision('Product Price')),
         'pricelist_id': fields.dummy(string='Pricelist', relation='product.pricelist', type='many2one'),
-        'name_template': fields.related('product_tmpl_id', 'name', string="Template Name", type='char', size=128, store=True, select=True),
+        'name_template': fields.related('product_tmpl_id', 'name', string="Template Name", type='char', size=128, store={
+            'product.template': (_get_name_template_ids, ['name'], 10),
+            'product.product': (lambda self, cr, uid, ids, c={}: ids, [], 10),
+
+            }, select=True),
         'color': fields.integer('Color Index'),
         # image: all image fields are base64 encoded and PIL-supported
         'image': fields.binary("Image",

--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -572,7 +572,7 @@ class product_product(osv.osv):
         'pricelist_id': fields.dummy(string='Pricelist', relation='product.pricelist', type='many2one'),
         'name_template': fields.related('product_tmpl_id', 'name', string="Template Name", type='char', size=128, store={
             'product.template': (_get_name_template_ids, ['name'], 10),
-            'product.product': (lambda self, cr, uid, ids, c={}: ids, ['product_tmpl_id'], 10),
+            'product.product': (lambda self, cr, uid, ids, c=None: ids, ['product_tmpl_id'], 10),
 
             }, select=True),
         'color': fields.integer('Color Index'),

--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -533,11 +533,8 @@ class product_product(osv.osv):
         return self.write(cr, uid, [id], {'image': tools.image_resize_image_big(value)}, context=context)
 
     def _get_name_template_ids(self, cr, uid, ids, context=None):
-        result = set()
         template_ids = self.pool.get('product.product').search(cr, uid, [('product_tmpl_id', 'in', ids)])
-        for el in template_ids:
-            result.add(el)
-        return list(result)
+        return list(set(template_ids))
 
     _defaults = {
         'active': lambda *a: 1,

--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -572,7 +572,7 @@ class product_product(osv.osv):
         'pricelist_id': fields.dummy(string='Pricelist', relation='product.pricelist', type='many2one'),
         'name_template': fields.related('product_tmpl_id', 'name', string="Template Name", type='char', size=128, store={
             'product.template': (_get_name_template_ids, ['name'], 10),
-            'product.product': (lambda self, cr, uid, ids, c={}: ids, [], 10),
+            'product.product': (lambda self, cr, uid, ids, c={}: ids, ['product_tmpl_id'], 10),
 
             }, select=True),
         'color': fields.integer('Color Index'),


### PR DESCRIPTION
Add store to field name_template to avoid unecessary browse and write.
Done by back-porting 2 commits from 8.0 and improving the store declaration to restrict the trigger for product on the field product_tmpl_id

(PR on odoo https://github.com/odoo/odoo/pull/3277)
