### PR TITLE
[FIX] prevent entering a blank amount_currency in an account.move.line

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -26,8 +26,11 @@ from operator import itemgetter
 
 from lxml import etree
 
+from openerp import SUPERUSER_ID
+
 from openerp import netsvc
 from openerp.osv import fields, osv, orm
+from openerp.tools.float_utils import float_is_zero
 from openerp.tools.translate import _
 import openerp.addons.decimal_precision as dp
 from openerp import tools
@@ -609,8 +612,16 @@ class account_move_line(osv.osv):
         return True
 
     def _check_currency_and_amount(self, cr, uid, ids, context=None):
+        digits = self.pool['decimal.precision'].precision_get(
+            cr, SUPERUSER_ID, 'Account')
         for l in self.browse(cr, uid, ids, context=context):
-            if (l.amount_currency and not l.currency_id):
+            amount_currency_is_zero = float_is_zero(l.amount_currency,
+                                                    precision_digits=digits)
+            # Require a non-zero amount if there is a currency
+            if amount_currency_is_zero and l.currency_id:
+                return False
+            # Forbid a non-zero amount if there is no currency
+            if not amount_currency_is_zero and not l.currency_id:
                 return False
         return True
 

--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -617,9 +617,6 @@ class account_move_line(osv.osv):
         for l in self.browse(cr, uid, ids, context=context):
             amount_currency_is_zero = float_is_zero(l.amount_currency,
                                                     precision_digits=digits)
-            # Require a non-zero amount if there is a currency
-            if amount_currency_is_zero and l.currency_id:
-                return False
             # Forbid a non-zero amount if there is no currency
             if not amount_currency_is_zero and not l.currency_id:
                 return False
@@ -1238,6 +1235,18 @@ class account_move_line(osv.osv):
                     account.currency_id.id, vals.get('debit', 0.0)-vals.get('credit', 0.0), context=ctx)
         if not ok:
             raise osv.except_osv(_('Bad Account!'), _('You cannot use this general account in this journal, check the tab \'Entry Controls\' on the related journal.'))
+
+        verify_amount_currency = context.get('verify_amount_currency', True)
+        if vals.get('currency_id') and verify_amount_currency:
+            digits = self.pool['decimal.precision'].precision_get(
+                cr, SUPERUSER_ID, 'Account')
+            amount_currency_is_zero = float_is_zero(
+                vals.get('amount_currency'),
+                precision_digits=digits)
+            if amount_currency_is_zero:
+                raise orm.except_orm(
+                    _('Validation Error'),
+                    _('The amount in secondary currency is missing'))
 
         result = super(account_move_line, self).create(cr, uid, vals, context=context)
         # CREATE Taxes

--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3497,6 +3497,12 @@ msgid "You cannot create journal items with a secondary currency without recordi
 msgstr ""
 
 #. module: account
+#: code:addons/account/account_move_line.py:1249
+#, python-format
+msgid "The amount in secondary currency is missing"
+msgstr ""
+
+#. module: account
 #: field:account.financial.report,display_detail:0
 msgid "Display details"
 msgstr ""
@@ -5277,6 +5283,12 @@ msgstr ""
 #: model:process.transition,name:account.process_transition_suppliervalidentries0
 #: model:process.transition,name:account.process_transition_validentries0
 msgid "Validation"
+msgstr ""
+
+#. module: account
+#: code:addons/account/account_move_line.py:1248
+#, python-format
+msgid "Validation Error"
 msgstr ""
 
 #. module: account

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -1,7 +1,9 @@
-from . import test_tax
+from . import test_currency
 from . import test_search
+from . import test_tax
 
 fast_suite = [
-	test_tax,
-	test_search,
+    test_currency,
+    test_search,
+    test_tax,
 ]

--- a/addons/account/tests/test_currency.py
+++ b/addons/account/tests/test_currency.py
@@ -1,0 +1,61 @@
+from openerp.osv import orm
+from openerp.tests.common import TransactionCase
+
+class TestSearch(TransactionCase):
+    """Tests for search on name_search (account.account)
+
+    The name search on account.account is quite complexe, make sure
+    we have all the correct results
+    """
+
+    def test_move_line_amount_in_currency_no_currency(self):
+        account_move_obj = self.registry("account.move")
+        defaults = account_move_obj.default_get(self.cr, self.uid,
+                                                ["period_id", "date"])
+        ref = self.ref
+
+        with self.assertRaises(orm.except_orm):
+            account_move_obj.create(
+                self.cr, self.uid,
+                {
+                    "journal_id": ref("account.sales_journal"),
+                    "period_id": defaults["period_id"],
+                    "date": defaults["date"],
+                    "line_id": [
+                        (0, 0, {
+                            "name": "Test Line",
+                            "account_id": ref("account.cash"),
+                            "debit": 5.00,
+                            "amount_currency": 5.00,
+                        }),
+                    ],
+                }
+            )
+
+
+    def test_move_line_no_amount_in_currency_with_currency(self):
+        account_move_obj = self.registry("account.move")
+        defaults = account_move_obj.default_get(self.cr, self.uid,
+                                                ["period_id", "date"])
+        ref = self.ref
+
+        with self.assertRaises(orm.except_orm):
+            account_move_obj.create(
+                self.cr, self.uid,
+                {
+                    "journal_id": ref("account.sales_journal"),
+                    "period_id": defaults["period_id"],
+                    "date": defaults["date"],
+                    "line_id": [
+                        (0, 0, {
+                            "name": "Test Line",
+                            "account_id": ref("account.usd_bnk"),
+                            "debit": 5.00,
+                            "amount_currency": 0.00,
+                            "currency_id": ref("base.USD"),
+                        }),
+                    ],
+                }
+            )
+
+

--- a/addons/account_voucher/account_voucher.py
+++ b/addons/account_voucher/account_voucher.py
@@ -1284,9 +1284,13 @@ class account_voucher(osv.osv):
 
             if not currency_obj.is_zero(cr, uid, voucher.company_id.currency_id, currency_rate_difference):
                 # Change difference entry in company currency
+                exch_context = context.copy()
+                exch_context['verify_amount_currency'] = False
                 exch_lines = self._get_exchange_lines(cr, uid, line, move_id, currency_rate_difference, company_currency, current_currency, context=context)
-                new_id = move_line_obj.create(cr, uid, exch_lines[0],context)
-                move_line_obj.create(cr, uid, exch_lines[1], context)
+                new_id = move_line_obj.create(cr, uid, exch_lines[0],
+                                              context=exch_context)
+                move_line_obj.create(cr, uid, exch_lines[1],
+                                     context=exch_context)
                 rec_ids.append(new_id)
 
             if line.move_line_id and line.move_line_id.currency_id and not currency_obj.is_zero(cr, uid, line.move_line_id.currency_id, foreign_currency_diff):


### PR DESCRIPTION
This is a fix for https://github.com/odoo/odoo/issues/4242 
Upstream PR: https://github.com/odoo/odoo/pull/4457
