### PR TITLE
[FIX] product: Continue to next pricelist rule when no seller is found for a 'Supplier prices on the product form' odoo/odoo#4505

### DIFF
--- a/addons/product/pricelist.py
+++ b/addons/product/pricelist.py
@@ -306,8 +306,8 @@ class product_pricelist(osv.osv):
                         if (not partner) or (seller_id.name.id != partner):
                             continue
                         seller = seller_id
-                    if not seller and product.seller_ids:
-                        seller = product.seller_ids[0]
+                    if not seller:
+                        continue
                     if seller:
                         qty_in_seller_uom = qty
                         seller_uom = seller.product_uom.id


### PR DESCRIPTION
Check link issue odoo/odoo#4505 for an explanation of the error
