### PR TITLE
Update pricelist.py

### DIFF
--- a/addons/product/pricelist.py
+++ b/addons/product/pricelist.py
@@ -353,7 +353,7 @@ class product_pricelist(osv.osv):
                         price = min(price, price_limit + price_max_margin)
 
                     rule_id = rule.id
-                break
+                    break
 
             # Final price conversion to target UoM
             price = product_uom_obj._compute_price(cr, uid, price_uom_id, price, qty_uom_id)


### PR DESCRIPTION
Described in Issue #4624
break should be in 'if price is not False:' condition, otherwise it checks only first rule and if the product not found in first rule it would return price false.
