### PR TITLE
[FIX] remove amount_currency from write_off line

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -477,7 +477,7 @@ class account_move_line(osv.osv):
             type='many2one', relation='account.invoice', fnct_search=_invoice_search),
         'account_tax_id':fields.many2one('account.tax', 'Tax'),
         'analytic_account_id': fields.many2one('account.analytic.account', 'Analytic Account'),
-        'company_id': fields.related('account_id', 'company_id', type='many2one', relation='res.company', 
+        'company_id': fields.related('account_id', 'company_id', type='many2one', relation='res.company',
                             string='Company', store=True, readonly=True)
     }
 
@@ -757,7 +757,7 @@ class account_move_line(osv.osv):
                 WHERE debit > 0 AND credit > 0 AND (last_reconciliation_date IS NULL OR max_date > last_reconciliation_date)
                 ORDER BY last_reconciliation_date""")
         ids = [x[0] for x in cr.fetchall()]
-        if not ids: 
+        if not ids:
             return []
 
         # To apply the ir_rules
@@ -785,7 +785,7 @@ class account_move_line(osv.osv):
             else:
                 currency_id = line.company_id.currency_id
             if line.reconcile_id:
-                raise osv.except_osv(_('Warning'), _("Journal Item '%s' (id: %s), Move '%s' is already reconciled!") % (line.name, line.id, line.move_id.name)) 
+                raise osv.except_osv(_('Warning'), _("Journal Item '%s' (id: %s), Move '%s' is already reconciled!") % (line.name, line.id, line.move_id.name))
             if line.reconcile_partial_id:
                 for line2 in line.reconcile_partial_id.line_partial_ids:
                     if not line2.reconcile_id:
@@ -888,17 +888,6 @@ class account_move_line(osv.osv):
             else:
                 libelle = _('Write-Off')
 
-            cur_obj = self.pool.get('res.currency')
-            cur_id = False
-            amount_currency_writeoff = 0.0
-            if context.get('company_currency_id',False) != context.get('currency_id',False):
-                cur_id = context.get('currency_id',False)
-                for line in unrec_lines:
-                    if line.currency_id and line.currency_id.id == context.get('currency_id',False):
-                        amount_currency_writeoff += line.amount_currency
-                    else:
-                        tmp_amount = cur_obj.compute(cr, uid, line.account_id.company_id.currency_id.id, context.get('currency_id',False), abs(line.debit-line.credit), context={'date': line.date})
-                        amount_currency_writeoff += (line.debit > 0) and tmp_amount or -tmp_amount
 
             writeoff_lines = [
                 (0, 0, {
@@ -908,8 +897,6 @@ class account_move_line(osv.osv):
                     'account_id': account_id,
                     'date': date,
                     'partner_id': partner_id,
-                    'currency_id': cur_id or (account.currency_id.id or False),
-                    'amount_currency': amount_currency_writeoff and -1 * amount_currency_writeoff or (account.currency_id.id and -1 * currency or 0.0)
                 }),
                 (0, 0, {
                     'name': libelle,
@@ -919,8 +906,6 @@ class account_move_line(osv.osv):
                     'analytic_account_id': context.get('analytic_id', False),
                     'date': date,
                     'partner_id': partner_id,
-                    'currency_id': cur_id or (account.currency_id.id or False),
-                    'amount_currency': amount_currency_writeoff and amount_currency_writeoff or (account.currency_id.id and currency or 0.0)
                 })
             ]
 
@@ -1121,7 +1106,7 @@ class account_move_line(osv.osv):
         period = period_obj.browse(cr, uid, period_id, context=context)
         for (state,) in result:
             if state == 'done':
-                raise osv.except_osv(_('Error!'), _('You can not add/modify entries in a closed period %s of journal %s.' % (period.name,journal.name)))                
+                raise osv.except_osv(_('Error!'), _('You can not add/modify entries in a closed period %s of journal %s.' % (period.name,journal.name)))
         if not result:
             jour_period_obj.create(cr, uid, {
                 'name': (journal.code or journal.name)+':'+(period.name or ''),


### PR DESCRIPTION
When you generate a write-off you don't want to have an amount currency in the move lines
