### PR TITLE
[FIX] MO: change required conditions on bom_id

### DIFF
--- a/addons/mrp/mrp_view.xml
+++ b/addons/mrp/mrp_view.xml
@@ -700,7 +700,7 @@
                             <field name="date_planned"/>
                         </group>
                         <group>
-                            <field name="bom_id" domain="[('product_id','=',product_id)]" context="{'default_product_id': product_id}" on_change="bom_id_change(bom_id)" required="1"/>
+                            <field name="bom_id" domain="[('product_id','=',product_id)]" context="{'default_product_id': product_id}" on_change="bom_id_change(bom_id)" attrs="{'required':[('state','=','draft')]}"/>
                             <field name="routing_id" class="oe_inline" groups="mrp.group_mrp_routings"/>
                             <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'mrp.group_mrp_user']}"/>
                             <field name="origin"/>


### PR DESCRIPTION
on mrp.production form view, bom_id field may be
not required on after draft states.
If the linked BOM is deleted, it avoids to block
the MO usage with the following message:
The following fields are invalid: Bill of Material

linked to https://github.com/odoo/odoo/issues/3417
