### PR TITLE
[7.0] Raise exception when ir_attachment creation fails

### DIFF
--- a/openerp/report/report_sxw.py
+++ b/openerp/report/report_sxw.py
@@ -504,7 +504,7 @@ class report_sxw(report_rml, preprocess.report):
                                 _('Error!'),
                                 _('Could not create saved report attachment'),
                             )
-                        raise e
+                        raise
                 results.append(result)
             if results:
                 if results[0][1]=='pdf':

--- a/openerp/report/report_sxw.py
+++ b/openerp/report/report_sxw.py
@@ -18,6 +18,9 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+from openerp.osv import orm
+from openerp.tools.translate import _
+
 from lxml import etree
 import StringIO
 import cStringIO
@@ -495,9 +498,13 @@ class report_sxw(report_rml, preprocess.report):
                             'res_id': obj.id,
                             }, context=ctx
                         )
-                    except Exception:
-                        #TODO: should probably raise a proper osv_except instead, shouldn't we? see LP bug #325632
-                        _logger.error('Could not create saved report attachment', exc_info=True)
+                    except Exception as e:
+                        if not isinstance(e, orm.except_orm):
+                            raise orm.except_orm(
+                                _('Error!'),
+                                _('Could not create saved report attachment'),
+                            )
+                        raise e
                 results.append(result)
             if results:
                 if results[0][1]=='pdf':


### PR DESCRIPTION
Odoo PR: https://github.com/odoo/odoo/pull/1514

> Currently, report creation failures are silent except for a message in the logs. We propose, with this pull request, to explicitely raise them to the user.
