### PR TITLE
[FIX] 'point_of_sale' add customer domain on  partner field of pos_order;

### DIFF
--- a/addons/point_of_sale/point_of_sale_view.xml
+++ b/addons/point_of_sale/point_of_sale_view.xml
@@ -30,7 +30,7 @@
                         <field name="name"/>
                         <field name="date_order"/>
                         <field name="session_id" required="1"/>
-                        <field name="partner_id" on_change="onchange_partner_id(partner_id, context)" domain="[('customer','=','True')]" context="{'search_default_customer':1}" attrs="{'readonly': [('state','=','invoiced')]}"/>
+                        <field name="partner_id" on_change="onchange_partner_id(partner_id, context)" domain="[('customer', '=', True)]" context="{'search_default_customer':1}" attrs="{'readonly': [('state','=','invoiced')]}"/>
                     </group>
                     <notebook colspan="4">
                         <page string="Products">

--- a/addons/point_of_sale/point_of_sale_view.xml
+++ b/addons/point_of_sale/point_of_sale_view.xml
@@ -30,7 +30,7 @@
                         <field name="name"/>
                         <field name="date_order"/>
                         <field name="session_id" required="1"/>
-                        <field name="partner_id" on_change="onchange_partner_id(partner_id, context)" context="{'search_default_customer':1}" attrs="{'readonly': [('state','=','invoiced')]}"/>
+                        <field name="partner_id" on_change="onchange_partner_id(partner_id, context)" domain="[('customer','=','True')]" context="{'search_default_customer':1}" attrs="{'readonly': [('state','=','invoiced')]}"/>
                     </group>
                     <notebook colspan="4">
                         <page string="Products">


### PR DESCRIPTION
Add the same behaviour in pos_order form view as in sale_order form view; (domain of partner is restricted to customer = True);
_PR also available on odoo branch_ : https://github.com/odoo/odoo/pull/4770
