### PR TITLE
[7.0] Prevent pgerrors from raising `UnicodeDecodeError`

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -5469,10 +5469,10 @@ class ImportWarning(Warning):
 def convert_pgerror_23502(model, fields, info, e):
     m = re.match(r'^null value in column "(?P<field>\w+)" violates '
                  r'not-null constraint\n',
-                 str(e))
+                 tools.ustr(e))
     field_name = m.group('field')
     if not m or field_name not in fields:
-        return {'message': unicode(e)}
+        return {'message': tools.ustr(e)}
     message = _(u"Missing required value for the field '%s'.") % field_name
     field = fields.get(field_name)
     if field:
@@ -5484,10 +5484,10 @@ def convert_pgerror_23502(model, fields, info, e):
     }
 def convert_pgerror_23505(model, fields, info, e):
     m = re.match(r'^duplicate key (?P<field>\w+) violates unique constraint',
-                 str(e))
+                 tools.ustr(e))
     field_name = m.group('field')
     if not m or field_name not in fields:
-        return {'message': unicode(e)}
+        return {'message': tools.ustr(e)}
     message = _(u"The value for the field '%s' already exists.") % field_name
     field = fields.get(field_name)
     if field:
@@ -5500,7 +5500,7 @@ def convert_pgerror_23505(model, fields, info, e):
 
 PGERROR_TO_OE = collections.defaultdict(
     # shape of mapped converters
-    lambda: (lambda model, fvg, info, pgerror: {'message': unicode(pgerror)}), {
+    lambda: (lambda model, fvg, info, pgerror: {'message': tools.ustr(pgerror)}), {
     # not_null_violation
     '23502': convert_pgerror_23502,
     # unique constraint error


### PR DESCRIPTION
Odoo PR: https://github.com/odoo/odoo/pull/4045

Use `tools.ustr` for error conversion to prevent `UnicodeDecodeError` when
converting errors which can be unicode in depending on data.

Example:

``` python
from openerp.osv.orm import convert_pgerror_23505
from psycopg2 import IntegrityError

e = IntegrityError(
    'duplicate key value violates unique constraint '
    '"hr_job_name_company_uniq"\nDETAIL:  '
    'Key (name, company_id)=(Directrice comptabilit\xc3\xa9, 1) '
    'already exists.\n'
)

convert_pgerror_23505(None, [], None, e)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 129: ordinal not in range(128)
```
