### PR TITLE
[7.0] Translate Error and Warning dialog titles (lp:1297525)

### DIFF
--- a/addons/web/session.py
+++ b/addons/web/session.py
@@ -8,6 +8,7 @@ import sys
 import xmlrpclib
 
 import openerp
+from openerp.tools.translate import _
 
 _logger = logging.getLogger(__name__)
 
@@ -84,17 +85,17 @@ class OpenERPSession(object):
         self.jsonp_requests = {}     # FIXME use a LRU
 
     def send(self, service_name, method, *args):
-        code_string = u"warning -- %s\n\n%s"
+        code_string = _(u"warning -- %s\n\n%s")
         try:
             return openerp.netsvc.dispatch_rpc(service_name, method, args)
         except openerp.osv.osv.except_osv, e:
             raise xmlrpclib.Fault(code_string % (e.name, e.value), '')
         except openerp.exceptions.Warning, e:
-            raise xmlrpclib.Fault(code_string % ("Warning", e), '')
+            raise xmlrpclib.Fault(code_string % (_("Warning"), e), '')
         except openerp.exceptions.AccessError, e:
-            raise xmlrpclib.Fault(code_string % ("AccessError", e), '')
+            raise xmlrpclib.Fault(code_string % (_("AccessError"), e), '')
         except openerp.exceptions.AccessDenied, e:
-            raise xmlrpclib.Fault('AccessDenied', openerp.tools.ustr(e))
+            raise xmlrpclib.Fault(_('AccessDenied'), openerp.tools.ustr(e))
         except openerp.exceptions.DeferredException, e:
             formatted_info = "".join(traceback.format_exception(*e.traceback))
             raise xmlrpclib.Fault(openerp.tools.ustr(e), formatted_info)

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1559,7 +1559,7 @@ class BaseModel(object):
                 )
                 self._invalids.update(fields)
         if error_msgs:
-            raise except_orm('ValidateError', '\n'.join(error_msgs))
+            raise except_orm(_('ValidateError'), '\n'.join(error_msgs))
         else:
             self._invalids.clear()
 

--- a/openerp/service/wsgi_server.py
+++ b/openerp/service/wsgi_server.py
@@ -44,6 +44,7 @@ import werkzeug.contrib.fixers
 import openerp
 import openerp.modules
 import openerp.tools.config as config
+from openerp.tools.translate import _
 import websrv_lib
 
 _logger = logging.getLogger(__name__)
@@ -123,17 +124,18 @@ def xmlrpc_handle_exception(e):
     return response
 
 def xmlrpc_handle_exception_legacy(e):
+    code_string = u"%s -- %s\n\n%s"
     if isinstance(e, openerp.osv.osv.except_osv):
-        fault = xmlrpclib.Fault('warning -- ' + e.name + '\n\n' + e.value, '')
+        fault = xmlrpclib.Fault(code_string % (_("warning"), e.name, e.value), '')
         response = xmlrpclib.dumps(fault, allow_none=False, encoding=None)
     elif isinstance(e, openerp.exceptions.Warning):
-        fault = xmlrpclib.Fault('warning -- Warning\n\n' + str(e), '')
+        fault = xmlrpclib.Fault(code_string % (_("warning"), _("Warning"), e), '')
         response = xmlrpclib.dumps(fault, allow_none=False, encoding=None)
     elif isinstance(e, openerp.exceptions.AccessError):
-        fault = xmlrpclib.Fault('warning -- AccessError\n\n' + str(e), '')
+        fault = xmlrpclib.Fault(code_string % (_("warning"), _("AccessError"), e), '')
         response = xmlrpclib.dumps(fault, allow_none=False, encoding=None)
     elif isinstance(e, openerp.exceptions.AccessDenied):
-        fault = xmlrpclib.Fault('AccessDenied', str(e))
+        fault = xmlrpclib.Fault(_('AccessDenied'), str(e))
         response = xmlrpclib.dumps(fault, allow_none=False, encoding=None)
     elif isinstance(e, openerp.exceptions.DeferredException):
         info = e.traceback

--- a/openerp/tools/translate.py
+++ b/openerp/tools/translate.py
@@ -196,7 +196,7 @@ class GettextAlias(object):
             lang = ctx.get('lang')
         s = frame.f_locals.get('self', {})
         if not lang:
-            c = getattr(s, 'localcontext', None)
+            c = getattr(s, 'localcontext', None) or getattr(s, 'context', None)
             if c:
                 lang = c.get('lang')
         if not lang:

--- a/openerp/tools/translate.py
+++ b/openerp/tools/translate.py
@@ -851,7 +851,7 @@ def trans_generate(lang, modules, cr):
         path_list = [root_path,] + apaths
 
     # Also scan these non-addon paths
-    for bin_path in ['osv', 'report' ]:
+    for bin_path in ['osv', 'report', 'tools', 'service' ]:
         path_list.append(os.path.join(config.config['root_path'], bin_path))
 
     _logger.debug("Scanning modules at paths: ", path_list)


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/22

Fix for https://bugs.launchpad.net/openerp-web/+bug/1297525 :

> When an except_osv or except_orm is raised in a non-english environment, the title of the Pop-up window is "OpenERP Warning" and there is no way to change that.
> 
> The same is true for "Access Denied"

Translate error messages in web and server
Add lookup `context` in `self` in translate.py's `_` function
