### PR TITLE
[FIX] mass_mailing: Mass-mailing smart-button behaviour

### DIFF
--- a/addons/mass_mailing/i18n/es.po
+++ b/addons/mass_mailing/i18n/es.po
@@ -535,6 +535,7 @@ msgid "From"
 msgstr "De"
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_search
 #: view:mail.mass_mailing.campaign:mass_mailing.view_mail_mass_mailing_campaign_search
 #: view:mail.mass_mailing.contact:mass_mailing.view_mail_mass_mailing_contact_search
@@ -861,6 +862,11 @@ msgid "Number of Contacts"
 msgstr "Número de contactos"
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
+msgid "Open Date"
+msgstr "Fecha de apertura"
+
+#. module: mass_mailing
 #: model:ir.actions.client,name:mass_mailing.action_client_marketing_menu
 msgid "Open Marketing Menu"
 msgstr "Abrit menú Marketing"
@@ -872,6 +878,7 @@ msgid "Open with Visual Editor"
 msgstr "Abrir con el editor visual"
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: field:mail.mail.statistics,opened:0
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_kanban
@@ -930,6 +937,7 @@ msgid "Preview"
 msgstr "Previsualización"
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing.campaign:mass_mailing.view_mail_mass_mailing_campaign_form
 msgid "Received"
@@ -960,6 +968,7 @@ msgid "Related Mailing(s)"
 msgstr "Envío(s) relacionado(s)"
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: field:mail.mail.statistics,replied:0
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_kanban
@@ -987,6 +996,11 @@ msgstr "Proporción de respondidos"
 #: field:mail.mass_mailing,reply_to:0
 msgid "Reply To"
 msgstr "Responder a"
+
+#. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
+msgid "Reply Date"
+msgstr "Fecha de respuesta"
 
 #. module: mass_mailing
 #: field:mail.mass_mailing,reply_to_mode:0

--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -415,6 +415,7 @@ msgid "From"
 msgstr ""
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_search
 #: view:mail.mass_mailing.campaign:mass_mailing.view_mail_mass_mailing_campaign_search
 #: view:mail.mass_mailing.contact:mass_mailing.view_mail_mass_mailing_contact_search
@@ -718,6 +719,11 @@ msgid "Number of Contacts"
 msgstr ""
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
+msgid "Open Date"
+msgstr ""
+
+#. module: mass_mailing
 #: model:ir.actions.client,name:mass_mailing.action_client_marketing_menu
 msgid "Open Marketing Menu"
 msgstr ""
@@ -729,6 +735,7 @@ msgid "Open with Visual Editor"
 msgstr ""
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: field:mail.mail.statistics,opened:0
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_kanban
@@ -783,6 +790,7 @@ msgid "Preview"
 msgstr ""
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing.campaign:mass_mailing.view_mail_mass_mailing_campaign_form
 msgid "Received"
@@ -813,6 +821,7 @@ msgid "Related Mailing(s)"
 msgstr ""
 
 #. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
 #: field:mail.mail.statistics,replied:0
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_form
 #: view:mail.mass_mailing:mass_mailing.view_mail_mass_mailing_kanban
@@ -839,6 +848,11 @@ msgstr ""
 #. module: mass_mailing
 #: field:mail.mass_mailing,reply_to:0
 msgid "Reply To"
+msgstr ""
+
+#. module: mass_mailing
+#: view:mail.mail.statistics:mass_mailing.view_mail_mail_statistics_search
+msgid "Reply Date"
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/views/mass_mailing.xml
+++ b/addons/mass_mailing/views/mass_mailing.xml
@@ -24,10 +24,17 @@
             <field name="name">mail.mail.statistics.search</field>
             <field name="model">mail.mail.statistics</field>
             <field name="arch" type="xml">
-               <search string="Mail Statistics">
+                <search string="Mail Statistics">
                     <field name="mail_mail_id_int"/>
                     <field name="message_id"/>
                     <field name="mass_mailing_id"/>
+                    <filter string="Received" name="filter_received" domain="[('sent', '!=', False), ('bounced', '=', False)]"/>
+                    <filter string="Opened" name="filter_opened" domain="[('opened', '!=', False)]"/>
+                    <filter string="Replied" name="filter_replied" domain="[('replied', '!=', False)]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Open Date" name="group_open_date" context="{'group_by': 'opened:day'}"/>
+                        <filter string="Reply Date" name="group_reply_date" context="{'group_by': 'replied:day'}"/>
+                    </group>
                 </search>
             </field>
         </record>
@@ -289,23 +296,28 @@
                     <sheet>
                         <div class="oe_button_box pull-right" attrs="{'invisible': [('state', 'in', ('draft','test'))]}">
                             <button name="%(action_view_mail_mail_statistics_mailing)d"
-                                type="action" class="oe_stat_button">
+                                    context="{'search_default_filter_received': True}"
+                                    type="action" class="oe_stat_button">
                                 <field name="received_ratio" string="Received" widget="percentpie"/>
                             </button>
                             <button name="%(action_view_mail_mail_statistics_mailing)d"
-                                type="action" class="oe_stat_button">
+                                    context="{'search_default_filter_opened': True}"
+                                    type="action" class="oe_stat_button">
                                 <field name="opened_ratio" string="Opened" widget="percentpie"/>
                             </button>
                             <button name="%(action_view_mail_mail_statistics_mailing)d"
-                                type="action" class="oe_stat_button">
+                                    context="{'search_default_filter_replied': True}"
+                                    type="action" class="oe_stat_button">
                                 <field name="replied_ratio" string="Replied" widget="percentpie"/>
                             </button>
                             <button name="%(action_view_mail_mail_statistics_mailing)d"
-                                type="action" class="oe_stat_button oe_inline">
+                                    context="{'search_default_filter_opened': True, 'search_default_group_open_date': True}"
+                                    type="action" class="oe_stat_button oe_inline">
                                 <field name="opened_daily" string="Opened Daily" widget="barchart"/>
                             </button>
                             <button name="%(action_view_mail_mail_statistics_mailing)d"
-                                type="action" class="oe_stat_button oe_inline">
+                                    context="{'search_default_filter_replied': True, 'search_default_group_reply_date': True}"
+                                    type="action" class="oe_stat_button oe_inline">
                                 <field name="replied_daily" string="Replied Daily" widget="barchart"/>
                             </button>
                         </div>


### PR DESCRIPTION
Upstream PR: https://github.com/odoo/odoo/pull/6147
# Mass mailing smart buttons don't filter records
## Impacted versions
- 8.0 and above
## Steps to reproduce
1. Go to Marketing > Mass Mailings
2. Click on "First Newsletter" record.
3. Click on "Opened" smartbutton.
4. You will see 5 records out of 5.
5. Go back.
6. Click on "Replied" smartbutton.
7. You will see also 5 records.
## Current behaviour
- All smartbuttons go to the same unfiltered list.
- There's no search filters nor group by.
## Expected behaviour
- Each smartbutton filter out records that doesn't fit the smartbutton criteria.
- There are filters and group by according criteria.
