### PR TITLE
7.0 bug compute qty same uom

### DIFF
--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -172,6 +172,8 @@ class product_uom(osv.osv):
     def _compute_qty_obj(self, cr, uid, from_unit, qty, to_unit, context=None):
         if context is None:
             context = {}
+        if from_unit.id == to_unit.id:
+            return qty
         if from_unit.category_id.id <> to_unit.category_id.id:
             if context.get('raise-exception', True):
                 raise osv.except_osv(_('Error!'), _('Conversion from Product UoM %s to Default UoM %s is not possible as they both belong to different Category!.') % (from_unit.name,to_unit.name,))

--- a/addons/product/tests/test_uom.py
+++ b/addons/product/tests/test_uom.py
@@ -20,6 +20,27 @@ class TestUom(TransactionCase):
         price = self.uom._compute_price(cr, uid, gram_id, 2, tonne_id)
         self.assertEquals(price, 2000000.0, "Converted price does not correspond.")
 
+    def test_11_conversion(self):
+        """compute qty must return qty if uom_from_id and uom_to_id
+        are identical."""
+        cr, uid = self.cr, self.uid
+        categ_kg_id = self.imd.get_object_reference(
+            cr, uid, 'product', 'product_uom_categ_kgm')[1]
+        uom_6kg_id = self.uom.create(cr, uid, {
+            'name': '6 kg',
+            'factor': 6,
+            'uom_type': 'bigger',
+            'rounding': 1.0,
+            'category_id': categ_kg_id,
+        })
+        input_qty = 1
+        computed_qty = self.uom._compute_qty(
+            cr, uid, uom_6kg_id, input_qty, uom_6kg_id)
+        self.assertEquals(
+            input_qty, computed_qty,
+            "Converting quantity if 'from' and 'to' units are identical must"
+            " return initial quantity")
+
     def test_20_rounding(self):
         cr, uid = self.cr, self.uid
         unit_id = self.imd.get_object_reference(cr, uid, 'product', 'product_uom_unit')[1]


### PR DESCRIPTION
Case:
- Create a new unit 6kg based on kg product uom category with factor 6 and rounding 1.0;
- Call the function _compute_qty of product_uom Model with the folllowing parameters:
  - from_unit = to_unit = 6kg
  - qty = 1
- Expected value: 1 (the input value, because there is no conversion to do).
- Return value: 0. (depending of rounding setting).

The case is written in a TransactionCase in test_uom.py

**Classical User Case**:
when an Delivery order is validated, the function _compute_qty is called, even if the units are identical.
