### PR TITLE
read instead of browse (3 to 5x faster here)

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -175,8 +175,8 @@ class sale_order(osv.osv):
         return [('id', 'in', [x[0] for x in res])]
 
     def _get_order(self, cr, uid, ids, context=None):
-        lines = self.pool.get('sale.order.line')
-        return list(set(line['order_id'] for line in lines.read(
+        line_obj = self.pool.get('sale.order.line')
+        return list(set(line['order_id'] for line in line_obj.read(
             cr, uid, ids, ['order_id'], load='_classic_write', context=context)))
 
     def _get_default_shop(self, cr, uid, context=None):

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -175,8 +175,9 @@ class sale_order(osv.osv):
         return [('id', 'in', [x[0] for x in res])]
 
     def _get_order(self, cr, uid, ids, context=None):
-        return [self.pool.get('sale.order.line').read(
-            cr, uid, ids[0], ['order_id'], context=context)['order_id'][0]]
+        lines = self.pool.get('sale.order.line')
+        return list(set(line['order_id'] for line in lines.read(
+            cr, uid, ids, ['order_id'], load='_classic_write', context=context)))
 
     def _get_default_shop(self, cr, uid, context=None):
         company_id = self.pool.get('res.users').browse(cr, uid, uid, context=context).company_id.id

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -175,10 +175,8 @@ class sale_order(osv.osv):
         return [('id', 'in', [x[0] for x in res])]
 
     def _get_order(self, cr, uid, ids, context=None):
-        result = {}
-        for line in self.pool.get('sale.order.line').browse(cr, uid, ids, context=context):
-            result[line.order_id.id] = True
-        return result.keys()
+        return [self.pool.get('sale.order.line').read(
+            cr, uid, ids[0], ['order_id'], context=context)['order_id'][0]]
 
     def _get_default_shop(self, cr, uid, context=None):
         company_id = self.pool.get('res.users').browse(cr, uid, uid, context=context).company_id.id


### PR DESCRIPTION
I have some unittests, where the _get_order function is called 1000x, each taking 1.5ms, leading to a total of 1.5s.
By replacing the browse and the loop with a simple read, it falls to 0.3ms, dividing the time by 5.

backport of odoo#6632
