### PR TITLE
[7.0] When first generating user groups xml, use SUPERUSER's context

### DIFF
--- a/openerp/addons/base/res/res_users.py
+++ b/openerp/addons/base/res/res_users.py
@@ -705,6 +705,11 @@ class groups_view(osv.osv):
     def update_user_groups_view(self, cr, uid, context=None):
         # the view with id 'base.user_groups_view' inherits the user form view,
         # and introduces the reified group fields
+        if context is None:
+            context = {}
+        if not context or context.get('install_mode'):
+            context = dict(context)
+            context.update(self.pool['res.users'].context_get(cr, uid))
         view = self.get_user_groups_view(cr, uid, context)
         if view:
             xml1, xml2 = [], []


### PR DESCRIPTION
Odoo PR: https://github.com/odoo/odoo/pull/3921

Fixes English User groups

Currently, on non-english systems, groups on the user's form have English names.

This patch allows translation at install time according to the superuser's context at install time
