### PR TITLE
Revert "Fixes #3698 - CSS subtotal_footer width"

### DIFF
--- a/addons/web/static/src/css/base.css
+++ b/addons/web/static/src/css/base.css
@@ -1957,7 +1957,7 @@
   border-right: none;
 }
 .openerp .oe_form .oe_subtotal_footer .oe_subtotal_footer_separator {
-  min-width: 108px;
+  width: 108px;
   border-top: 1px solid #cacaca;
   margin-top: 4px;
   padding-top: 4px;


### PR DESCRIPTION
Reverts OCA/OCB#99, because it has been merged on upstream at https://github.com/odoo/odoo/commit/aba75e75781e6f44c4d8b0ce21fa41cf48f9ed3d
