### PR TITLE
[FIX] Allows to write log_access fields

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3770,15 +3770,17 @@ class BaseModel(object):
 
     def log_access_write(self, cr, user, ids, vals, context=None):
         log_access_vals = {}
+        self._check_concurrency(cr, ids, context=context)
+        self.check_access_rights(cr, user, 'write')
         for field in LOG_ACCESS_COLUMNS:
-            if vals.get(field, None) != None:
+            if vals.get(field, None) is not None:
                 log_access_vals[field] = vals[field]
         if not log_access_vals:
             return True
         self._log_access = False
-        result = self._write(cr, user, ids, log_access_vals, context=context)
+        self._write(cr, user, ids, log_access_vals, context=context)
         self._log_access = True
-        return result
+        return True
 
     def _write(self, cr, user, ids, vals, context=None):
         # low-level implementation of write()

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3768,6 +3768,18 @@ class BaseModel(object):
 
         return True
 
+    def log_access_write(self, cr, user, ids, vals, context=None):
+        log_access_vals = {}
+        for field in LOG_ACCESS_COLUMNS:
+            if vals.get(field, None) != None:
+                log_access_vals[field] = vals[field]
+        if not log_access_vals:
+            return True
+        self._log_access = False
+        result = self._write(cr, user, ids, log_access_vals, context=context)
+        self._log_access = True
+        return result
+
     def _write(self, cr, user, ids, vals, context=None):
         # low-level implementation of write()
         if not context:


### PR DESCRIPTION
Adds a new method to BaseModel, called log_access_write, that allows to write log_access fields: `'create_uid', 'create_date', 'write_uid', 'write_date'`
