### PR TITLE
[FIX] Backtrack to other pricelist items in the case of currency conv…

### DIFF
--- a/addons/product/pricelist.py
+++ b/addons/product/pricelist.py
@@ -306,7 +306,7 @@ class product_pricelist(osv.osv):
                         price = currency_obj.compute(cr, uid,
                                 ptype_src, pricelist.currency_id.id,
                                 price_tmp, round=False,
-                                context=context)
+                                context=context) if price_tmp is not False else False
                 elif rule.base == -2:
                     seller = False
                     for seller_id in product.seller_ids:


### PR DESCRIPTION
…ersion.

This change prevents the conversion to take special False value and return 0.0,
which prevents the backtracking. Additional to
https://github.com/odoo/odoo/pull/4763.
