### PR TITLE
[7.0] Allow EDI fields to be propagated if they have `_fnct_inv`

### DIFF
--- a/addons/edi/models/edi.py
+++ b/addons/edi/models/edi.py
@@ -567,7 +567,7 @@ class EDIMixin(object):
                 continue
             field = field_info.column
             # skip function/related fields
-            if isinstance(field, fields.function):
+            if isinstance(field, fields.function) and not field._fnct_inv:
                 _logger.warning("Unexpected function field value is found in '%s' EDI document: '%s'." % (self._name, field_name))
                 continue
             relation_model = field._obj


### PR DESCRIPTION
Odoo Issue: https://github.com/odoo/odoo/pull/4306

This is a rebase of 78520a2 from #114

Allow EDI fields to be propagated if they have `_fnct_inv`

Presently, edi will skip writing to function fields even if they have a `_fnct_inv`.

This is a problem with the [partner_firstname](https://github.com/OCA/partner-contact/tree/7.0/partner_firstname) which overwrites name with a field function feeding a required field.
