### PR TITLE
Make exp_report() signature correspond to the one in web_services

### DIFF
--- a/addons/base_calendar/base_calendar.py
+++ b/addons/base_calendar/base_calendar.py
@@ -1829,7 +1829,7 @@ ir_model()
 
 class virtual_report_spool(web_services.report_spool):
 
-    def exp_report(self, db, uid, object, ids, data=None, context=None):
+    def exp_report(self, db, uid, object, ids, datas=None, context=None):
         """
         Export Report
         @param self: The object pointer
@@ -1840,13 +1840,13 @@ class virtual_report_spool(web_services.report_spool):
 
         if object == 'printscreen.list':
             return super(virtual_report_spool, self).exp_report(db, uid, \
-                            object, ids, data, context)
+                            object, ids, datas, context)
         new_ids = []
         for id in ids:
             new_ids.append(base_calendar_id2real_id(id))
-        if data.get('id', False):
-            data['id'] = base_calendar_id2real_id(data['id'])
-        return super(virtual_report_spool, self).exp_report(db, uid, object, new_ids, data, context)
+        if datas.get('id', False):
+            datas['id'] = base_calendar_id2real_id(datas['id'])
+        return super(virtual_report_spool, self).exp_report(db, uid, object, new_ids, datas, context)
 
 virtual_report_spool()
 


### PR DESCRIPTION
Copy of https://github.com/odoo/odoo/pull/7098 : This PR is to make the method signature in base_calendar correspond to its base in https://github.com/odoo/odoo/blob/7.0/openerp/service/web_services.py#L701 .

This, in turn, causes an issue with https://github.com/OCA/reporting-engine/blob/7.0/base_report_assembler/report_assembler.py#L74-L75
