### PR TITLE
    [FIX] mail.message: checking rules on deleted records.

### DIFF
--- a/addons/mail/mail_message.py
+++ b/addons/mail/mail_message.py
@@ -751,7 +751,7 @@ class mail_message(osv.Model):
         document_related_ids = []
         for model, doc_ids in model_record_ids.items():
             model_obj = self.pool[model]
-            mids = model_obj.exists(cr, uid, list(doc_ids))
+            mids = list(doc_ids)
             if hasattr(model_obj, 'check_mail_message_access'):
                 model_obj.check_mail_message_access(cr, uid, mids, operation, context=context)
             else:

--- a/addons/website_mail/models/email_template.py
+++ b/addons/website_mail/models/email_template.py
@@ -10,7 +10,12 @@ class EmailTemplate(osv.Model):
     def action_edit_html(self, cr, uid, ids, context=None):
         if not len(ids) == 1:
             raise ValueError('One and only one ID allowed for this action')
-        url = '/website_mail/email_designer?model=email.template&res_id=%d&return_action=%d&enable_editor=1' % (ids[0], context['params']['action'])
+        if not context.get('params'):
+            action_id = self.pool['ir.model.data'].xmlid_to_res_id(cr, uid, 'mass_mailing.action_email_template_marketing')
+        else:
+            action_id = context['params']['action']
+
+        url = '/website_mail/email_designer?model=email.template&res_id=%d&return_action=%d&enable_editor=1' % (ids[0], action_id)
         return {
             'name': _('Edit Template'),
             'type': 'ir.actions.act_url',


### PR DESCRIPTION
This change avoid to raise 'Access Denied' when accessing to messages related to deleted documents, which user had access right on.

Example: user A can see messages related to sale.order SO1, even if A is not directly notified.
    Someone deletes SO1.
    'A' opens 'inbox', 'check_access_rule' is called, 'mids' is empty, 'document_related_ids' is empty, 'other_ids' is not empy -> exception is raised

Upstream: https://github.com/odoo/odoo/pull/5343
