### PR TITLE
[7.0][FIX] prevent polynomial time filtering on document ids

### DIFF
--- a/addons/document/document.py
+++ b/addons/document/document.py
@@ -110,7 +110,8 @@ class document_file(osv.osv):
             ids.extend(parents[parent_id])
 
         # sort result according to the original sort ordering
-        ids = [id for id in orig_ids if id in ids]
+        set_ids = set(ids)
+        ids = [id for id in orig_ids if id in set_ids]
         return len(ids) if count else ids
 
     def copy(self, cr, uid, id, default=None, context=None):

--- a/addons/document/document.py
+++ b/addons/document/document.py
@@ -110,9 +110,11 @@ class document_file(osv.osv):
             ids.extend(parents[parent_id])
 
         # sort result according to the original sort ordering
-        set_ids = set(ids)
-        ids = [id for id in orig_ids if id in set_ids]
-        return len(ids) if count else ids
+        if count:
+            return len(ids)
+        else:
+            set_ids = set(ids)
+            return [id for id in orig_ids if id in set_ids]
 
     def copy(self, cr, uid, id, default=None, context=None):
         if not default:


### PR DESCRIPTION
Upstream 7.0: https://github.com/odoo/odoo/pull/6397

This fix prevents the request from taking polynomial time when searching for a lot of documents. At 160k documents, this takes > 1 minute. With this change it is < 25ms.

Note that since the web interface does a search_count when loading a page to get the total count, a search will always be done on all documents, triggering this.
