### PR TITLE
Remove filter on message type for 'body_original'

### DIFF
--- a/addons/mail/mail_message.py
+++ b/addons/mail/mail_message.py
@@ -375,7 +375,7 @@ class mail_message(osv.Model):
                 'type': message.type,
                 'subtype': message.subtype_id.name if message.subtype_id else False,
                 'body': body_html,
-                'body_original': message.body if message.type in ('comment', 'email') else None,
+                'body_original': message.body,
                 'model': message.model,
                 'res_id': message.res_id,
                 'record_name': message.record_name,


### PR DESCRIPTION
The reason to remove the filter is that, just as I added `comment` in https://github.com/OCA/OCB/commit/aeaaa1093d8c7cad3dfec8b4585ad90bd8d125ae , if a notification is longer than the truncate threshold, it does not create the `body_original`, so clicking "Read more..." will just make it blank.

Since that covers all 3 types of mail messages, it is cleaner to just remove the condition.
