### PR TITLE
[FIX] project_issue: Incorrect access rule when project security = followers

### DIFF
--- a/addons/project_issue/security/project_issue_security.xml
+++ b/addons/project_issue/security/project_issue_security.xml
@@ -17,7 +17,7 @@
                                                 ('project_id.privacy_visibility', 'in', ['public', 'employees']),
                                                 '&amp;',
                                                     ('project_id.privacy_visibility', '=', 'followers'),
-                                                    ('message_follower_ids', 'in', [user.id]),
+                                                    ('message_follower_ids', 'in', [user.partner.id]),
                                             ('user_id', '=', user.id),
                                         ]</field>
             <field name="groups" eval="[(4,ref('base.group_user'))]"/>


### PR DESCRIPTION
Followers are res.partner objects, not res.users, so security rule is not correct.

There's no upstream PR, because v8 is already fixed (https://github.com/odoo/odoo/blob/8.0/addons/project_issue/security/project_issue_security.xml#L19)
