### PR TITLE
[FIX] Runtime error if ids is empty

### DIFF
--- a/openerp/addons/base/res/res_partner.py
+++ b/openerp/addons/base/res/res_partner.py
@@ -743,6 +743,8 @@ class res_partner(osv.Model, format_address):
             adr_pref.add('default')
         result = {}
         visited = set()
+        if isinstance(ids, (int, long)):
+            ids = [ids]
         for partner in self.browse(cr, uid, filter(None, ids), context=context):
             current_partner = partner
             while current_partner:
@@ -765,7 +767,7 @@ class res_partner(osv.Model, format_address):
                 current_partner = current_partner.parent_id
 
         # default to type 'default' or the partner itself
-        default = result.get('default', partner.id)
+        default = result.get('default', ids and ids[0] or False)
         for adr_type in adr_pref:
             result[adr_type] = result.get(adr_type) or default 
         return result


### PR DESCRIPTION
**Runtime error if ids is empty**

Impacted versions:
- 8.0

Steps to reproduce:
1. Calling res.partner.address_get() method with ids = [] 

Current behavior:
- Runtime error:

```
(...)
File "/opt/odoo/common/openerp/v8/addons/event/event.py", line 390, in _onchange_partner
    contact_id = self.partner_id.address_get().get('default', False)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 239, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 546, in new_api
    result = method(self._model, cr, uid, self.ids, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/addons/base/res/res_partner.py", line 768, in address_get
    default = result.get('default', partner.id)
UnboundLocalError: local variable 'partner' referenced before assignment
```

Expected behavior:
- Return False

Proposed change:
1. Be sure ids is a list, not long or integer
2. If no 'default' address type found, select first item in ids list. If ids is empty then return False

Odoo PR: https://github.com/odoo/odoo/pull/7359
