### PR TITLE
[7.0] use the pypi version of PyChart

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def py2exe_options():
                         'PIL',
                         'poplib',
                         'psutil',
-                        'pychart',
+                        'python-chart',
                         'pydot',
                         'pyparsing',
                         'pytz',
@@ -116,7 +116,6 @@ setup(
     packages=find_packages(),
     package_dir={'%s' % lib_name: 'openerp'},
     include_package_data=True,
-    dependency_links=['http://download.gna.org/pychart/'],
     install_requires=[
         'babel',
         'docutils',
@@ -129,7 +128,7 @@ setup(
         'PIL', # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list
         'psycopg2 >= 2.2',
-        'pychart',  # not on pypi, use: pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz
+        'python-chart',
         'pydot',
         'python-dateutil < 2',
         'python-ldap',  # optional


### PR DESCRIPTION
this will save pain when download.gna.org is down
https://pypi.python.org/pypi/Python-Chart/1.39

Backport of #250 to 7.0
