### PR TITLE
Noupdate if unchanged

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -30,6 +30,7 @@ import os
 import sys
 import threading
 import time
+import md5
 
 import openerp
 import openerp.modules.db
@@ -115,6 +116,18 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
                 noupdate = False
                 if kind in ('demo', 'demo_xml') or (filename.endswith('.csv') and kind in ('init', 'init_xml')):
                     noupdate = True
+            if tools.config.options.get('noupdate_if_unchanged'):
+                cr.execute('select value from ir_values where name=%s and key=%s', (pathname, 'digest'))
+                olddigest = (cr.fetchone() or (None,))[0]
+                if olddigest is None:
+                    cr.execute('insert into ir_values (name, model, key, value) values (%s, %s, %s, NULL)',
+                               (pathname, 'ir_module_module', 'digest',))
+                digest = md5.md5(fp.read()).hexdigest()
+                fp.seek(0)
+                if digest == olddigest:
+                    noupdate = True
+                else:
+                    cr.execute('update ir_values set value=%s where name=%s and key=%s', (digest, pathname, 'digest'))
                 tools.convert_file(cr, module_name, filename, idref, mode, noupdate, kind, report)
         finally:
             if kind in ('demo', 'test'):

--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -114,20 +114,21 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
             for filename in _get_files_of_kind(kind):
                 _logger.info("loading %s/%s", module_name, filename)
                 noupdate = False
+                if tools.config.options.get('noupdate_if_unchanged'):
+                    pathname = os.path.join(module_name, filename)
+                    cr.execute('select value from ir_values where name=%s and key=%s', (pathname, 'digest'))
+                    olddigest = (cr.fetchone() or (None,))[0]
+                    if olddigest is None:
+                        cr.execute('insert into ir_values (name, model, key, value) values (%s, %s, %s, NULL)',
+                                   (pathname, 'ir_module_module', 'digest',))
+                    with tools.file_open(pathname) as fp:
+                        digest = md5.md5(fp.read()).hexdigest()
+                    if digest == olddigest:
+                        noupdate = True
+                    else:
+                        cr.execute('update ir_values set value=%s where name=%s and key=%s', (digest, pathname, 'digest'))
                 if kind in ('demo', 'demo_xml') or (filename.endswith('.csv') and kind in ('init', 'init_xml')):
                     noupdate = True
-            if tools.config.options.get('noupdate_if_unchanged'):
-                cr.execute('select value from ir_values where name=%s and key=%s', (pathname, 'digest'))
-                olddigest = (cr.fetchone() or (None,))[0]
-                if olddigest is None:
-                    cr.execute('insert into ir_values (name, model, key, value) values (%s, %s, %s, NULL)',
-                               (pathname, 'ir_module_module', 'digest',))
-                digest = md5.md5(fp.read()).hexdigest()
-                fp.seek(0)
-                if digest == olddigest:
-                    noupdate = True
-                else:
-                    cr.execute('update ir_values set value=%s where name=%s and key=%s', (digest, pathname, 'digest'))
                 tools.convert_file(cr, module_name, filename, idref, mode, noupdate, kind, report)
         finally:
             if kind in ('demo', 'test'):


### PR DESCRIPTION
Allows to switch to "noupdate" mode when a xml file has not been modified since last update.
It allows:
- faster updates (2x faster on a typical -u all)
- prevents from overwriting modifications made in the db at each update. The modified file is overwritten only if modified upstream.

To try it:
- add the `noupdate_if_unchanged=True` option in your openerp config.
- run a database update with -u all and note down the time it takes
- run the database update again and compare the time

The only current drawback is that I don't yet see a way to warn the user of a conflict between a file modified both locally and upstream.
