### PR TITLE
8.0 fix old style computed fields dle

### DIFF
--- a/addons/delivery/__openerp__.py
+++ b/addons/delivery/__openerp__.py
@@ -41,7 +41,9 @@ invoices from picking, OpenERP is able to add and compute the shipping line.
         'views/report_shipping.xml',
     ],
     'demo': ['delivery_demo.xml'],
-    'test': ['test/delivery_cost.yml'],
+    'test': ['test/delivery_cost.yml',
+             'test/stock_move_values_with_invoice_before_delivery.yml',
+             ],
     'installable': True,
     'auto_install': False,
 }

--- a/addons/delivery/test/stock_move_values_with_invoice_before_delivery.yml
+++ b/addons/delivery/test/stock_move_values_with_invoice_before_delivery.yml
@@ -1,0 +1,83 @@
+-
+  test that the store fields of stock moves are computed with invoice before delivery flow
+-
+  set a weight on ipod 16GB
+-
+  !python {model: product.product, id: product.product_product_11}: |
+    self.write({'weight': 0.25, 'weight_net': 0.2})
+-
+  create a SO with invoice before delivery
+-
+  !record {model: sale.order, id: sale_prepaid}:
+    partner_id: base.res_partner_18
+    partner_invoice_id: base.res_partner_18
+    partner_shipping_id: base.res_partner_18
+    pricelist_id: product.list0
+    order_policy: 'prepaid'
+    order_line:
+      - name: 'Ipod'
+        product_id: product.product_product_11
+        product_uom_qty: 2
+        product_uos_qty: 2
+        product_uom: product.product_uom_unit
+        price_unit: 750.00
+    carrier_id: normal_delivery_carrier
+-
+  I add delivery cost in Sale order.
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+    self.delivery_set()
+-
+  I confirm the SO.
+-
+  !workflow {model: sale.order, action: order_confirm, ref: sale_prepaid}
+-
+  I check that the invoice was created
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+    assert len(self.invoice_ids) == 1, "Invoice not created."
+-
+  I confirm the invoice
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+    invoice = self.invoice_ids[0]
+    invoice.signal_workflow('invoice_open')
+-
+  I pay the invoice.
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+    invoice = self.invoice_ids[0]
+    invoice.signal_workflow('invoice_open')
+    journal = self.env['account.journal'].search([('type', '=', 'cash'),
+                                                  ('company_id', '=', self.company_id.id)],
+                                                  limit=1)
+    invoice.pay_and_reconcile(
+         invoice.amount_total, ref('account.cash'), ref('account.period_8'),
+         journal.id, ref('account.cash'),
+         ref('account.period_8'), journal.id,
+         name='test')
+-
+  Check the SO after paying the invoice
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+     assert self.invoice_exists, 'order not invoiced'
+     assert self.invoiced, 'order is not paid'
+     assert len(self.picking_ids) == 1, 'pickings not generated'
+-
+  check the stock moves
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+     move = self.picking_ids.move_lines
+     assert move.product_qty == 2, 'wrong product_qty'
+     assert move.weight == 0.5, 'wrong move weight'
+     assert move.weight_net == 0.4, 'wrong move weight_net'
+-
+  ship
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+     picking = self.picking_ids.action_done()
+-
+  Check the SO after shipping
+-
+  !python {model: sale.order, id: sale_prepaid}: |
+     assert self.state == 'done'

--- a/addons/sale/test/manual_order_policy.yml
+++ b/addons/sale/test/manual_order_policy.yml
@@ -7,7 +7,7 @@
 -
   !python {model: sale.order}: |
     sale_order = self.browse(cr, uid, ref("sale_order_2"))
-    assert len(sale_order.invoice_ids) == False, "Invoice should not created."
+    assert len(sale_order.invoice_ids) == 0, "Invoice should not created."
 -
   I create advance invoice where type is 'Fixed Price'.
 -

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -24,7 +24,6 @@ from dateutil import relativedelta
 import json
 import time
 
-from openerp import models, fields as new_fields, api
 from openerp.osv import fields, osv
 from openerp.tools.float_utils import float_compare, float_round
 from openerp.tools.translate import _
@@ -1591,7 +1590,7 @@ class stock_production_lot(osv.osv):
 # Move
 # ----------------------------------------------------
 
-class stock_move(models.Model):
+class stock_move(osv.osv):
     _name = "stock.move"
     _description = "Stock Move"
     _order = 'date_expected desc, id'
