### PR TITLE
[IMP] Don't search for children, _product_get_multi_location does it

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -366,8 +366,7 @@ class stock_location(osv.osv):
             states = ['done']
         # build the list of ids of children of the location given by id
         ids = id and [id] or []
-        location_ids = self.search(cr, uid, [('location_id', 'child_of', ids)])
-        return self._product_get_multi_location(cr, uid, location_ids, product_ids, context, states)
+        return self._product_get_multi_location(cr, uid, ids, product_ids, context=context, states=states)
 
     def _product_virtual_get(self, cr, uid, id, product_ids=False, context=None, states=None):
         if states is None:


### PR DESCRIPTION
In stock.py, `_product_all_get` gives the stock for several products at the same location, and to to this it expends the list of locations to include the children.
But that is unneeded because `_product_get_multi_location` does it already.
It's hard to notice when only few locations are concerned but on our database with 20000 of them it makes evaluating the reordering rules very slow (>10 hours instead of <2 minutes).

Same branch proposed upstream: https://github.com/odoo/odoo/pull/5918
