### PR TITLE
8.0 oca longer alias expression

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -4555,6 +4555,9 @@ class BaseModel(object):
         if not regex_order.match(m2o_order):
             # _order is complex, can't use it here, so we default to _rec_name
             m2o_order = dest_model._rec_name
+        # Prevent recursion when order field refers to self.
+        if dest_model._table == self._table:
+            m2o_order = dest_model._rec_name
 
         # Join the dest m2o table if it's not joined yet. We use [LEFT] OUTER join here
         # as we don't want to exclude results that have NULL values for the m2o

--- a/openerp/osv/expression.py
+++ b/openerp/osv/expression.py
@@ -135,6 +135,7 @@ import collections
 
 import logging
 import traceback
+import hashlib
 
 import openerp.modules
 from . import fields
@@ -342,7 +343,15 @@ def generate_table_alias(src_table_alias, joined_tables=[]):
         return '%s' % alias, '%s' % _quote(alias)
     for link in joined_tables:
         alias += '__' + link[1]
-    assert len(alias) < 64, 'Table alias name %s is longer than the 64 characters size accepted by default in postgresql.' % alias
+    # Use an alternate alias scheme if length exceeds the PostgreSQL limit
+    # of 63 characters.
+    if len(alias) >= 64:
+        # We have to fit a 160 bit hash (= 40 characters) and one underscore
+        # into a 63 character alias. The remaining space we can use to add
+        # a human readable prefix.
+        ALIAS_PREFIX_LENGTH = 63 - 40 - 1
+        alias = "%s_%s" % (
+            alias[:ALIAS_PREFIX_LENGTH], hashlib.sha1(alias).hexdigest())
     return '%s' % alias, '%s as %s' % (_quote(joined_tables[-1][0]), _quote(alias))
 
 


### PR DESCRIPTION
Fix issue 8094 and prevent recursion when field in order by refers to own model.

Upstream PR is: https://github.com/odoo/odoo/pull/8142
