### PR TITLE
Add oe_read_only as inverse of class oe_edit_only

### DIFF
--- a/addons/web/static/src/css/base.css
+++ b/addons/web/static/src/css/base.css
@@ -2116,6 +2116,9 @@
 .openerp .oe_form_readonly .oe_edit_only, .openerp .oe_form_readonly .oe_form_field:empty {
   display: none !important;
 }
+.openerp .oe_form_editable .oe_read_only, .openerp .oe_form_editable .oe_form_field:empty {
+  display: none !important;
+}
 .openerp .oe_form_readonly .oe_form .oe_form_field_date {
   width: auto;
 }


### PR DESCRIPTION
See https://www.odoo.com/forum/help-1/question/inverse-of-css-class-oe-edit-only-11853

Already present in branch 8.0, see https://github.com/odoo/odoo/blob/8.0/addons/web/static/src/css/base.css#L1833
