### PR TITLE
[FIX] procurement_jit_stock: Don't lose autocommit parameter

### DIFF
--- a/addons/procurement_jit_stock/procurement_jit_stock.py
+++ b/addons/procurement_jit_stock/procurement_jit_stock.py
@@ -25,14 +25,14 @@ from openerp.osv import osv
 class procurement_order(osv.osv):
     _inherit = "procurement.order"
 
-    def run(self, cr, uid, ids, context=None):
+    def run(self, cr, uid, ids, autocommit=False, context=None):
         context = dict(context or {}, procurement_autorun_defer=True)
-        res = super(procurement_order, self).run(cr, uid, ids, context=context)
+        res = super(procurement_order, self).run(cr, uid, ids, autocommit=autocommit, context=context)
 
         procurement_ids = self.search(cr, uid, [('move_dest_id.procurement_id', 'in', ids)], order='id', context=context)
 
         if procurement_ids:
-            return self.run(cr, uid, procurement_ids, context=context)
+            return self.run(cr, uid, procurement_ids, autocommit=autocommit, context=context)
         return res
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
This module omits autocommit keyword argument, which makes that modules in new API that inherit this parameter failed with `ValueError: "run() got an unexpected keyword argument 'autocommit'" while evaluating`

Upstream: https://github.com/odoo/odoo/pull/6775
