### PR TITLE
Support for defining addon_path in several lines

### DIFF
--- a/openerp/tools/config.py
+++ b/openerp/tools/config.py
@@ -460,7 +460,7 @@ class configmanager(object):
             self.options['addons_path'] = ','.join(default_addons)
         else:
             self.options['addons_path'] = ",".join(
-                    os.path.abspath(os.path.expanduser(os.path.expandvars(x)))
+                    os.path.abspath(os.path.expanduser(os.path.expandvars(x.strip())))
                       for x in self.options['addons_path'].split(','))
 
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}


### PR DESCRIPTION
Impacted versions:
- 8.0

Steps to reproduce:
1. Define addons_path using ConfigParser syntax for several lines. For example

``` bash
root_path = /var/openerp/odoo
addons_path: /usr/lib/python2.7/dist-packages/openerp/addons,
             %(root_path)s/addons/,
             %(root_path)s/extras/
```
1. openerp/tools/config.py will parse adddons folder starting with '/\n'

Current behavior:

``` bash
openerp: addons paths: ['/var/openerp/.local/share/Odoo/addons/8.0', u'/var/openerp/master/addons', u'/\n/var/openerp/master/partner-contact', u'/\n/var/openerp/master/bank-statement-reconcile', u'/\n/var/openerp/master/account-payment', u'/\n/var/openerp/master/l10n-spain', u'/\n/var/openerp/master/extras', '/var/openerp/master/openerp/addons']
```

Expected behavior:

``` bash
openerp: addons paths: ['/var/openerp/.local/share/Odoo/addons/8.0', u'/var/openerp/master/addons', u'/var/openerp/master/partner-contact', u'/var/openerp/master/bank-statement-reconcile', u'/var/openerp/master/account-payment', u'/var/openerp/master/l10n-spain', u'/var/openerp/master/extras', '/var/openerp/master/openerp/addons']
```
