### PR TITLE
Handle reply to document

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -556,6 +556,12 @@ class mail_thread(osv.AbstractModel):
                     _logger.info('Routing mail from %s to %s with Message-Id %s: direct reply to model: %s, thread_id: %s, custom_values: %s, uid: %s',
                                     email_from, email_to, message_id, model, thread_id, custom_values, uid)
                     return [(model, thread_id, custom_values, uid)]
+                else:
+                    # Reply to a particular document
+                    message = model_pool.browse(cr, uid, thread_id, context=context)
+                    _logger.info('Routing mail from %s to %s with Message-Id %s: reply to document: %s, id: %s, custom_values: %s, uid: %s'
+                                    % (email_from, email_to, message_id, message.model, message.res_id, custom_values, uid))
+                    return [(message.model, message.res_id, custom_values, uid)]
 
         # Verify whether this is a reply to a private message
         if in_reply_to:


### PR DESCRIPTION
This is intended to work with an extension of crm_claim that allows to respond to the partner with a specific email wizard, that is not connected to the chatter.  To be more specific, in my usecase, we separate the chatter, that is used for internal communication between staff members, and an email response feature that is only used to communicate with the partner (to give the final answer, resolution of the incident).

When we send an email to the partner in this way, we also need to handle replies that we may receive from the partner (not a subscriber) and include them in the chatter.

Changing message_route() is the only way to get the reply, otherwise OpenERP fails with the following message:

```
2014-07-24 13:35:44,921 7171 ERROR cmlid openerp.addons.fetchmail.fetchmail: Failed to process mail from imap server Hotline.
Traceback (most recent call last):
  File "/path/to/odoo/addons/fetchmail/fetchmail.py", line 202, in fetch_mail
    context=context)
  File "/path/to/custom/mail_thread.py", line 49, in message_process
    thread_id, context)
  File "/path/to/odoo/addons/mail/mail_thread.py", line 699, in message_process

  File "/path/to/odoo/addons/mail/mail_thread.py", line 623, in message_route
    if not (thread_id and hasattr(model_pool, 'message_update') or hasattr(model_pool, 'message_new')):
ValueError: No possible route found for incoming message from Mr Partner <mr.partner@mydomain.com> to Hotline <hotline@mycompany.com> (Message-Id <some.id@server.com>:). Create an appropriate mail.alias or force the destination model
```

To be more specific, my scenario is to have custom notification messages using email_template.  Please have a look at my implementation of `mail_followers._notify()` below (this is an excerpt):

```
def _notify(self, cr, uid, msg_id, partners_to_notify=None, context=None):
    obj = self.pool.get(msg.model)
    claim = obj.browse(cr, uid, msg.res_id, context=context)
    context['document'] = claim

    tmpl_obj=self.pool.get('email.template')

    template = self.getClaimTemplate(claim.categ_id)
    if template is False:
        raise Exception("Could not find template for claim category %s" % claim.categ_id)

    if context.has_key('default_composition_mode'):
        tmpl_name = template.name.replace(u'Réponse', 'Message')
    elif claim.first_email is False:
        tmpl_name = template.name.replace(u'Réponse', 'New')
        obj.write(cr,uid,msg.res_id,{'first_email':True})
    else:
        tmpl_name = template.name.replace(u'Réponse', 'Followup')

    tmpl_ids=tmpl_obj.search(cr,uid,[('name','=',tmpl_name)])
    tmpl_obj.send_mail(cr, uid, tmpl_ids[0], msg_id, force_send=True, context=context)
```

As this function works with mail.message (msg_id parameter) I'm manipulating mail.message objects, and so email_template creates messages with model = "mail.message" instead of eg "crm.claim" thus the reply is made to a message, and not a document.
