### PR TITLE
If context contains 'search_disable_custom_filters': False, do not deactivate custom filters

### DIFF
--- a/addons/web/static/src/js/views.js
+++ b/addons/web/static/src/js/views.js
@@ -315,10 +315,9 @@ instance.web.ActionManager = instance.web.Widget.extend({
         // Ensure context & domain are evaluated and can be manipulated/used
         var ncontext = new instance.web.CompoundContext(options.additional_context, action.context || {});
         action.context = instance.web.pyeval.eval('context', ncontext);
-        if ((!('search_disable_custom_filters' in action.context)
-             || action.context.search_disable_custom_filters)
-            && (action.context.active_id
-                || action.context.active_ids)
+        // if the variable 'search_disable_custom_filters' is already in the context,
+        // do nothing
+        if (!('search_disable_custom_filters' in action.context) && (action.context.active_id || action.context.active_ids)
            ) {
             // Here we assume that when an `active_id` or `active_ids` is used
             // in the context, we are in a `related` action, so we disable the

--- a/addons/web/static/src/js/views.js
+++ b/addons/web/static/src/js/views.js
@@ -315,7 +315,11 @@ instance.web.ActionManager = instance.web.Widget.extend({
         // Ensure context & domain are evaluated and can be manipulated/used
         var ncontext = new instance.web.CompoundContext(options.additional_context, action.context || {});
         action.context = instance.web.pyeval.eval('context', ncontext);
-        if (action.context.active_id || action.context.active_ids) {
+        if ((!('search_disable_custom_filters' in action.context)
+             || action.context.search_disable_custom_filters)
+            && (action.context.active_id
+                || action.context.active_ids)
+           ) {
             // Here we assume that when an `active_id` or `active_ids` is used
             // in the context, we are in a `related` action, so we disable the
             // searchview's default custom filters.


### PR DESCRIPTION
This PR is to mirror the change requested in https://github.com/odoo/odoo/pull/4952 ; if an ir_actions.act_window is defined with "{'search_disable_custom_filters': False}", this variable is correctly considered by the Web page.
