### PR TITLE
[FIX] Prevent error with using wrong pot file on loading translations

### DIFF
--- a/openerp/tools/translate.py
+++ b/openerp/tools/translate.py
@@ -953,10 +953,12 @@ def trans_load_data(cr, fileobj, fileformat, lang, lang_name=None, verbose=True,
                     # Normally the path looks like /path/to/xxx/i18n/lang.po
                     # and we try to find the corresponding
                     # /path/to/xxx/i18n/xxx.pot file.
+                    # (Sometimes we have 'i18n_extra' instead of just 'i18n')
                     addons_module_i18n, _ = os.path.split(fileobj.name)
-                    addons_module, _ = os.path.split(addons_module_i18n)
+                    addons_module, i18n_dir = os.path.split(addons_module_i18n)
                     addons, module = os.path.split(addons_module)
-                    pot_handle = misc.file_open(os.path.join(addons, module, 'i18n', module + '.pot'))
+                    pot_handle = misc.file_open(os.path.join(
+                        addons, module, i18n_dir, module + '.pot'))
                     pot_reader = TinyPoFile(pot_handle)
                 except:
                     pass


### PR DESCRIPTION
```
from i18n_extra directory.
```

This problem solves a problem when loading translations from an i18n_extra directory. Withouth the fix, it will link the translations to a pot file in the standard i18n directory.
