### PR TITLE
Fix binary fields in one2many widgets:

### DIFF
--- a/addons/web/static/src/js/data.js
+++ b/addons/web/static/src/js/data.js
@@ -753,7 +753,7 @@ instance.web.DataSetStatic =  instance.web.DataSet.extend({
         var offset = options.offset || 0,
             limit = options.limit || false;
         var end_pos = limit && limit !== -1 ? offset + limit : this.ids.length;
-        return this.read_ids(this.ids.slice(offset, end_pos), fields);
+        return this.read_ids(this.ids.slice(offset, end_pos), fields, options);
     },
     set_ids: function (ids) {
         this.ids = ids;

--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -4379,6 +4379,10 @@ instance.web.form.One2ManyViewManager = instance.web.ViewManager.extend({
 instance.web.form.One2ManyDataSet = instance.web.BufferedDataSet.extend({
     get_context: function() {
         this.context = this.o2m.build_context();
+        var self = this;
+        _.each(arguments, function(context) {
+            self.context.add(context);
+        });
         return this.context;
     }
 });

--- a/addons/web/static/src/js/view_list.js
+++ b/addons/web/static/src/js/view_list.js
@@ -2305,13 +2305,9 @@ instance.web.list.Binary = instance.web.list.Column.extend({
         var text = _t("Download");
         var value = row_data[this.id].value;
         var download_url;
-        if (value && value.substr(0, 10).indexOf(' ') == -1) {
-            download_url = "data:application/octet-stream;base64," + value;
-        } else {
-            download_url = instance.session.url('/web/binary/saveas', {model: options.model, field: this.id, id: options.id});
-            if (this.filename) {
-                download_url += '&filename_field=' + this.filename;
-            }
+        download_url = instance.session.url('/web/binary/saveas', {model: options.model, field: this.id, id: options.id});
+        if (this.filename) {
+            download_url += '&filename_field=' + this.filename;
         }
         if (this.filename && row_data[this.filename]) {
             text = _.str.sprintf(_t("Download \"%s\""), instance.web.format_value(


### PR DESCRIPTION
- Don't retrieve the binary contents just to display the size, but pass context with bin_size=True instead
- Always pass filename in download link

Combination of patches from the bug report from Enrico Ganzaroli, Cedric Le Brouster and the last commit from myself which actually prevents the preloading of the binaries.

https://launchpad.net/bugs/1167429
