### PR TITLE
Use valid email addresses in tests

### DIFF
--- a/addons/email_template/tests/test_mail.py
+++ b/addons/email_template/tests/test_mail.py
@@ -37,7 +37,7 @@ class test_message_compose(TestMailBase):
         """ Tests designed for the mail.compose.message wizard updated by email_template. """
         cr, uid = self.cr, self.uid
         mail_compose = self.registry('mail.compose.message')
-        self.res_users.write(cr, uid, [uid], {'signature': 'Admin', 'email': 'a@a.a'})
+        self.res_users.write(cr, uid, [uid], {'signature': 'Admin', 'email': 'a@test'})
         user_admin = self.res_users.browse(cr, uid, uid)
         p_a_id = user_admin.partner_id.id
         group_pigs = self.mail_group.browse(cr, uid, self.group_pigs_id)
@@ -64,8 +64,8 @@ class test_message_compose(TestMailBase):
             'body_html': '${object.description}',
             'user_signature': True,
             'attachment_ids': [(0, 0, _attachments[0]), (0, 0, _attachments[1])],
-            'email_to': 'b@b.b, c@c.c',
-            'email_cc': 'd@d.d'
+            'email_to': 'b@test, c@test',
+            'email_cc': 'd@test'
             })
 
         # ----------------------------------------
@@ -111,7 +111,7 @@ class test_message_compose(TestMailBase):
         compose.refresh()
 
         message_pids = [partner.id for partner in compose.partner_ids]
-        partner_ids = self.res_partner.search(cr, uid, [('email', 'in', ['b@b.b', 'c@c.c', 'd@d.d'])])
+        partner_ids = self.res_partner.search(cr, uid, [('email', 'in', ['b@test', 'c@test', 'd@test'])])
         # Test: mail.compose.message: subject, body, partner_ids
         self.assertEqual(compose.subject, _subject1, 'mail.compose.message subject incorrect')
         self.assertIn(_body_html1, compose.body, 'mail.compose.message body incorrect')
@@ -173,7 +173,7 @@ class test_message_compose(TestMailBase):
         # Test: partner_ids: p_a_id (default) + 3 newly created partners
         message_pigs_pids = [partner.id for partner in message_pigs.notified_partner_ids]
         message_bird_pids = [partner.id for partner in message_bird.notified_partner_ids]
-        partner_ids = self.res_partner.search(cr, uid, [('email', 'in', ['b@b.b', 'c@c.c', 'd@d.d'])])
+        partner_ids = self.res_partner.search(cr, uid, [('email', 'in', ['b@test', 'c@test', 'd@test'])])
         partner_ids.append(p_a_id)
         self.assertEqual(set(message_pigs_pids), set(partner_ids), 'mail.message on pigs incorrect number of notified_partner_ids')
         self.assertEqual(set(message_bird_pids), set(partner_ids), 'mail.message on bird notified_partner_ids incorrect')
@@ -183,9 +183,9 @@ class test_message_compose(TestMailBase):
         # ----------------------------------------
 
         # get already-created partners back
-        p_b_id = self.res_partner.search(cr, uid, [('email', '=', 'b@b.b')])[0]
-        p_c_id = self.res_partner.search(cr, uid, [('email', '=', 'c@c.c')])[0]
-        p_d_id = self.res_partner.search(cr, uid, [('email', '=', 'd@d.d')])[0]
+        p_b_id = self.res_partner.search(cr, uid, [('email', '=', 'b@test')])[0]
+        p_c_id = self.res_partner.search(cr, uid, [('email', '=', 'c@test')])[0]
+        p_d_id = self.res_partner.search(cr, uid, [('email', '=', 'd@test')])[0]
         # modify template: use email_recipients, use template and email address in email_to to test all features together
         user_model_id = self.registry('ir.model').search(cr, uid, [('model', '=', 'res.users')])[0]
         email_template.write(cr, uid, [email_template_id], {
@@ -216,8 +216,8 @@ class test_message_compose(TestMailBase):
             'subject': '${object.name}',
             'body_html': '${object.description}',
             'user_signature': True,
-            'email_to': 'b@b.b c@c.c',
-            'email_cc': 'd@d.d',
+            'email_to': 'b@test c@test',
+            'email_cc': 'd@test',
             'email_recipients': '${user.partner_id.id},%s,%s,-1' % (self.user_raoul.partner_id.id, self.user_bert.partner_id.id)
         })
 
@@ -225,8 +225,8 @@ class test_message_compose(TestMailBase):
         msg_id = email_template.send_mail(cr, uid, email_template_id, self.group_pigs_id, context=context)
         mail = self.mail_mail.browse(cr, uid, msg_id, context=context)
         self.assertEqual(mail.subject, 'Pigs', 'email_template: send_mail: wrong subject')
