### PR TITLE
[IMP] Allow to define SQL expressions for pivot measured fields

### DIFF
--- a/openerp/fields.py
+++ b/openerp/fields.py
@@ -1013,10 +1013,13 @@ class Integer(Field):
     type = 'integer'
     _slots = {
         'group_operator': None,         # operator for aggregating values
+        'group_expression': None,       # advance expression for aggregating values
     }
 
     _related_group_operator = property(attrgetter('group_operator'))
     _column_group_operator = property(attrgetter('group_operator'))
+    _related_group_expression = property(attrgetter('group_expression'))
+    _column_group_expression = property(attrgetter('group_expression'))
 
     def convert_to_cache(self, value, record, validate=True):
         if isinstance(value, dict):
@@ -1046,6 +1049,7 @@ class Float(Field):
     _slots = {
         '_digits': None,                # digits argument passed to class initializer
         'group_operator': None,         # operator for aggregating values
+        'group_expression': None,       # advance expression for aggregating values
     }
 
     def __init__(self, string=None, digits=None, **kwargs):
@@ -1069,12 +1073,14 @@ class Float(Field):
 
     _related__digits = property(attrgetter('_digits'))
     _related_group_operator = property(attrgetter('group_operator'))
+    _related_group_expression = property(attrgetter('group_expression'))
 
     _description_digits = property(attrgetter('digits'))
 
     _column_digits = property(lambda self: not callable(self._digits) and self._digits)
     _column_digits_compute = property(lambda self: callable(self._digits) and self._digits)
     _column_group_operator = property(attrgetter('group_operator'))
+    _column_group_expression = property(attrgetter('group_expression'))
 
     def convert_to_cache(self, value, record, validate=True):
         # apply rounding here, otherwise value in cache may be wrong!

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -2098,11 +2098,25 @@ class BaseModel(object):
             if f not in groupby_fields
             if f in self._fields
             if self._fields[f].type in ('integer', 'float')
+            if not self._fields[f].group_expression
+            if getattr(self._fields[f].base_field.column, '_classic_write', False)
+        ]
+
+        expression_fields = [
+            f for f in fields
+            if f not in ('id', 'sequence')
+            if f not in groupby_fields
+            if f in self._fields
+            if self._fields[f].type in ('integer', 'float')
+            if self._fields[f].group_expression
             if getattr(self._fields[f].base_field.column, '_classic_write', False)
         ]
 
         field_formatter = lambda f: (self._fields[f].group_operator or 'sum', self._inherits_join_calc(f, query), f)
         select_terms = ["%s(%s) AS %s" % field_formatter(f) for f in aggregated_fields]
+
+        for ef in expression_fields:
+            select_terms.append('(%s) as "%s" ' % (self._fields[ef].group_expression, ef))
 
         for gb in annotated_groupbys:
             select_terms.append('%s as "%s" ' % (gb['qualified_field'], gb['groupby']))


### PR DESCRIPTION
With this new attribute (group_expression) in integer and float fields we can define an advance SQL expression to calcule aggregated value in graph pivot table.

For example, adding a margin_percent measured column for sale.order reports:

At sale.report model

```
    margin_total_percentage = fields.Float(
        string="Margen medio (%)", readonly=True,
        group_expression="( 1 - (sum(cost_total) / sum(price_total)) ) * 100")
```

In this case, we have already added a `cost_total` column that aggregate cost_price of each sale.order.line  and we have to define also a way to calculate `margin_total_percentage` for sale_report SQL view:

```
    def _select(self):
        select_str = super(SaleReport, self)._select()
        select_str += (
            ","
            "(coalesce("
                # margin_percentage = (1 - (cost_total / price_total) ) * 100
                "(1.0 -"
                    "("
                        # cost_total / price_total or NULL to avoid zero division
                        "sum(l.purchase_price * l.product_uom_qty) /"
                        "NULLIF(sum(l.product_uom_qty * l.price_unit * (100.0 - l.discount) / 100.0), 0)"
                    ")"
                ") * 100.0,"
                "0.0"
            ")) as margin_total_percentage"
        )
        return select_str
```

Odoo Issue: https://github.com/odoo/odoo/issues/6974
Odoo PR: https://github.com/odoo/odoo/pull/6973
