### PR TITLE
[IMP] Ship with reasonable default thousands separator format

### DIFF
--- a/openerp/addons/base/res/res_lang.py
+++ b/openerp/addons/base/res/res_lang.py
@@ -161,7 +161,7 @@ class lang(osv.osv):
         'direction': 'ltr',
         'date_format':_get_default_date_format,
         'time_format':_get_default_time_format,
-        'grouping': '[]',
+        'grouping': '[3, 0]',
         'decimal_point': '.',
         'thousands_sep': ',',
     }


### PR DESCRIPTION
As said in issue #274 , this is a change from ocb-server/7.0 rev. 4923 on Launchpad, which was not ported to v8.0
