### PR TITLE
Allow EDI fields to be propagated if they have `_fnct_inv`

### DIFF
--- a/addons/account/account_view.xml
+++ b/addons/account/account_view.xml
@@ -995,7 +995,9 @@
                             <group>
                                 <field name="name"/>
                                 <field name="ref"/>
-                                <field name="partner_id" on_change="onchange_partner_id(False,partner_id,account_id,debit,credit,date)"/>
+                                <field name="partner_id"
+                                    domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
+                                    on_change="onchange_partner_id(False,partner_id,account_id,debit,credit,date)"/>
                             </group>
                             <group>
                                 <field name="journal_id"/>
@@ -1068,7 +1070,9 @@
                                 <field name="journal_id" readonly="False"/>
                                 <field name="period_id" readonly="False"/>
                                 <field name="account_id" domain="[('type','&lt;&gt;','view'),('type','&lt;&gt;','consolidation'),('company_id', '=', company_id)]"/>
-                                <field name="partner_id" on_change="onchange_partner_id(False,partner_id,account_id,debit,credit,date)"/>
+                                <field name="partner_id"
+                                    domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
+                                    on_change="onchange_partner_id(False,partner_id,account_id,debit,credit,date)"/>
                                 <newline/>
                                 <field name="debit"/>
                                 <field name="credit"/>
@@ -1112,7 +1116,9 @@
                     <field name="name"/>
                     <field name="ref"/>
                     <field name="statement_id" invisible="1"/>
-                    <field name="partner_id" on_change="onchange_partner_id(move_id, partner_id, account_id, debit, credit, date, journal_id)"/>
+                    <field name="partner_id"
+                        domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
+                        on_change="onchange_partner_id(move_id, partner_id, account_id, debit, credit, date, journal_id)"/>
                     <field name="account_id" options='{"no_open":True}' domain="[('journal_id','=',journal_id), ('company_id', '=', company_id)]" on_change="onchange_account_id(account_id, partner_id, context)"/>
                     <field name="account_tax_id" options='{"no_open":True}' invisible="context.get('journal_type', False) not in ['sale','sale_refund','purchase','purchase_refund','general']"/>
                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" domain="[('type','not in',['view','template'])]" invisible="not context.get('analytic_journal_id',False)"/>
@@ -1289,7 +1295,9 @@
                                     <group col="6" colspan="4">
                                         <field name="name"/>
                                         <field name="ref"/>
-                                        <field name="partner_id" on_change="onchange_partner_id(False, partner_id, account_id, debit, credit, date, journal_id, context)"/>
+                                        <field name="partner_id"
+                                            domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
+                                            on_change="onchange_partner_id(False, partner_id, account_id, debit, credit, date, journal_id, context)"/>
 
                                         <field name="journal_id"/>
                                         <field name="period_id"/>
@@ -1353,7 +1361,9 @@
                                 <tree colors="blue:state == 'draft';black:state == 'posted'" editable="top" string="Journal Items">
                                     <field name="invoice"/>
                                     <field name="name"/>
-                                    <field name="partner_id" on_change="onchange_partner_id(False, partner_id, account_id, debit, credit, parent.date, parent.journal_id, context)"/>
+                                    <field name="partner_id"
+                                        domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
+                                        on_change="onchange_partner_id(False, partner_id, account_id, debit, credit, parent.date, parent.journal_id, context)"/>
                                     <field name="account_id" domain="[('journal_id','=',parent.journal_id),('company_id', '=', parent.company_id)]"/>
                                     <field name="date_maturity"/>
                                     <field name="debit" sum="Total Debit"/>

--- a/addons/account/report/account_aged_partner_balance.py
+++ b/addons/account/report/account_aged_partner_balance.py
@@ -188,9 +188,12 @@ class aged_trial_report(report_sxw.rml_parse, common_report_header):
                         partial = date and date[0][0] <= form[str(i)]['stop']
                     if partial:
                         # partial reconcilation
