### PR TITLE
replace recursive get children call by single sql query

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -277,7 +277,7 @@ class account_account(osv.osv):
                 WITH RECURSIVE account_children(id, depth) AS (
                     SELECT id, 0 as depth
                     FROM account_account
-                    WHERE id IN (%s)
+                    WHERE id IN %s
                 UNION (
                     WITH account_children AS (
                         SELECT ac.id, ac.depth

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -304,7 +304,7 @@ class account_account(osv.osv):
             (tuple(ids),)
         )
         res_ids = [r[0] for r in cr.fetchall()]
-        return self.search(cr, uid, ('id', 'in', res_ids), context=context)
+        return self.search(cr, uid, [('id', 'in', res_ids)], context=context)
 
     def __compute(self, cr, uid, ids, field_names, arg=None, context=None,
                   query='', query_params=()):

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -286,7 +286,7 @@ class account_account(osv.osv):
                                  FROM account_account_consol_rel a
                                  WHERE a.child_id = ac.id)
                 )
-                SELECT DISTINCT id, depth,
+                SELECT DISTINCT id, depth
                      , max(depth) OVER (PARTITION BY id) as max_depth
                 FROM account_children
                 ORDER BY depth DESC

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -289,7 +289,7 @@ class account_account(osv.osv):
                 SELECT DISTINCT id, depth
                      , max(depth) OVER (PARTITION BY id) as max_depth
                 FROM account_children
-                ORDER BY depth DESC
+                ORDER BY depth
             ) children
             WHERE children.depth = children.max_depth
             """,

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -278,7 +278,7 @@ class account_account(osv.osv):
             LEFT JOIN account_account child
                 ON parent.parent_left <= child.parent_left
                AND parent.parent_right >= child.parent_right
-            WHERE parent.id IN (%s)
+            WHERE parent.id IN %s
             ORDER by COALESCE(child.level, 0), child.parent_left
             """,
             (tuple(ids),)

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -269,13 +269,20 @@ class account_account(osv.osv):
                 order, context=context, count=count)
 
     def _get_children_and_consol(self, cr, uid, ids, context=None):
+        res = self._query_children_and_consol(cr, uid, ids, context=context)
+        if ids and not res:
+            self._parent_store_compute(cr)
+            res = self._query_children_and_consol(cr, uid, ids, context=context)
+        return res
+
+    def _query_children_and_consol(self, cr, uid, ids, context=None):
         if isinstance(ids, (int, long)):
             ids = [ids]
         cr.execute(
             """
             SELECT child.id
             FROM account_account parent
-            LEFT JOIN account_account child
+            INNER JOIN account_account child
                 ON parent.parent_left <= child.parent_left
                AND parent.parent_right >= child.parent_right
             WHERE parent.id IN %s

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -269,13 +269,6 @@ class account_account(osv.osv):
                 order, context=context, count=count)
 
     def _get_children_and_consol(self, cr, uid, ids, context=None):
-        res = self._query_children_and_consol(cr, uid, ids, context=context)
-        if ids and not res:
-            self._parent_store_compute(cr)
-            res = self._query_children_and_consol(cr, uid, ids, context=context)
-        return res
-
-    def _query_children_and_consol(self, cr, uid, ids, context=None):
         if isinstance(ids, (int, long)):
             ids = [ids]
         cr.execute(


### PR DESCRIPTION
This replaces the recursive account children call by a single query.

I have an issue with an environment failing tests because of a badly ordered return of this function, and I couldn't find the cause, so I made a replacement.
