### PR TITLE
[account.tax] name field needs copy=False attribute to make duplicate…

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -1870,7 +1870,7 @@ class account_tax(osv.osv):
     _name = 'account.tax'
     _description = 'Tax'
     _columns = {
-        'name': fields.char('Tax Name', required=True, translate=True, help="This name will be displayed on reports"),
+        'name': fields.char('Tax Name', required=True, translate=True, copy=False, help="This name will be displayed on reports"),
         'sequence': fields.integer('Sequence', required=True, help="The sequence field is used to order the tax lines from the lowest sequences to the higher ones. The order is important if you have a tax with several tax children. In this case, the evaluation order is important."),
         'amount': fields.float('Amount', required=True, digits_compute=get_precision_tax(), help="For taxes of type percentage, enter % ratio between 0-1."),
         'active': fields.boolean('Active', help="If the active field is set to False, it will allow you to hide the tax without removing it."),


### PR DESCRIPTION
After updating my local ocb instance with more recent code from here, I've noticed that duplicating account.tax items did not work any more as the unique name constraint was not acknowledged. This fixes it.
