### PR TITLE
Remove setting the procurement state as 'exception'

### DIFF
--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -277,10 +277,6 @@ class purchase_order(osv.osv):
             move_ids += [po_line.move_dest_id.id for po_line in order.order_line if po_line.move_dest_id]
         if order_line_ids:
             line.write(cr, uid, order_line_ids, {'state': status}, context=context)
-        if order_line_ids and status == 'cancel':
-            procs = proc_obj.search(cr, uid, [('move_id', 'in', move_ids)], context=context)
-            if procs:
-                proc_obj.write(cr, uid, procs, {'state': 'exception'}, context=context)
         return True
 
     def button_dummy(self, cr, uid, ids, context=None):

--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -271,7 +271,6 @@ class purchase_order(osv.osv):
         line = self.pool.get('purchase.order.line')
         order_line_ids = []
         move_ids = []
-        proc_obj = self.pool.get('procurement.order')
         for order in self.browse(cr, uid, ids, context=context):
             order_line_ids += [po_line.id for po_line in order.order_line]
             move_ids += [po_line.move_dest_id.id for po_line in order.order_line if po_line.move_dest_id]


### PR DESCRIPTION
Copy of https://github.com/odoo/odoo/pull/7153, for OCB.

This PR is to remove one part of the code added in commit https://github.com/odoo/odoo/commit/940b5beb2621858fdc8a2d1af6c205d5ebda5b10 (discussed in issue https://github.com/odoo/odoo/issues/4168). The goal is similar to the PR https://github.com/odoo/odoo/pull/4973 , but the state is not written directly in the procurement anymore.

There are multiple reasons for doing this:
1) writing the state directly on an object where a workflow exists is incorrect; that means that, since the workflow and the state are desynchronized, a procurement in exception after a PO merge will not be retryable.
2) in the case of a PO cancellation, the procurement workflow will use the transition shown at https://github.com/odoo/odoo/blob/7.0/addons/purchase/purchase_workflow.xml#L227-L230 to cancel just after, which does write the state as "cancel". It means that the removed write() is redundant in that case.
3) in the case of a PO merge (which does cancel the "old" PO and assigns the "new" PO), when the workflow is verified, the "new" PO is in place and will keep the state as "running" (since it has a new draft PO). If it was modified with the 'exception' state, this creates the issues described in 1).