-        self.assertEqual(mail.email_to, 'b@b.b c@c.c', 'email_template: send_mail: wrong email_to')
-        self.assertEqual(mail.email_cc, 'd@d.d', 'email_template: send_mail: wrong email_cc')
+        self.assertEqual(mail.email_to, 'b@test c@test', 'email_template: send_mail: wrong email_to')
+        self.assertEqual(mail.email_cc, 'd@test', 'email_template: send_mail: wrong email_cc')
 
         # force send: take email_recipients into account
         email_template.send_mail(cr, uid, email_template_id, self.group_pigs_id, force_send=True, context=context)

--- a/addons/email_template/tests/test_mail.py
+++ b/addons/email_template/tests/test_mail.py
@@ -191,9 +191,9 @@ class test_message_compose(TestMailBase):
         email_template.write(cr, uid, [email_template_id], {
             'model_id': user_model_id,
             'body_html': '${object.login}',
-            'email_to': '${object.email}, c@c',
+            'email_to': '${object.email}, c@test',
             'email_recipients': '%i,%i' % (p_b_id, p_c_id),
-            'email_cc': 'd@d',
+            'email_cc': 'd@test',
             })
         # patner by email + partner by id (no double)
         send_to = [p_a_id, p_b_id, p_c_id, p_d_id]

--- a/addons/mail/tests/test_mail_features.py
+++ b/addons/mail/tests/test_mail_features.py
@@ -336,7 +336,7 @@ class test_mail(TestMailBase):
 
         # Test: notifications emails: to a and b, c is email only, r is author
         # test_emailto = ['Administrator <a@test>', 'Bert Tartopoils <b@test>']
