### PR TITLE
Revert "[FIX] account: Error when manually adding analytic account in the generated tax lines on an invoice"

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -1683,7 +1683,7 @@ class account_invoice_tax(osv.osv):
         'invoice_id': fields.many2one('account.invoice', 'Invoice Line', ondelete='cascade', select=True),
         'name': fields.char('Tax Description', size=64, required=True),
         'account_id': fields.many2one('account.account', 'Tax Account', required=True, domain=[('type','<>','view'),('type','<>','income'), ('type', '<>', 'closed')]),
-        'account_analytic_id': fields.many2one('account.analytic.account', 'Analytic account', readonly=True),
+        'account_analytic_id': fields.many2one('account.analytic.account', 'Analytic account'),
         'base': fields.float('Base', digits_compute=dp.get_precision('Account')),
         'amount': fields.float('Amount', digits_compute=dp.get_precision('Account')),
         'manual': fields.boolean('Manual'),

--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -830,7 +830,7 @@ class account_invoice(osv.osv):
             for tax in inv.tax_line:
                 if tax.manual:
                     continue
-                key = (tax.tax_code_id.id, tax.base_code_id.id, tax.account_id.id)
+                key = (tax.tax_code_id.id, tax.base_code_id.id, tax.account_id.id, tax.account_analytic_id.id)
                 tax_key.append(key)
                 if not key in compute_taxes:
                     raise osv.except_osv(_('Warning!'), _('Global taxes defined, but they are not in invoice lines !'))
@@ -1766,7 +1766,7 @@ class account_invoice_tax(osv.osv):
                 if not val.get('account_analytic_id') and line.account_analytic_id and val['account_id'] == line.account_id.id:
                     val['account_analytic_id'] = line.account_analytic_id.id
 
-                key = (val['tax_code_id'], val['base_code_id'], val['account_id'])
+                key = (val['tax_code_id'], val['base_code_id'], val['account_id'], val['account_analytic_id'])
                 if not key in tax_grouped:
                     tax_grouped[key] = val
                 else:

--- a/addons/account/account_invoice_view.xml
+++ b/addons/account/account_invoice_view.xml
@@ -232,7 +232,11 @@
                                     <tree editable="bottom" string="Taxes">
                                         <field name="name"/>
                                         <field name="account_id" groups="account.group_account_invoice"/>
-                                        <field name="account_analytic_id" domain="[('type','&lt;&gt;','view'), ('company_id', '=', parent.company_id)]" groups="analytic.group_analytic_accounting"/>
+                                        <field name="manual" invisible="True"/>
+                                        <field name="account_analytic_id" 
+                                               domain="[('type','&lt;&gt;','view'), ('company_id', '=', parent.company_id)]" 
+                                               groups="analytic.group_analytic_accounting"
+                                               attrs="{'readonly':[('manual','=',False)]}" />
                                         <field name="base" on_change="base_change(base,parent.currency_id,parent.company_id,parent.date_invoice)" readonly="1"/>
                                         <field name="amount" on_change="amount_change(amount,parent.currency_id,parent.company_id,parent.date_invoice)"/>
 


### PR DESCRIPTION
This reverts commit ab797f0cd8f76be232fcd918eafa52b847102504.

OCB has already merged a fix for the issue with commit 7b7ca96e654b67481f824e2ccead757ab4ae81c6

The reverted fix may introduce a problem if multiple taxes have similar code but different analytic account or multiple invoice lines with tax that has no account.

This PR is related to #82
