### PR TITLE
[FIX] if a special period is present, it must be selected fist

### DIFF
--- a/addons/account/wizard/account_chart.py
+++ b/addons/account/wizard/account_chart.py
@@ -51,7 +51,7 @@ class account_chart(osv.osv_memory):
                                FROM account_period p
                                LEFT JOIN account_fiscalyear f ON (p.fiscalyear_id = f.id)
                                WHERE f.id = %s
-                               ORDER BY p.date_start ASC
+                               ORDER BY p.date_start ASC, p.special DESC
                                LIMIT 1) AS period_start
                 UNION ALL
                 SELECT * FROM (SELECT p.id


### PR DESCRIPTION
This is fix related to 
https://github.com/odoo/odoo/issues/3946