@@ -1612,11 +1611,12 @@ class stock_move(models.Model):
             res.append((line.id, name))
         return res
 
-    @api.depends('product_id', 'product_uom_qty', 'product_uom', 'product_id.uom_id')
-    def _quantity_normalize(self):
+    def _quantity_normalize(self, cr, uid, ids, name, args, context=None):
         uom_obj = self.pool.get('product.uom')
-        for m in self:
-            m.product_qty = uom_obj._compute_qty_obj(self.env.cr, self.env.uid, m.product_uom, m.product_uom_qty, m.product_id.uom_id, context=self.env.context)
+        res = {}
+        for m in self.browse(cr, uid, ids, context=context):
+            res[m.id] = uom_obj._compute_qty_obj(cr, uid, m.product_uom, m.product_uom_qty, m.product_id.uom_id, context=context)
+        return res
 
     def _get_remaining_qty(self, cr, uid, ids, field_name, args, context=None):
         uom_obj = self.pool.get('product.uom')
@@ -1700,6 +1700,11 @@ class stock_move(models.Model):
             res += [x.id for x in picking.move_lines]
         return res
 
+    def _get_moves_from_prod(self, cr, uid, ids, context=None):
+        if ids:
+            return self.pool.get('stock.move').search(cr, uid, [('product_id', 'in', ids)], context=context)
+        return []
+
     def _set_product_qty(self, cr, uid, id, field, value, arg, context=None):
         """ The meaning of product_qty field changed lately and is now a functional field computing the quantity
             in the default product UoM. This code has been added to raise an error if a write is made given a value
@@ -1708,9 +1713,6 @@ class stock_move(models.Model):
         """
         raise osv.except_osv(_('Programming Error!'), _('The requested operation cannot be processed because of a programming error setting the `product_qty` field instead of the `product_uom_qty`.'))
 
-    product_qty = new_fields.Float(compute='_quantity_normalize', inverse='_set_product_qty', digits=0, store=True, string='Quantity',
-                                   help='Quantity in the default UoM of the product')
-
     _columns = {
         'name': fields.char('Description', required=True, select=True),
         'priority': fields.selection(procurement.PROCUREMENT_PRIORITIES, 'Priority'),
@@ -1718,6 +1720,8 @@ class stock_move(models.Model):
         'date': fields.datetime('Date', required=True, select=True, help="Move date: scheduled date until move is done, then date of actual move processing", states={'done': [('readonly', True)]}),
         'date_expected': fields.datetime('Expected Date', states={'done': [('readonly', True)]}, required=True, select=True, help="Scheduled date for the processing of this move"),
         'product_id': fields.many2one('product.product', 'Product', required=True, select=True, domain=[('type', '<>', 'service')], states={'done': [('readonly', True)]}),
+        'product_qty': fields.function(_quantity_normalize, fnct_inv=_set_product_qty, type='float', digits=0, store=True, string='Quantity',
+            help='Quantity in the default UoM of the product'),
         'product_uom_qty': fields.float('Quantity', digits_compute=dp.get_precision('Product Unit of Measure'),
             required=True, states={'done': [('readonly', True)]},
             help="This is the quantity of products from an inventory "

--- a/openerp/api.py
+++ b/openerp/api.py
@@ -903,6 +903,15 @@ class Environment(object):
         finally:
             self.all.recompute = tmp
 
+    def clear_recompute_list(self):
+        del self.all.recompute_list[:]
+
+    def extend_recompute_list(self, items):
+        self.all.recompute_list += items
+
+    def get_recompute_list(self):
+        return self.all.recompute_list
+
 
 class Environments(object):
     """ A common object for all environments in a request. """
@@ -911,6 +920,7 @@ class Environments(object):
         self.todo = {}                  # recomputations {field: [records]}
         self.mode = False               # flag for draft/onchange
         self.recompute = True
+        self.recompute_list = []        # list of old api compute fields to recompute
 
     def add(self, env):
         """ Add the environment `env`. """


### PR DESCRIPTION
This is a port of https://github.com/odoo/odoo/pull/6315 to OCB with my additional (yet unmerged) PR https://github.com/odoo-dev/odoo/pull/106 included (adding an automated test). 

It fixes the following bug: when records are created through a workflow chain, some stored function fields may not be computed at record creation. This happens for stock.move in the prepaid sale order flow. 

See #6053 for the discussion. 
