### PR TITLE
[FIX]: The v7 job recruitment state change function is misspelled

### DIFF
--- a/addons/hr/hr.py
+++ b/addons/hr/hr.py
@@ -163,7 +163,7 @@ class hr_job(osv.Model):
     # ----------------------------------------
     _no_of_employee = _get_nbr_employees  # v7 compatibility
     job_open = set_open  # v7 compatibility
-    job_recruitment = set_recruit  # v7 compatibility
+    job_recruitement = set_recruit  # v7 compatibility
 
 
 class hr_employee(osv.osv):


### PR DESCRIPTION
The hr.job state changing functions were changed in version 8.0 and a compatibility re-direction was created so that modules calling the functions by the old names would still work. However, the v7 name is misspelled for one of the functions so that modules calling the function by it v7 name will still fail. The name should be spelled as job_recruitement not job_recruitment.

Odoo PR: #5477
