### PR TITLE
Create invoice from picking copies sales team from the order to the invoice

### DIFF
--- a/addons/sale_stock/sale_stock.py
+++ b/addons/sale_stock/sale_stock.py
@@ -453,6 +453,7 @@ class stock_picking(osv.osv):
                 'fiscal_position': sale.fiscal_position.id,
                 'payment_term': sale.payment_term.id,
                 'user_id': sale.user_id.id,
+                'section_id': sale.section_id.id,
                 'name': sale.client_order_ref or '',
                 })
         return inv_vals


### PR DESCRIPTION
Propagation of some fields from sales orders to invoices (when created on deliveries) have been added in 31a01ea, but it missed the section_id field (Sales Team).

Upstream PR: https://github.com/odoo/odoo/pull/4155
