### PR TITLE
7.0 fix 2854 product reserve round floor

### DIFF
--- a/addons/product/tests/test_uom.py
+++ b/addons/product/tests/test_uom.py
@@ -35,3 +35,22 @@ class TestUom(TransactionCase):
 
         qty = self.uom._compute_qty(cr, uid, unit_id, 2, score_id)
         self.assertEquals(qty, 1, "Converted quantity should be rounded up.")
+
+    def test_06_rounding(self):
+        cr, uid = self.cr, self.uid
+        unit_id = self.imd.get_object_reference(cr, uid, 'product', 'product_uom_unit')[1]
+        categ_unit_id = self.imd.get_object_reference(cr, uid, 'product', 'product_uom_categ_unit')[1]
+
+        score_id = self.uom.create(cr, uid, {
+            'name': 'Score',
+            'factor_inv': 6,
+            'uom_type': 'bigger',
+            'rounding': 1.0,
+            'category_id': categ_unit_id
+        })
+
+        qty = self.uom._compute_qty(cr, uid, unit_id, 721, score_id)
+        self.assertEquals(qty, 121)
+
+        qty = self.uom._compute_qty(cr, uid, unit_id, 721, score_id, to_unit_rounding='DOWN')
+        self.assertEquals(qty, 120)

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -467,7 +467,7 @@ class stock_location(osv.osv):
             total = 0.0
             results2 = 0.0
             for r in results:
-                # ROND down to prevent negative stocks.
+                # rounds down to prevent negative stocks.
                 amount = uom_obj._compute_qty(cr, uid, r['product_uom'], r['product_qty'], context.get('uom', False), to_unit_rounding='DOWN')
                 results2 += amount
                 total += amount

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -467,7 +467,8 @@ class stock_location(osv.osv):
             total = 0.0
             results2 = 0.0
             for r in results:
-                amount = uom_obj._compute_qty(cr, uid, r['product_uom'], r['product_qty'], context.get('uom', False))
+                # ROND down to prevent negative stocks.
+                amount = uom_obj._compute_qty(cr, uid, r['product_uom'], r['product_qty'], context.get('uom', False), to_unit_rounding='DOWN')
                 results2 += amount
                 total += amount
             if total <= 0.0:

--- a/addons/stock/tests/__init__.py
+++ b/addons/stock/tests/__init__.py
@@ -20,9 +20,11 @@
 ##############################################################################
 
 from . import test_multicompany
+from . import test_stock
 
 checks = [
     test_multicompany,
+    test_stock
 ]
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/addons/stock/tests/test_stock.py
+++ b/addons/stock/tests/test_stock.py
@@ -1,0 +1,79 @@
+from openerp.tests import common
+from openerp.tools.float_utils import float_compare
+
+
+class TestStock(common.TransactionCase):
+
+    def setUp(self):
+        super(TestStock, self).setUp()
+        cr, uid = self.cr, self.uid
+        self.stock_location = self.registry('stock.location')
+        self.stock_change_product_qty = self.registry(
+            'stock.change.product.qty')
+        self.uom = self.registry('product.uom')
+        self.stock_location_shelf1 = self.ref(
+            'stock.stock_location_components')
+        self.stock_location_shelf2 = self.ref(
+            'stock.stock_location_14')
+        self.unit_id = self.ref('product.product_uom_unit')
+        categ_unit_id = self.ref('product.product_uom_categ_unit')
+        self.six_unit_id = self.uom.create(cr, uid, {
+            'name': 'Score',
+            'factor_inv': 6,
+            'uom_type': 'bigger',
+            'rounding': 1.0,
+            'category_id': categ_unit_id
+        })
+        self.product_id = self.ref('product.product_product_7')
+
+        # put 721 qty in chelf1
+        # and 7 qty in shelf2
+        ctx = {'active_id':  self.product_id}
+        wiz_id_1 = self.stock_change_product_qty.create(
+            cr, uid, {'product_id': self.product_id,
+                      'new_quantity': 721,
+                      'location_id': self.stock_location_shelf1},
+            context=ctx)
+        wiz_id_2 = self.stock_change_product_qty.create(
+            cr, uid, {'product_id': self.product_id,
+                      'new_quantity': 7,
+                      'location_id': self.stock_location_shelf2},
+            context=ctx)
+        self.stock_change_product_qty.change_product_qty(
+            cr, uid, [wiz_id_1, wiz_id_2], context=ctx)
+
+    def test_product_reserve_01(self):
+        """Test product_reserve in unit_id
+        """
+        cr, uid = self.cr, self.uid
+        res = self.stock_location._product_reserve(
+            cr, uid, [self.stock_location_shelf1], self.product_id, 722)
+        self.assertFalse(res, 'Only 721 unit available in shelf 1 not 722')
+        res = self.stock_location._product_reserve(
+            cr, uid, [self.stock_location_shelf1, self.stock_location_shelf2],
+            self.product_id, 722)
+        self.assertEquals(len(res), 2)
+        total = 0.0
+        for amount, _ in res:
+            total += amount
+        res_cmp = float_compare(total, 722, precision_digits=1.0)
+        self.assertEqual(0, res_cmp)
+
+    def test_product_reserve_06(self):
+        """Test product_reserve in six_unit_id
+        """
+        cr, uid = self.cr, self.uid
+        ctx = {'uom': self.six_unit_id}
+        res = self.stock_location._product_reserve(
+            cr, uid, [self.stock_location_shelf1], self.product_id, 121,
+            context=ctx)
+        self.assertFalse(res, 'Only 120 six_unit available in shelf 1 not 121')
+        res = self.stock_location._product_reserve(
+            cr, uid, [self.stock_location_shelf1, self.stock_location_shelf2],
+            self.product_id, 121, context=ctx)
+        self.assertEquals(len(res), 2)
+        total = 0.0
+        for amount, _ in res:
+            total += amount
+        res_cmp = float_compare(total, 121, precision_digits=1.0)
+        self.assertEqual(0, res_cmp)