-        test_emailto = [u'"Followers of \\"Pigs\\" !\xf9 $%-" <a@test>', u'"Followers of \\"Pigs\\" !\xf9 $%-" <b@b>']
+        test_emailto = [u'"Followers of \\"Pigs\\" !\xf9 $%-" <a@test>', u'"Followers of \\"Pigs\\" !\xf9 $%-" <b@test>']
         self.assertEqual(len(sent_emails), 2,
                         'message_post: notification emails wrong number of send emails')
         self.assertEqual(set([m['email_to'][0] for m in sent_emails]), set(test_emailto),

--- a/addons/mail/tests/test_mail_features.py
+++ b/addons/mail/tests/test_mail_features.py
@@ -234,14 +234,14 @@ class test_mail(TestMailBase):
         # Data creation
         # --------------------------------------------------
         # 0 - Update existing users-partners
-        self.res_users.write(cr, uid, [uid], {'email': 'a@a', 'notification_email_send': 'comment'})
-        self.res_users.write(cr, uid, [self.user_raoul_id], {'email': 'r@r'})
+        self.res_users.write(cr, uid, [uid], {'email': 'a@test', 'notification_email_send': 'comment'})
+        self.res_users.write(cr, uid, [self.user_raoul_id], {'email': 'r@test'})
         # 1 - Bert Tartopoils, with email, should receive emails for comments and emails
-        p_b_id = self.res_partner.create(cr, uid, {'name': 'Bert Tartopoils', 'email': 'b@b'})
+        p_b_id = self.res_partner.create(cr, uid, {'name': 'Bert Tartopoils', 'email': 'b@test'})
         # 2 - Carine Poilvache, with email, should receive emails for emails
-        p_c_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@c', 'notification_email_send': 'email'})
+        p_c_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@test', 'notification_email_send': 'email'})
         # 3 - Dédé Grosbedon, without email, to test email verification; should receive emails for every message
-        p_d_id = self.res_partner.create(cr, uid, {'name': 'Dédé Grosbedon', 'email': 'd@d', 'notification_email_send': 'all'})
+        p_d_id = self.res_partner.create(cr, uid, {'name': 'Dédé Grosbedon', 'email': 'd@test', 'notification_email_send': 'all'})
         # 4 - Attachments
         attach1_id = self.ir_attachment.create(cr, user_raoul.id, {
             'name': 'Attach1', 'datas_fname': 'Attach1',
@@ -335,8 +335,8 @@ class test_mail(TestMailBase):
                         'message_post: mail.mail notifications should have been auto-deleted!')
 
         # Test: notifications emails: to a and b, c is email only, r is author
-        # test_emailto = ['Administrator <a@a>', 'Bert Tartopoils <b@b>']
-        test_emailto = [u'"Followers of \\"Pigs\\" !\xf9 $%-" <a@a>', u'"Followers of \\"Pigs\\" !\xf9 $%-" <b@b>']
+        # test_emailto = ['Administrator <a@test>', 'Bert Tartopoils <b@test>']
+        test_emailto = [u'"Followers of \\"Pigs\\" !\xf9 $%-" <a@test>', u'"Followers of \\"Pigs\\" !\xf9 $%-" <b@b>']
         self.assertEqual(len(sent_emails), 2,
                         'message_post: notification emails wrong number of send emails')
         self.assertEqual(set([m['email_to'][0] for m in sent_emails]), set(test_emailto),
@@ -409,17 +409,17 @@ class test_mail(TestMailBase):
         self.assertFalse(self.mail_mail.search(cr, uid, [('mail_message_id', '=', msg2_id)]), 'mail.mail notifications should have been auto-deleted!')
 
         # Test: emails send by server (to a, b, c, d)
-        # test_emailto = [u'Administrator <a@a>', u'Bert Tartopoils <b@b>', u'Carine Poilvache <c@c>', u'D\xe9d\xe9 Grosbedon <d@d>']
-        test_emailto = [u'Followers of Pigs <a@a>', u'Followers of Pigs <b@b>', u'Followers of Pigs <c@c>', u'Followers of Pigs <d@d>']
+        # test_emailto = [u'Administrator <a@test>', u'Bert Tartopoils <b@test>', u'Carine Poilvache <c@test>', u'D\xe9d\xe9 Grosbedon <d@test>']
+        test_emailto = [u'Followers of Pigs <a@test>', u'Followers of Pigs <b@test>', u'Followers of Pigs <c@test>', u'Followers of Pigs <d@test>']
         # self.assertEqual(len(sent_emails), 3, 'sent_email number of sent emails incorrect')
         for sent_email in sent_emails:
-            self.assertEqual(sent_email['email_from'], 'Raoul Grosbedon <r@r>',
+            self.assertEqual(sent_email['email_from'], 'Raoul Grosbedon <r@test>',
                             'message_post: notification email wrong email_from: should use email of sender when no alias domain set')
             self.assertEqual(len(sent_email['email_to']), 1,
                             'message_post: notification email sent to more than one email address instead of a precise partner')
             self.assertIn(sent_email['email_to'][0], test_emailto,
                             'message_post: notification email email_to incorrect')
-            self.assertEqual(sent_email['reply_to'], 'Followers of Pigs <r@r>',
+            self.assertEqual(sent_email['reply_to'], 'Followers of Pigs <r@test>',
                             'message_post: notification email reply_to incorrect: should name Followers of Pigs, and have raoul email')
             self.assertEqual(_mail_subject, sent_email['subject'],
                             'message_post: notification email subject incorrect')
@@ -463,14 +463,14 @@ class test_mail(TestMailBase):
         # Data creation
         # --------------------------------------------------
         # 0 - Update existing users-partners
-        self.res_users.write(cr, uid, [uid], {'email': 'a@a'})
-        self.res_users.write(cr, uid, [self.user_raoul_id], {'email': 'r@r'})
+        self.res_users.write(cr, uid, [uid], {'email': 'a@test'})
+        self.res_users.write(cr, uid, [self.user_raoul_id], {'email': 'r@test'})
         # 1 - Bert Tartopoils, with email, should receive emails for comments and emails
-        p_b_id = self.res_partner.create(cr, uid, {'name': 'Bert Tartopoils', 'email': 'b@b'})
+        p_b_id = self.res_partner.create(cr, uid, {'name': 'Bert Tartopoils', 'email': 'b@test'})
         # 2 - Carine Poilvache, with email, should receive emails for emails
-        p_c_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@c', 'notification_email_send': 'email'})
+        p_c_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@test', 'notification_email_send': 'email'})
         # 3 - Dédé Grosbedon, without email, to test email verification; should receive emails for every message
-        p_d_id = self.res_partner.create(cr, uid, {'name': 'Dédé Grosbedon', 'email': 'd@d', 'notification_email_send': 'all'})
+        p_d_id = self.res_partner.create(cr, uid, {'name': 'Dédé Grosbedon', 'email': 'd@test', 'notification_email_send': 'all'})
         # 4 - Create a Bird mail.group, that will be used to test mass mailing
         group_bird_id = self.mail_group.create(cr, uid,
             {

--- a/addons/portal/tests/test_portal.py
+++ b/addons/portal/tests/test_portal.py
@@ -106,7 +106,7 @@ class test_portal(TestMailBase):
         mail_invite = self.registry('mail.wizard.invite')
         base_url = self.registry('ir.config_parameter').get_param(cr, uid, 'web.base.url', default='')
         # Carine Poilvache, with email, should receive emails for comments and emails
-        partner_carine_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@c'})
+        partner_carine_id = self.res_partner.create(cr, uid, {'name': 'Carine Poilvache', 'email': 'c@test'})
 
         # Do: create a mail_wizard_invite, validate it
         self._init_mock_build_email()


### PR DESCRIPTION
This is so my email validation module 
(https://github.com/OCA/partner-contact/pull/86)
doesn't break tests when installed.
