### PR TITLE
[FIX]ZeroDivisionError: float division by zero in MRP

### DIFF
--- a/addons/mrp/mrp.py
+++ b/addons/mrp/mrp.py
@@ -24,7 +24,7 @@ import openerp.addons.decimal_precision as dp
 from collections import OrderedDict
 from openerp.osv import fields, osv, orm
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
-from openerp.tools import float_compare
+from openerp.tools import float_compare, float_is_zero
 from openerp.tools.translate import _
 from openerp import tools, SUPERUSER_ID
 from openerp.addons.product import _common
@@ -930,6 +930,7 @@ class mrp_production(osv.osv):
         uom_obj = self.pool.get("product.uom")
         production = self.browse(cr, uid, production_id, context=context)
         production_qty_uom = uom_obj._compute_qty(cr, uid, production.product_uom.id, production_qty, production.product_id.uom_id.id)
+        precision = self.pool['decimal.precision'].precision_get(cr, uid, 'Product Unit of Measure')
 
         main_production_move = False
         if production_mode == 'consume_produce':
@@ -951,7 +952,8 @@ class mrp_production(osv.osv):
                                                          location_id=produce_product.location_id.id, restrict_lot_id=lot_id, context=context)
                 stock_mov_obj.write(cr, uid, new_moves, {'production_id': production_id}, context=context)
                 remaining_qty = subproduct_factor * production_qty_uom - qty
-                if remaining_qty: # In case you need to make more than planned
+                if not float_is_zero(remaining_qty, precision_rounding=precision):
+                    # In case you need to make more than planned
                     #consumed more in wizard than previously planned
                     extra_move_id = stock_mov_obj.copy(cr, uid, produce_product.id, default={'product_uom_qty': remaining_qty,
                                                                                              'production_id': production_id}, context=context)
@@ -981,7 +983,7 @@ class mrp_production(osv.osv):
                     stock_mov_obj.action_consume(cr, uid, [raw_material_line.id], consumed_qty, raw_material_line.location_id.id,
                                                  restrict_lot_id=consume['lot_id'], consumed_for=main_production_move, context=context)
                     remaining_qty -= consumed_qty
-                if remaining_qty:
+                if not float_is_zero(remaining_qty, precision_rounding=precision):
                     #consumed more in wizard than previously planned
                     product = self.pool.get('product.product').browse(cr, uid, consume['product_id'], context=context)
                     extra_move_id = self._make_consume_line_from_data(cr, uid, production, product, product.uom_id.id, remaining_qty, False, 0, context=context)


### PR DESCRIPTION
When making produce action from a production we have an error in stock_account because it is trying to calculate the value of a move of quantity 0.

```
File "/opt/odoo/v8/core/addons/stock_account/stock_account.py", line 286, in _store_average_cost_price
    average_valuation_price = average_valuation_price / move.product_qty
```

The main problem of this 0 quantity stock move becomes from a wrong split doing the remaining quantity of the product to consume on the production order.

We have done a patch in mrp module to fix this problem taking into account the product UoM to calculate the decimal rounding for the remaining product quantity.

Reported to Oddo on Issue 6439.
PR: https://github.com/odoo/odoo/pull/6451
