### PR TITLE
[8.0] fix workflow loading

### DIFF
--- a/openerp/workflow/service.py
+++ b/openerp/workflow/service.py
@@ -92,8 +92,14 @@ class WorkflowService(object):
                             "where model='workflow' and res_id in %s",
                             wkf_ids)
             modules = self.cr.fetchall()
-            modules = filter(check_module, modules)
-            wkf_ids = map(to_record, modules)
+
+            all_ids = set(map(lambda x: x[0], wkf_ids))
+            static_ids = set(map(lambda x: x[1], modules))
+            # Created on the system programmatically or manually
+            dynamic_ids = map(lambda x: (x, ), all_ids - static_ids)
+
+            filtered_modules = filter(check_module, modules)
+            wkf_ids = map(to_record, filtered_modules) + dynamic_ids
 
         for (wkf_id, ) in wkf_ids:
             WorkflowInstance.create(self.session, self.record, wkf_id)

--- a/openerp/workflow/service.py
+++ b/openerp/workflow/service.py
@@ -79,20 +79,22 @@ class WorkflowService(object):
 
                 openerp.addons.module_name
 
-            :param module: The name of the openerp module
-            :type module: tuple (module_name, res_id)
+            :param module: The id of the workflow with the module that
+                           created it.
+            :type module: tuple (res_id, module_name)
             :returns: python module or None
             """
-            return sys.modules.get('openerp.addons.%s' % module[0])
+            return sys.modules.get('openerp.addons.%s' % module[1])
 
         def to_record(module_record):
             """
             Convert a module record to the same format that is used in
             wkf_ids. We have to convert the tuple of format
-            (id,...) to (id, 0).
+            (id, ...) to (id,).
             
-            :param module_record: A tuple containing a pair (module, res_id)
-            :type module_record: tuple (module_name, res_id)
+            :param module_record: A tuple containing a pair
+                                  (res_id, module_name).
+            :type module_record: tuple (res_id, module_name)
             :returns: tuple (id, )
             """
             return (module_record[0], )

--- a/openerp/workflow/service.py
+++ b/openerp/workflow/service.py
@@ -85,16 +85,15 @@ class WorkflowService(object):
         if not wkf_ids:
             self.cr.execute('select id from wkf where osv=%s and on_create=True', (self.record.model,))
             wkf_ids = self.cr.fetchall()
-
-            if len(wkf_ids) > 0:
-                self.cr.execute("select module, res_id from ir_model_data "
-                                "where model='workflow' and res_id in %s",
-                                wkf_ids)
-                modules = self.cr.fetchall()
-                modules = filter(check_module, modules)
-                wkf_ids = map(to_record, modules)
-
             WorkflowService.CACHE[self.cr.dbname][self.record.model] = wkf_ids
+
+        if wkf_ids:
+            self.cr.execute("select module, res_id from ir_model_data "
+                            "where model='workflow' and res_id in %s",
+                            wkf_ids)
+            modules = self.cr.fetchall()
+            modules = filter(check_module, modules)
+            wkf_ids = map(to_record, modules)
 
         for (wkf_id, ) in wkf_ids:
             WorkflowInstance.create(self.session, self.record, wkf_id)


### PR DESCRIPTION
Prevent workflows from being used, if they depends on python modules that aren't yet loaded in sys.modules.

If the workflows are created without any reference to ir_model_data, they are loaded anyway as we do not have any idea if they depend on anything. Those are usually user created workflows... so the user should know.

https://github.com/odoo/odoo/pull/5703
