### PR TITLE
[FIX] Don't force arbitrary precision on weights

### DIFF
--- a/addons/product/product_view.xml
+++ b/addons/product/product_view.xml
@@ -107,8 +107,8 @@
                                     </group>
                                     <group name="weight" string="Weights" attrs="{'invisible':[('type','=','service')]}">
                                         <field digits="(14, 3)" name="volume"/>
-                                        <field digits="(14, 3)" name="weight"/>
-                                        <field digits="(14, 3)" name="weight_net"/>
+                                        <field name="weight"/>
+                                        <field name="weight_net"/>
                                     </group>
                                 </group>
                                 <group name="packaging" string="Packaging" attrs="{'invisible':[('type','=','service')]}" groups="product.group_stock_packaging" colspan="4">


### PR DESCRIPTION
The product view forces the decimal accuracy to 3 digits on weight, weight_net and volume, but the accuracy can actually be set using the 'Decimal Accuracy' feature so it must not be forced here

PR upstream: https://github.com/odoo/odoo/pull/6812
