### PR TITLE
Fixes #3664 adds product_id_change_with_wh in sale order line form view

### DIFF
--- a/addons/sale_stock/sale_stock_view.xml
+++ b/addons/sale_stock/sale_stock_view.xml
@@ -29,23 +29,22 @@
                     <field name="client_order_ref" position="after">
                          <field name="warehouse_id" on_change="onchange_warehouse_id(warehouse_id)" options="{'no_create': True}" groups="stock.group_locations"/>
                     </field>
-                   <xpath expr="//field[@name='order_line']/tree//field[@name='product_id']" position="replace">
-                       <field name="product_id"
-                       context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}"
-                       groups="base.group_user" 
-                       on_change="product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,False,product_uos_qty,False,name,parent.partner_id, False, True, parent.date_order, product_packaging, parent.fiscal_position, False, parent.warehouse_id, context)"/>
+                   <xpath expr="//field[@name='order_line']/tree//field[@name='product_id']" position="attributes">
+                       <attribute name="on_change">product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,False,product_uos_qty,False,name,parent.partner_id, False, True, parent.date_order, product_packaging, parent.fiscal_position, False, parent.warehouse_id, context)</attribute>
                    </xpath>
-                   <xpath expr="//field[@name='order_line']/tree//field[@name='product_uom_qty']" position="replace">
-                       <field context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}"
-                             name="product_uom_qty" 
-                       on_change="product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,False,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, context)"/>
+                   <xpath expr="//field[@name='order_line']/tree//field[@name='product_uom_qty']" position="attributes">
+                       <attribute name="on_change">product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,False,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, context)</attribute>
                    </xpath>
-                   <xpath expr="//field[@name='order_line']/form//field[@name='product_uos_qty']" position="replace">
-                       <field context="{'partner_id':parent.partner_id, 'quantity':product_uos_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}"
-                             name="product_uos_qty" class="oe_inline"
-                       on_change="product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,product_uos,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, context)"/>
+                   <xpath expr="//field[@name='order_line']/form//field[@name='product_uos_qty']" position="attributes">
+                       <attribute name="context">{'partner_id':parent.partner_id, 'quantity':product_uos_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom}</attribute>
+                        <attribute name="on_change">product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,product_uos,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, context)</attribute>
                    </xpath>
-
+                   <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="attributes">
+                       <attribute name="on_change">product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,False,product_uos_qty,False,name,parent.partner_id, False, True, parent.date_order, product_packaging, parent.fiscal_position, False, parent.warehouse_id, context)</attribute>
+                   </xpath>
+                   <xpath expr="//field[@name='order_line']/form//field[@name='product_uom_qty']" position="attributes">
+                       <attribute name="on_change">product_id_change_with_wh(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,False,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, context)</attribute>
+                   </xpath>
                    <field name='invoiced' position="after">
                        <field name="shipped"/>
                        <field name="invoice_exists" invisible="1"/>


### PR DESCRIPTION
Better inherit of tree view of sale order line via position=attributes

I haven't proposed this PR to the odoo/odoo branch because it updates the XML and therefore requires an update of the module sale_stock, which is not allowed in the official branch AFAIK.
