### PR TITLE
Replace list of IDs by proper domain

### DIFF
--- a/addons/account_payment/wizard/account_payment_populate_statement.py
+++ b/addons/account_payment/wizard/account_payment_populate_statement.py
@@ -35,15 +35,7 @@ class account_payment_populate_statement(osv.osv_memory):
         line_obj = self.pool.get('payment.line')
 
         res = super(account_payment_populate_statement, self).fields_view_get(cr, uid, view_id=view_id, view_type=view_type, context=context, toolbar=toolbar, submenu=False)
-        line_ids = line_obj.search(cr, uid, [
-            ('move_line_id.reconcile_id', '=', False),
-            ('bank_statement_line_id', '=', False),
-            ('move_line_id.state','=','valid')])
-        line_ids.extend(line_obj.search(cr, uid, [
-            ('move_line_id.reconcile_id', '=', False),
-            ('order_id.mode', '=', False),
-            ('move_line_id.state','=','valid')]))
-        domain = '[("id", "in", '+ str(line_ids)+')]'
+        domain = '[("move_line_id.reconcile_id", "=", False), ("move_line_id.state","=","valid"), "|", ("bank_statement_line_id", "=", False), ("order_id.mode", "=", False)]'
         doc = etree.XML(res['arch'])
         nodes = doc.xpath("//field[@name='lines']")
         for node in nodes:

--- a/addons/account_payment/wizard/account_payment_populate_statement.py
+++ b/addons/account_payment/wizard/account_payment_populate_statement.py
@@ -28,20 +28,13 @@ class account_payment_populate_statement(osv.osv_memory):
     _name = "account.payment.populate.statement"
     _description = "Account Payment Populate Statement"
     _columns = {
-        'lines': fields.many2many('payment.line', 'payment_line_rel_', 'payment_id', 'line_id', 'Payment Lines')
+        'lines': fields.many2many('payment.line', 'payment_line_rel_', 'payment_id', 'line_id', 'Payment Lines',
+                                  domain=[('move_line_id.reconcile_id', '=', False),
+                                          ('move_line_id.state', '=', 'valid'),
+                                          '|',
+                                          ('bank_statement_line_id', '=', False),
+                                          ('order_id.mode', '=', False)])
     }
-
-    def fields_view_get(self, cr, uid, view_id=None, view_type='form', context=None, toolbar=False, submenu=False):
-        line_obj = self.pool.get('payment.line')
-
-        res = super(account_payment_populate_statement, self).fields_view_get(cr, uid, view_id=view_id, view_type=view_type, context=context, toolbar=toolbar, submenu=False)
-        domain = '[("move_line_id.reconcile_id", "=", False), ("move_line_id.state","=","valid"), "|", ("bank_statement_line_id", "=", False), ("order_id.mode", "=", False)]'
-        doc = etree.XML(res['arch'])
-        nodes = doc.xpath("//field[@name='lines']")
-        for node in nodes:
-            node.set('domain', domain)
-        res['arch'] = etree.tostring(doc)
-        return res
 
     def populate_statement(self, cr, uid, ids, context=None):
         line_obj = self.pool.get('payment.line')


### PR DESCRIPTION
Copy of odoo/odoo/pull/6422 .

Since fields_view_get() is called when the module is updated, if the wizard would fail due to too many results, it would fail during the update instead of when it's displayed.
