### PR TITLE
Strip In-Reply-To header

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -554,7 +554,7 @@ class mail_thread(osv.AbstractModel):
         email_from = decode_header(message, 'From')
         email_to = decode_header(message, 'To')
         references = decode_header(message, 'References')
-        in_reply_to = decode_header(message, 'In-Reply-To')
+        in_reply_to = decode_header(message, 'In-Reply-To').strip()
 
         # 1. Verify if this is a reply to an existing thread
         thread_references = references or in_reply_to

--- a/addons/mail/tests/test_mail_gateway.py
+++ b/addons/mail/tests/test_mail_gateway.py
@@ -533,7 +533,7 @@ class TestMailgateway(TestMailBase):
 
         # 1. In-Reply-To header
         reply_msg2 = format(MAIL_TEMPLATE, to='erroneous@example.com',
-                                extra='In-Reply-To: %s' % msg1.message_id,
+                                extra='In-Reply-To:\r\n\t%s' % msg1.message_id,
                                 msg_id='<1198923581.41972151344608186760.JavaMail.3@agrolait.com>')
         self.mail_group.message_process(cr, uid, None, reply_msg2)
 


### PR DESCRIPTION
Header could be expressed like this:

In-Reply-To:
    <4ba8f246904b4fedb49fbab7945a7f82@AM3PR06MB433.eurprd06.prod.outl$$k.com>

The message lookup fails if header is not stripped
