### PR TITLE
[IMP] disable auto_install for im_odoo_support

### DIFF
--- a/addons/im_odoo_support/__openerp__.py
+++ b/addons/im_odoo_support/__openerp__.py
@@ -22,6 +22,6 @@ Ask your functionnal question directly to the Odoo Operators with the livechat s
         'static/src/xml/im_odoo_support.xml'
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'application': True,
 }


### PR DESCRIPTION
I don't think the community version needs this. Why not do this in disable_openerp_online? To do this right, disable_openerp_online would have to depend on im_odoo_support just to completely remove its functionality
