### PR TITLE
Fix missing origin field in backorder pickings

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -750,9 +750,8 @@ class stock_picking(osv.osv):
         if ('name' not in default) or (picking_obj.name == '/'):
             seq_obj_name = 'stock.picking.' + picking_obj.type
             default['name'] = self.pool.get('ir.sequence').get(cr, uid, seq_obj_name)
-            default['backorder_id'] = False
-        if 'origin' not in default:
             default['origin'] = ''
+            default['backorder_id'] = False
         if 'invoice_state' not in default and picking_obj.invoice_state == 'invoiced':
             default['invoice_state'] = '2binvoiced'
         res = super(stock_picking, self).copy(cr, uid, id, default, context)


### PR DESCRIPTION
This fixes a current ocb only bug that backorder picking does not copy `origin` field due to an incorrect fix of an old bug [lp:1098557](https://bugs.launchpad.net/openobject-addons/+bug/1098557) . A fix for the original bug has been just merged into 7.0 in commit  8af9fdfa0635f6a9f78320d59d5cfb7ff1b89df2.

This PR reverts and old commit and applies the new fix to prevent a conflict when merging the official 7.0 branch.
