### PR TITLE
[FIX] Fix incorrect merge 3e1d5be951fb8

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -1768,7 +1768,7 @@ class account_invoice_tax(osv.osv):
                 if not val.get('account_analytic_id') and line.account_analytic_id and val['account_id'] == line.account_id.id:
                     val['account_analytic_id'] = line.account_analytic_id.id
 
-                key = (val['tax_code_id'], val['base_code_id'], val['account_id'], val['account_analytic_id'])
+                key = (val['tax_code_id'], val['base_code_id'], val['account_id'])
                 if not key in tax_grouped:
                     tax_grouped[key] = val
                 else:


### PR DESCRIPTION
Merge 3e1d5be951fb8 had a conflict that was incorrectly resolved. As a result, cannot validate invoices with 
tax line.

This PR correctly merges commit ab797f0cd8f76be2 to resolve the issue.
