### PR TITLE
[FIX] use the correct sequence for pickings

### DIFF
--- a/addons/mrp/mrp.py
+++ b/addons/mrp/mrp.py
@@ -962,10 +962,7 @@ class mrp_production(osv.osv):
             partner_id = routing_loc.partner_id and routing_loc.partner_id.id or False
 
         # Take next Sequence number of shipment base on type
-        if pick_type!='internal':
-            pick_name = ir_sequence.get(cr, uid, 'stock.picking.' + pick_type)
-        else:
-            pick_name = ir_sequence.get(cr, uid, 'stock.picking')
+        pick_name = ir_sequence.get(cr, uid, 'stock.picking.' + pick_type)
 
         picking_id = stock_picking.create(cr, uid, {
             'name': pick_name,

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -2124,10 +2124,7 @@ class stock_move(osv.osv):
                 ptype = todo[0][1][5] and todo[0][1][5] or location_obj.picking_type_get(cr, uid, todo[0][0].location_dest_id, todo[0][1][0])
                 if picking:
                     # name of new picking according to its type
-                    if ptype == 'internal':
-                        new_pick_name = seq_obj.get(cr, uid,'stock.picking')
-                    else :
-                        new_pick_name = seq_obj.get(cr, uid, 'stock.picking.' + ptype)
+                    new_pick_name = seq_obj.get(cr, uid, 'stock.picking.' + ptype)
                     pickid = self._create_chained_picking(cr, uid, new_pick_name, picking, ptype, todo, context=context)
                     # Need to check name of old picking because it always considers picking as "OUT" when created from Sales Order
                     old_ptype = location_obj.picking_type_get(cr, uid, picking.move_lines[0].location_id, picking.move_lines[0].location_dest_id)


### PR DESCRIPTION
The sequence code for internal picking was changed in OCB, but the change was not reflected in the module 'mrp'.
Fixes https://github.com/OCA/OCB/issues/95
