### PR TITLE
[FIX] base: Missing orm import

### DIFF
--- a/openerp/addons/base/res/res_partner.py
+++ b/openerp/addons/base/res/res_partner.py
@@ -27,7 +27,7 @@ import urlparse
 
 import openerp
 from openerp import tools, api
-from openerp.osv import osv, fields
+from openerp.osv import osv, orm, fields
 from openerp.osv.expression import get_unaccent_wrapper
 from openerp.tools.translate import _
 


### PR DESCRIPTION
In #152, a new call was introduced that it's not declared in the import section.

Please fast track this ASAP to fix the general problem.
