### PR TITLE
Print detail depending on target_move field

### DIFF
--- a/addons/account/report/account_tax_report.py
+++ b/addons/account/report/account_tax_report.py
@@ -33,6 +33,7 @@ class tax_report(report_sxw.rml_parse, common_report_header):
         self.period_ids = []
         period_obj = self.pool.get('account.period')
         self.display_detail = data['form']['display_detail']
+        self.target_move = data['form']['target_move']
         res['periods'] = ''
         res['fiscalyear'] = data['form'].get('fiscalyear_id', False)
 
@@ -108,6 +109,10 @@ class tax_report(report_sxw.rml_parse, common_report_header):
     def _get_general(self, tax_code_id, period_list, company_id, based_on, context=None):
         if not self.display_detail:
             return []
+        if self.target_move == 'all':
+            move_states = ('draft', 'posted')
+        else:
+            move_states = ('posted', )
         res = []
         obj_account = self.pool.get('account.account')
         periods_ids = tuple(period_list)
@@ -153,9 +158,9 @@ class tax_report(report_sxw.rml_parse, common_report_header):
                         AND account.company_id = %s \
                         AND line.period_id IN %s\
                         AND account.active \
-                        AND move.state <> %s \
+                        AND move.state IN %s \
                     GROUP BY account.id,account.name,account.code', ('draft', tax_code_id,
-                        company_id, periods_ids, 'draft',))
+                        company_id, periods_ids, move_states,))
         res = self.cr.dictfetchall()
 
         i = 0


### PR DESCRIPTION
This PR is to fix a conflict between 2 commits:
- the first one is specific to OCB (hence, no odoo version of this PR), and added the field `target_move` to the Taxes Report, in order to have sums for unposted entries: https://github.com/OCA/OCB/commit/7eee34a7cc0f330b2a3be0808bd978b7b2fef368
- the second one is more recent, in odoo, and limits the printed details to posted entries: https://github.com/odoo/odoo/commit/3c055a769fc22e5fdc71ab9dc5a48237dd6d1812

In order to be consistent for the OCB version, the entries are now retrieved depending on the `target_move`value.
