### PR TITLE
[ADD] add sequence on product attribute line

### DIFF
--- a/addons/product/product.py
+++ b/addons/product/product.py
@@ -423,7 +423,9 @@ class product_attribute_price(osv.osv):
 class product_attribute_line(osv.osv):
     _name = "product.attribute.line"
     _rec_name = 'attribute_id'
+    _order = "sequence"
     _columns = {
+        'sequence': fields.integer('Sequence'),
         'product_tmpl_id': fields.many2one('product.template', 'Product Template', required=True, ondelete='cascade'),
         'attribute_id': fields.many2one('product.attribute', 'Attribute', required=True, ondelete='restrict'),
         'value_ids': fields.many2many('product.attribute.value', id1='line_id', id2='val_id', string='Product Attribute Value'),

--- a/addons/product/product_view.xml
+++ b/addons/product/product_view.xml
@@ -255,6 +255,7 @@
                         </p>
                         <field name="attribute_line_ids" widget="one2many_list" context="{'show_attribute': False}">
                             <tree string="Variants" editable="bottom">
+                                <field name="sequence" widget="handle"/>
                                 <field name="attribute_id"/>
                                 <field name="value_ids" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('attribute_id', '=', attribute_id)]" context="{'default_attribute_id': attribute_id}"/>
                             </tree>


### PR DESCRIPTION
Add a sequence field on product.attribute.line object.
Allows to order attributes on the product form.
