### PR TITLE
Don't copy many2many when copying statement line

### DIFF
--- a/addons/account/account_bank_statement.py
+++ b/addons/account/account_bank_statement.py
@@ -577,6 +577,16 @@ class account_bank_statement_line(osv.osv):
         'type': 'general',
     }
 
+    def copy(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        if context is None:
+            context = {}
+        default = default.copy()
+        default['move_ids'] = []
+        return super(account_bank_statement_line, self).copy(
+            cr, uid, id, default, context=context)
+
 account_bank_statement_line()
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/addons/account/account_bank_statement.py
+++ b/addons/account/account_bank_statement.py
@@ -580,8 +580,6 @@ class account_bank_statement_line(osv.osv):
     def copy(self, cr, uid, id, default=None, context=None):
         if default is None:
             default = {}
-        if context is None:
-            context = {}
         default = default.copy()
         default['move_ids'] = []
         return super(account_bank_statement_line, self).copy(


### PR DESCRIPTION
This PR is to fix an issue with bank statements: duplicating a bank statement with its lines will keep the relation between the line and the old account.move.

Here is also a SQL request to remove "duplicate" move relations:
`DELETE FROM account_bank_statement_line_move_rel many
WHERE EXISTS (
SELECT * FROM account_bank_statement_line_move_rel too_many
WHERE many.statement_line_id = too_many.statement_line_id
AND too_many.move_id > many.move_id
);`

Copy of https://github.com/odoo/odoo/pull/6617
