### PR TITLE
[FIX]: Never hide the invoice control on pickings

### DIFF
--- a/addons/stock/stock_view.xml
+++ b/addons/stock/stock_view.xml
@@ -765,7 +765,7 @@
                         <group>
                             <field name="partner_id" on_change="onchange_partner_in(partner_id)"/>
                             <field name="backorder_id" readonly="1" attrs="{'invisible': [('backorder_id','=',False)]}"/>
-                            <field name="invoice_state" string="Invoice Control" groups="account.group_account_invoice" attrs="{'invisible':[('invoice_state', '=', 'none')]}"/>
+                            <field name="invoice_state" string="Invoice Control" groups="account.group_account_invoice"/>
                             <field name="stock_journal_id" widget="selection" groups="account.group_account_user"/>
                         </group>
                         <group>


### PR DESCRIPTION
Invoice control field was invisible, and we cannot change value if none selected or copy picking in.
v8 is already working this way.
Proposed upstream in https://github.com/odoo/odoo/pull/3636
