### PR TITLE
Use decimal precision for write-off

### DIFF
--- a/addons/account/wizard/account_reconcile.py
+++ b/addons/account/wizard/account_reconcile.py
@@ -24,7 +24,6 @@ import time
 from openerp.osv import fields, osv
 from openerp.tools.translate import _
 import openerp.addons.decimal_precision as dp
-from openerp.tools.float_utils import float_is_zero
 
 
 class account_move_line_reconcile(osv.osv_memory):

--- a/addons/account/wizard/account_reconcile.py
+++ b/addons/account/wizard/account_reconcile.py
@@ -68,8 +68,7 @@ class account_move_line_reconcile(osv.osv_memory):
                 account = line.account_id
         # If the write-off is lower than the account precision,
         # set it to 0.
-        currency = account.currency_id and \
-            account.currency_id or account.company_id.currency_id
+        currency = account.company_id.currency_id
         writeoff = debit - credit
         if self.pool['res.currency'].is_zero(cr, uid, currency, writeoff):
             writeoff = 0.0

--- a/addons/account/wizard/account_reconcile.py
+++ b/addons/account/wizard/account_reconcile.py
@@ -66,10 +66,13 @@ class account_move_line_reconcile(osv.osv_memory):
                 credit += line.credit
                 debit += line.debit
                 account = line.account_id
+        writeoff = debit - credit
         # If the write-off is lower than the account precision,
         # set it to 0.
+        if not account:
+            return {'trans_nbr': count, 'account_id': False,
+                    'credit': credit, 'debit': debit, 'writeoff': writeoff}
         currency = account.company_id.currency_id
-        writeoff = debit - credit
         if self.pool['res.currency'].is_zero(cr, uid, currency, writeoff):
             writeoff = 0.0
         return {'trans_nbr': count, 'account_id': account.id,

--- a/addons/account/wizard/account_reconcile.py
+++ b/addons/account/wizard/account_reconcile.py
@@ -58,21 +58,22 @@ class account_move_line_reconcile(osv.osv_memory):
         if context is None:
             context = {}
         credit = debit = 0
-        account_id = False
+        account = False
         count = 0
         for line in account_move_line_obj.browse(cr, uid, context['active_ids'], context=context):
             if not line.reconcile_id and not line.reconcile_id.id:
                 count += 1
                 credit += line.credit
                 debit += line.debit
-                account_id = line.account_id.id
+                account = line.account_id
         # If the write-off is lower than the account precision,
         # set it to 0.
+        currency = account.currency_id and \
+            account.currency_id or account.company_id.currency_id
         writeoff = debit - credit
-        if float_is_zero(writeoff,
-                         precision_rounding=dp.get_precision('Account')):
+        if self.pool['res.currency'].is_zero(cr, uid, currency, writeoff):
             writeoff = 0.0
-        return {'trans_nbr': count, 'account_id': account_id,
+        return {'trans_nbr': count, 'account_id': account.id,
                 'credit': credit, 'debit': debit, 'writeoff': writeoff}
 
     def trans_rec_addendum_writeoff(self, cr, uid, ids, context=None):


### PR DESCRIPTION
This PR is to use decimal precision to assess that the write-off is equal to 0; otherwise, you can have a write-off line with "-0.00" or "0.00" as an amount in the wizard.

Done in https://github.com/odoo/odoo/pull/4969 as well.
