### PR TITLE
    [FIX] mail.message: checking rules on deleted records.

### DIFF
--- a/addons/mail/mail_message.py
+++ b/addons/mail/mail_message.py
@@ -751,7 +751,7 @@ class mail_message(osv.Model):
         document_related_ids = []
         for model, doc_ids in model_record_ids.items():
             model_obj = self.pool[model]
-            mids = model_obj.exists(cr, uid, list(doc_ids))
+            mids = list(doc_ids)
             if hasattr(model_obj, 'check_mail_message_access'):
                 model_obj.check_mail_message_access(cr, uid, mids, operation, context=context)
             else:


### PR DESCRIPTION
This change avoid to raise 'Access Denied' when accessing to messages related to deleted documents, which user had access right on.

Example: user A can see messages related to sale.order SO1, even if A is not directly notified.
    Someone deletes SO1.
    'A' opens 'inbox', 'check_access_rule' is called, 'mids' is empty, 'document_related_ids' is empty, 'other_ids' is not empy -> exception is raised

upstream: https://github.com/odoo/odoo/pull/5343
