### PR TITLE
Fix 'report_webkit' module support real mako again. 

### DIFF
--- a/addons/report_webkit/data.xml
+++ b/addons/report_webkit/data.xml
@@ -55,7 +55,7 @@
     <body style="border:0; margin: 0;" onload="subst()">
         <table class="header" style="border-bottom: 0px solid black; width: 100%">
             <tr>
-                <td>${helper.embed_company_logo()|safe}</td>
+                <td>${helper.embed_company_logo()|n}</td>
                 <td style="text-align:right"> </td>
             </tr>
             <tr>
@@ -77,7 +77,7 @@
             <tr>
                 <td>Mail: ${company.partner_id.email or ''}<br/></td>
             </tr>
-        </table> ${_debug or ''|safe} </body>
+        </table> ${_debug or ''|n} </body>
 </html>]]>
 </field>
             <field eval="55.0" name="margin_top"/>

--- a/addons/report_webkit/webkit_report.py
+++ b/addons/report_webkit/webkit_report.py
@@ -147,13 +147,15 @@ class WebKitParser(report_sxw):
         if header :
             with tempfile.NamedTemporaryFile(suffix=".head.html",
                                              delete=False) as head_file:
-                head_file.write(self._sanitize_html(header.encode('utf-8')))
+#                head_file.write(self._sanitize_html(header.encode('utf-8')))
+                head_file.write(self._sanitize_html(header))
             file_to_del.append(head_file.name)
             command.extend(['--header-html', head_file.name])
         if footer :
             with tempfile.NamedTemporaryFile(suffix=".foot.html",
                                              delete=False) as foot_file:
-                foot_file.write(self._sanitize_html(footer.encode('utf-8')))
+#                foot_file.write(self._sanitize_html(footer.encode('utf-8')))
+                foot_file.write(self._sanitize_html(footer))
             file_to_del.append(foot_file.name)
             command.extend(['--footer-html', foot_file.name])
 
@@ -174,7 +176,8 @@ class WebKitParser(report_sxw):
             with tempfile.NamedTemporaryFile(suffix="%d.body.html" %count,
                                              delete=False) as html_file:
                 count += 1
-                html_file.write(self._sanitize_html(html.encode('utf-8')))
+#                html_file.write(self._sanitize_html(html.encode('utf-8')))
+                html_file.write(self._sanitize_html(html))
             file_to_del.append(html_file.name)
             command.append(html_file.name)
         command.append(out_filename)


### PR DESCRIPTION
Port parts of the original 7.0 code to 8.0 to let the module support real Mako again. 
Mapping jinja2 to mako is way to limited to support all Mako features used previously. 
Fix some minor bugs too. 

From discussions among the community it seams this module will be deprecated and unsupported in the future anyway so it's mostly useful to support old reports previously written for v7 during a transition period. 
Therefore we think the current state of the module in core is not very useful because it breaks this support without making any noticeable improvements. 

This is our proposal to make things work again. 