--- a/openerp/addons/base/test/base_test.yml
+++ b/openerp/addons/base/test/base_test.yml
@@ -225,6 +225,16 @@
         try_round(1.8, '2', 0, rounding_method='UP')
         try_round(-1.8, '-2', 0, rounding_method='UP')
 
+        # Try some rounding value with rounding method DOWN instead of HALF-UP
+        try_round(8.175, '8.175', rounding_method='DOWN')
+        try_round(8.1751, '8.175', rounding_method='DOWN')
+        try_round(-8.175, '-8.175', rounding_method='DOWN')
+        try_round(-8.1751, '-8.175', rounding_method='DOWN')
+        try_round(-6.000, '-6.000', rounding_method='DOWN')
+        try_round(1.8, '1', 0, rounding_method='DOWN')
+        try_round(-1.8, '-1', 0, rounding_method='DOWN')
+
+
         # Extended float range test, inspired by Cloves Almeida's test on bug #882036.
         fractions = [.0, .015, .01499, .675, .67499, .4555, .4555, .45555]
         expecteds = ['.00', '.02', '.01', '.68', '.67', '.46', '.456', '.4556']

--- a/openerp/tools/float_utils.py
+++ b/openerp/tools/float_utils.py
@@ -42,9 +42,9 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
        :param float precision_rounding: decimal number representing the minimum
            non-zero value at the desired precision (for example, 0.01 for a 
            2-digit precision).
-       :param rounding_method: the rounding method used: 'HALF-UP' or 'UP', the first
+       :param rounding_method: the rounding method used: 'HALF-UP', 'UP' or 'DOWN', the first
            one rounding up to the closest number with the rule that number>=0.5 is 
-           rounded up to 1, and the latest one always rounding up.
+           rounded up to 1, the second one always rounding up, and the latest always rounds FLOOR
        :return: rounded float
     """
     rounding_factor = _float_check_precision(precision_digits=precision_digits,
@@ -86,6 +86,11 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
         sign = cmp(normalized_value, 0)
         normalized_value -= sign*epsilon
         rounded_value = math.ceil(abs(normalized_value))*sign # ceil to integer
+
+    elif rounding_method == 'DOWN':
+        sign = cmp(normalized_value, 0)
+        normalized_value += sign*epsilon
+        rounded_value = math.floor(abs(normalized_value))*sign # ceil to integer
 
     result = rounded_value * rounding_factor # de-normalize
     return result


### PR DESCRIPTION
This fixes https://github.com/odoo/odoo/issues/2854. 
PR on Odoo https://github.com/odoo/odoo/pull/3457

By default, the rounding method in product_uom round amount with ceiling. Using a ceiling rounding method in product reserve can let the user reserve more than what is available in a location. Using floor rounding in that situation is safe and will prevent negative stocks.