+                        limit_date = 'COALESCE(l.date_maturity,l.date) %s %%s' % '<=' if self.direction_selection == 'past' else '>='
                         self.cr.execute('''SELECT SUM(l.debit-l.credit)
                                            FROM account_move_line AS l, account_move AS am
-                                           WHERE l.move_id = am.id AND am.state in %s AND l.reconcile_partial_id = %s''', (tuple(move_state), partner_info[2],))
+                                           WHERE l.move_id = am.id AND am.state in %s
+                                           AND l.reconcile_partial_id = %s
+                                           AND ''' + limit_date, (tuple(move_state), partner_info[2], self.date_from))
                         unreconciled_amount = self.cr.fetchall()
                         partners_amount[partner_info[0]] += unreconciled_amount[0][0]
                 else:

--- a/addons/account_check_writing/account_voucher_view.xml
+++ b/addons/account_check_writing/account_voucher_view.xml
@@ -12,14 +12,14 @@
                 <field name="amount" position="after">
                     <newline/>
                     <field name="allow_check" invisible="1"/>
-                    <field name="amount_in_word" attrs="{'invisible':[('allow_check','!=',1)]}" nolabel="1" colspan="6"/>
+                    <field name="amount_in_word" attrs="{'invisible':[('allow_check','!=',True)]}" nolabel="1" colspan="6"/>
                     <newline/>
                 </field>
                 <field name="number" position="replace">
-                    <field name="number" attrs="{'readonly':[('allow_check','!=',1)]}" />
+                    <field name="number" attrs="{'readonly':[('allow_check','!=',True)]}" />
                 </field>
                 <button name="proforma_voucher" position="after">
-                    <button name="print_check" icon="gtk-print" string="Print Check" type="object" attrs="{'invisible':['|',('allow_check','!=',1),('state','!=','posted') ]}" class="oe_highlight"/>
+                    <button name="print_check" icon="gtk-print" string="Print Check" type="object" attrs="{'invisible':['|',('allow_check','!=',True),('state','!=','posted') ]}" class="oe_highlight"/>
                 </button>
             </field>
         </record>

--- a/addons/edi/models/edi.py
+++ b/addons/edi/models/edi.py
@@ -567,7 +567,7 @@ class EDIMixin(object):
                 continue
             field = field_info.column
             # skip function/related fields
-            if isinstance(field, fields.function):
+            if isinstance(field, fields.function) and not field._fnct_inv:
                 _logger.warning("Unexpected function field value is found in '%s' EDI document: '%s'." % (self._name, field_name))
                 continue
             relation_model = field._obj

--- a/addons/stock/wizard/stock_return_picking.py
+++ b/addons/stock/wizard/stock_return_picking.py
@@ -69,10 +69,10 @@ class stock_return_picking(osv.osv_memory):
         pick = pick_obj.browse(cr, uid, record_id, context=context)
         if pick:
             if 'invoice_state' in fields:
-                if pick.invoice_state=='invoiced':
-                    res.update({'invoice_state': '2binvoiced'})
+                if pick.invoice_state in ['invoiced','2binvoiced']:
+                    res['invoice_state'] = '2binvoiced'
                 else:
-                    res.update({'invoice_state': 'none'})
+                    res['invoice_state'] = 'none'
             return_history = self.get_return_history(cr, uid, record_id, context)       
             for line in pick.move_lines:
                 qty = line.product_qty - return_history.get(line.id, 0)


### PR DESCRIPTION
Odoo Issue: https://github.com/odoo/odoo/pull/4306

Only adding commit 78520a2

Allow EDI fields to be propagated if they have `_fnct_inv`

Presently, edi will skip writing to function fields even if they have a `_fnct_inv`.

This is a problem with the [partner_firstname](https://github.com/OCA/partner-contact/tree/7.0/partner_firstname) which overwrites name with a field function feeding a required field.
