### PR TITLE
[FIX] don't recompute old fields if recompute=False

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3995,23 +3995,23 @@ class BaseModel(object):
 
         result += self._store_get_values(cr, user, ids, vals.keys(), context)
 
-        done = {}
-        recs.env.recompute_old.extend(result)
-        for order, model_name, ids_to_update, fields_to_recompute in sorted(recs.env.recompute_old):
-            key = (model_name, tuple(fields_to_recompute))
-            done.setdefault(key, {})
-            # avoid to do several times the same computation
-            todo = []
-            for id in ids_to_update:
-                if id not in done[key]:
-                    done[key][id] = True
-                    if id not in deleted_related[model_name]:
-                        todo.append(id)
-            self.pool[model_name]._store_set_values(cr, user, todo, fields_to_recompute, context)
-        recs.env.clear_recompute_old()
-
-        # recompute new-style fields
         if recs.env.recompute and context.get('recompute', True):
+            done = {}
+            recs.env.recompute_old.extend(result)
+            for order, model_name, ids_to_update, fields_to_recompute in sorted(recs.env.recompute_old):
+                key = (model_name, tuple(fields_to_recompute))
+                done.setdefault(key, {})
+                # avoid to do several times the same computation
+                todo = []
+                for id in ids_to_update:
+                    if id not in done[key]:
+                        done[key][id] = True
+                        if id not in deleted_related[model_name]:
+                            todo.append(id)
+                self.pool[model_name]._store_set_values(cr, user, todo, fields_to_recompute, context)
+            recs.env.clear_recompute_old()
+
+            # recompute new-style fields
             recs.recompute()
 
         self.step_workflow(cr, user, ids, context=context)
@@ -4261,9 +4261,9 @@ class BaseModel(object):
         result += self._store_get_values(cr, user, [id_new],
                 list(set(vals.keys() + self._inherits.values())),
                 context)
-        recs.env.recompute_old.extend(result)
 
         if recs.env.recompute and context.get('recompute', True):
+            recs.env.recompute_old.extend(result)
             done = []
             for order, model_name, ids, fields2 in sorted(recs.env.recompute_old):
                 if not (model_name, ids, fields2) in done:

--- a/openerp/osv/fields.py
+++ b/openerp/osv/fields.py
@@ -801,6 +801,7 @@ class one2many(_column):
                     result += obj._store_get_values(cr, user, [id_new], act[2].keys(), context)
                 elif act[0] == 1:
                     obj.write(cr, user, [act[1]], act[2], context=context)
+                    result += obj._store_get_values(cr, user, [act[1]], act[2].keys(), context)
                 elif act[0] == 2:
                     obj.unlink(cr, user, [act[1]], context=context)
                 elif act[0] == 3:


### PR DESCRIPTION
This changes make `_write()` behave like `_create()` in respect of `context['recompute']` and `env.recompute`: https://github.com/odoo/odoo/blob/8.0/openerp/models.py#L4266

Upstream PR: https://github.com/odoo/odoo/pull/6626
