### PR TITLE
Faster orm intersect

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -2479,7 +2479,7 @@ class BaseModel(object):
                     else:
                         res[lang][f] = self._columns[f].string
         for table in self._inherits:
-            cols = intersect(self._inherit_fields.keys(), fields)
+            cols = [f for f in self._inherit_fields.keys() if f in fields]
             res2 = self.pool.get(table).read_string(cr, uid, id, langs, cols, context)
         for lang in res2:
             if lang in res:
@@ -2497,7 +2497,7 @@ class BaseModel(object):
                     src = self._columns[field].string
                     self.pool.get('ir.translation')._set_ids(cr, uid, self._name+','+field, 'field', lang, [0], vals[field], src)
         for table in self._inherits:
-            cols = intersect(self._inherit_fields.keys(), vals)
+            cols = [f for f in self._inherit_fields.keys() if f in vals]
             if cols:
                 self.pool.get(table).write_string(cr, uid, id, langs, vals, context)
         return True
@@ -3780,7 +3780,7 @@ class BaseModel(object):
 
         for table in self._inherits:
             col = self._inherits[table]
-            cols = [x for x in intersect(self._inherit_fields.keys(), fields_to_read) if x not in self._columns.keys()]
+            cols = [f for f in self._inherit_fields.keys() if f in fields_to_read and f not in self._columns.keys()]
             if not cols:
                 continue
             res2 = self.pool.get(table).read(cr, user, [x[col] for x in res], cols, context, load)

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -240,7 +240,7 @@ POSTGRES_CONFDELTYPES = {
 }
 
 def intersect(la, lb):
-    return filter(lambda x: x in lb, la)
+    return list(set(lb).intersection(la))
 
 def fix_import_export_id_paths(fieldname):
     """
@@ -2479,7 +2479,7 @@ class BaseModel(object):
                     else:
                         res[lang][f] = self._columns[f].string
         for table in self._inherits:
-            cols = [f for f in self._inherit_fields.keys() if f in fields]
+            cols = list(set(fields).intersection(self._inherit_fields))
             res2 = self.pool.get(table).read_string(cr, uid, id, langs, cols, context)
         for lang in res2:
             if lang in res:
@@ -2497,7 +2497,7 @@ class BaseModel(object):
                     src = self._columns[field].string
                     self.pool.get('ir.translation')._set_ids(cr, uid, self._name+','+field, 'field', lang, [0], vals[field], src)
         for table in self._inherits:
-            cols = [f for f in self._inherit_fields.keys() if f in vals]
+            cols = list(set(vals).intersection(self._inherit_fields))
             if cols:
                 self.pool.get(table).write_string(cr, uid, id, langs, vals, context)
         return True
@@ -3780,7 +3780,7 @@ class BaseModel(object):
 
         for table in self._inherits:
             col = self._inherits[table]
-            cols = [f for f in self._inherit_fields.keys() if f in fields_to_read and f not in self._columns.keys()]
+            cols = list(set(fields_to_read).intersection(self._inherit_fields).difference(self._columns))
             if not cols:
                 continue
             res2 = self.pool.get(table).read(cr, user, [x[col] for x in res], cols, context, load)


### PR DESCRIPTION
Backport of odoo#6594 which helps on a custom implementation.
On some unittests I gain at least 15% of the overall execution time.
The intersect() function is not used anymore, but I've kept it in place in case someone else uses it.
