### PR TITLE
[FIX] Delaying update quantity in website_sale

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -1,4 +1,13 @@
 $(document).ready(function () {
+
+var clickwatch = (function(){
+  var timer = 0;
+  return function(callback, ms){
+    clearTimeout (timer);
+    timer = setTimeout(callback, ms);
+  };
+})();
+
 $('.oe_website_sale').each(function () {
     var oe_website_sale = this;
 
@@ -50,43 +59,45 @@ $('.oe_website_sale').each(function () {
         var line_id = parseInt($input.data('line-id'),10);
         var product_id = parseInt($input.data('product-id'),10);
         var product_ids = [product_id];
-        $dom_optional.each(function(){
-            product_ids.push($(this).find('span[data-product-id]').data('product-id'));
-        });
-        if (isNaN(value)) value = 0;
-        openerp.jsonRpc("/shop/get_unit_price", 'call', {
-            'product_ids': product_ids,
-            'add_qty': value,
-            'use_order_pricelist': true})
-        .then(function (res) {
-            //basic case
-            $dom.find('span.oe_currency_value').last().text(res[product_id].toFixed(2));
-            $dom.find('.text-danger').toggle(res[product_id]<default_price && (default_price-res[product_id] > default_price/100));
-            //optional case
+        clickwatch(function{
             $dom_optional.each(function(){
-                var id = $(this).find('span[data-product-id]').data('product-id');
-                var price = parseFloat($(this).find(".text-danger > span.oe_currency_value").text());
-                $(this).find("span.oe_currency_value").last().text(res[id].toFixed(2));
-                $(this).find('.text-danger').toggle(res[id]<price && (price-res[id]>price/100));
+                product_ids.push($(this).find('span[data-product-id]').data('product-id'));
             });
-            openerp.jsonRpc("/shop/cart/update_json", 'call', {
-            'line_id': line_id,
-            'product_id': parseInt($input.data('product-id'),10),
-            'set_qty': value})
-            .then(function (data) {
-                if (!data.quantity) {
-                    location.reload();
-                    return;
-                }
-                var $q = $(".my_cart_quantity");
-                $q.parent().parent().removeClass("hidden", !data.quantity);
-                $q.html(data.cart_quantity).hide().fadeIn(600);
+            if (isNaN(value)) value = 0;
+            openerp.jsonRpc("/shop/get_unit_price", 'call', {
+                'product_ids': product_ids,
+                'add_qty': value,
+                'use_order_pricelist': true})
+            .then(function (res) {
+                //basic case
+                $dom.find('span.oe_currency_value').last().text(res[product_id].toFixed(2));
+                $dom.find('.text-danger').toggle(res[product_id]<default_price && (default_price-res[product_id] > default_price/100));
+                //optional case
+                $dom_optional.each(function(){
+                    var id = $(this).find('span[data-product-id]').data('product-id');
+                    var price = parseFloat($(this).find(".text-danger > span.oe_currency_value").text());
+                    $(this).find("span.oe_currency_value").last().text(res[id].toFixed(2));
+                    $(this).find('.text-danger').toggle(res[id]<price && (price-res[id]>price/100));
+                });
+                openerp.jsonRpc("/shop/cart/update_json", 'call', {
+                'line_id': line_id,
+                'product_id': parseInt($input.data('product-id'),10),
+                'set_qty': value})
+                .then(function (data) {
+                    if (!data.quantity) {
+                        location.reload();
+                        return;
+                    }
+                    var $q = $(".my_cart_quantity");
+                    $q.parent().parent().removeClass("hidden", !data.quantity);
+                    $q.html(data.cart_quantity).hide().fadeIn(600);
 
-                $input.val(data.quantity);
-                $('.js_quantity[data-line-id='+line_id+']').val(data.quantity).html(data.quantity);
-                $("#cart_total").replaceWith(data['website_sale.total']);
+                    $input.val(data.quantity);
+                    $('.js_quantity[data-line-id='+line_id+']').val(data.quantity).html(data.quantity);
+                    $("#cart_total").replaceWith(data['website_sale.total']);
+                });
             });
-        });
+        }, 500);
     });
 
     // hack to add and rome from cart with json


### PR DESCRIPTION
Impacted versions:
- 8.0

Steps to reproduce:
1. Update quantity by incrementing rapidly

Current behavior:
- When updating quantity in website_sale module it triggers a request per each update, thus when somebody frantically increments/decrements the quantity using mouse clicks it floods the server with as many requests

Expected behavior:
- One request should be sent at "the end" of the quantity update 

This fix adds a half-second delay to quantity updates in order to preserve bandwidth and server load but still updating "real-time"
