### PR TITLE
Add timeout to fetchmail server connections

### DIFF
--- a/addons/fetchmail/fetchmail.py
+++ b/addons/fetchmail/fetchmail.py
@@ -90,7 +90,7 @@ class fetchmail_server(osv.osv):
     }
     _defaults = {
         'state': "draft",
-        'timeout': 10,
+        'timeout': 60,
         'type': "pop",
         'active': True,
         'priority': 5,

--- a/addons/fetchmail/fetchmail.py
+++ b/addons/fetchmail/fetchmail.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 
+import socket
 import logging
 import poplib
 import time
@@ -61,6 +62,7 @@ class fetchmail_server(osv.osv):
         ], 'Status', select=True, readonly=True),
         'server' : fields.char('Server Name', size=256, readonly=True, help="Hostname or IP of the mail server", states={'draft':[('readonly', False)]}),
         'port' : fields.integer('Port', readonly=True, states={'draft':[('readonly', False)]}),
+        'timeout' : fields.integer('Timeout (in seconds)', readonly=True, states={'draft':[('readonly', False)]}),
         'type':fields.selection([
             ('pop', 'POP Server'),
             ('imap', 'IMAP Server'),
@@ -88,6 +90,7 @@ class fetchmail_server(osv.osv):
     }
     _defaults = {
         'state': "draft",
+        'timeout': 10,
         'type': "pop",
         'active': True,
         'priority': 5,
@@ -154,6 +157,8 @@ openerp_mailgate: "|/path/to/openerp-mailgate.py --host=localhost -u %(uid)d -p 
             #connection.user("recent:"+server.user)
             connection.user(server.user)
             connection.pass_(server.password)
+        # Add timeout on socket
+        connection.sock.settimeout(server.timeout)
         return connection
 
     def button_confirm_login(self, cr, uid, ids, context=None):

--- a/addons/fetchmail/fetchmail_view.xml
+++ b/addons/fetchmail/fetchmail_view.xml
@@ -41,6 +41,7 @@
                                 <group attrs="{'invisible' : [('type', '=', 'local')]}" string="Server Information">
                                     <field name="server" colspan="2" attrs="{'required' : [('type', '!=', 'local')]}" />
                                     <field name="port" required="1" attrs="{'required' : [('type', '!=', 'local')]}" />
+                                    <field name="timeout" required="1" attrs="{'required' : [('type', '!=', 'local')]}" />
                                     <field name="is_ssl" on_change="onchange_server_type(type, is_ssl)"/>
                                 </group>
                                 <group attrs="{'invisible' : [('type', '=', 'local')]}" string="Login Information">


### PR DESCRIPTION
Copy of https://github.com/odoo/odoo/pull/7782 for OCB.

This PR is to add something missing in the base `imaplib`: a timeout for the socket connection created.
Usually, the way to do this is to set the default timeout for all sockets, but to avoid side effects, only the socket used to connect to the mail server has a defined timeout.
