### PR TITLE
Procurement schedulers now catch all exceptions and log them

### DIFF
--- a/addons/procurement/schedulers.py
+++ b/addons/procurement/schedulers.py
@@ -85,8 +85,9 @@ class procurement_order(osv.osv):
                         if use_new_cursor:
                             cr.commit()
                     except Exception as e:
-                        logger.warn("Exception in _procure_confirm on "
-                                    "procurement %s: %s", (proc.id, e))
+                        if not isinstance(e, OperationalError):
+                            logger.warn("Exception in _procure_confirm on "
+                                        "procurement %s: %s", (proc.name, e))
                         if use_new_cursor:
                             cr.rollback()
                             continue
@@ -107,8 +108,9 @@ class procurement_order(osv.osv):
                         if use_new_cursor:
                             cr.commit()
                     except Exception as e:
-                        logger.warn("Exception in _procure_confirm on "
-                                    "procurement %s: %s", (proc.id, e))
+                        if not isinstance(e, OperationalError):
+                            logger.warn("Exception in _procure_confirm on "
+                                        "procurement %s: %s", (proc.name, e))
                         if use_new_cursor:
                             cr.rollback()
                             continue
@@ -277,8 +279,9 @@ class procurement_order(osv.osv):
                     if use_new_cursor:
                         cr.commit()
                 except Exception as e:
-                    logger.warn("Exception in _procure_orderpoint_confirm "
-                                "on orderpoint %s: %s", (op.id, e))
+                    if not isinstance(e, OperationalError):
+                        logger.warn("Exception in _procure_orderpoint_confirm "
+                                    "on orderpoint %s: %s", (op.name, e))
                     if use_new_cursor:
                         if isinstance(e, OperationalError):
                             orderpoint_ids.append(op.id)

--- a/addons/procurement/schedulers.py
+++ b/addons/procurement/schedulers.py
@@ -29,6 +29,10 @@ from openerp.tools.translate import _
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
 from openerp import tools
 from psycopg2 import OperationalError
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class procurement_order(osv.osv):
     _inherit = 'procurement.order'
@@ -80,7 +84,9 @@ class procurement_order(osv.osv):
 
                         if use_new_cursor:
                             cr.commit()
-                    except OperationalError:
+                    except Exception as e:
+                        logger.warn("Exception in _procure_confirm on "
+                                    "procurement %s: %s", (proc.id, e))
                         if use_new_cursor:
                             cr.rollback()
                             continue
@@ -100,7 +106,9 @@ class procurement_order(osv.osv):
 
                         if use_new_cursor:
                             cr.commit()
-                    except OperationalError:
+                    except Exception as e:
+                        logger.warn("Exception in _procure_confirm on "
+                                    "procurement %s: %s", (proc.id, e))
                         if use_new_cursor:
                             cr.rollback()
                             continue
@@ -268,9 +276,12 @@ class procurement_order(osv.osv):
                                     {'procurement_id': proc_id}, context=context)
                     if use_new_cursor:
                         cr.commit()
-                except OperationalError:
+                except Exception as e:
+                    logger.warn("Exception in _procure_orderpoint_confirm "
+                                "on orderpoint %s: %s", (op.id, e))
                     if use_new_cursor:
-                        orderpoint_ids.append(op.id)
+                        if isinstance(e, OperationalError):
+                            orderpoint_ids.append(op.id)
                         cr.rollback()
                         continue
                     else:


### PR DESCRIPTION
This PR is to improve the procurement schedulers: instead of just catching the SQL Operational Errors (and retrying them later in one case), they catch all exceptions (so that the scheduled task is not stopped), log them as warnings, and still retrying the one case for OperationalError.

It was also done for upstream in https://github.com/odoo/odoo/pull/3841 .
