### PR TITLE
[FIX] wrong tax code sign when manually changing tax amount

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -1549,6 +1549,8 @@ class account_invoice_tax(models.Model):
         compute='_compute_factors')
     factor_tax = fields.Float(string='Multipication factor Tax code',
         compute='_compute_factors')
+    account_tax_id = fields.Many2one(
+        'account.tax', string='Tax')
 
     @api.multi
     def base_change(self, base, currency_id=False, company_id=False, date_invoice=False):
@@ -1558,6 +1560,10 @@ class account_invoice_tax(models.Model):
             currency = self.env['res.currency'].browse(currency_id)
             currency = currency.with_context(date=date_invoice or fields.Date.context_today(self))
             base = currency.compute(base * factor, company.currency_id, round=False)
+            if self.invoice_id.type in ('out_invoice','in_invoice'):
+                base = base * self.account_tax_id.base_sign
+            else:
+                base = base * self.account_tax_id.ref_base_sign
         return {'value': {'base_amount': base}}
 
     @api.multi
@@ -1567,8 +1573,11 @@ class account_invoice_tax(models.Model):
             currency = self.env['res.currency'].browse(currency_id)
             currency = currency.with_context(date=date_invoice or fields.Date.context_today(self))
             amount = currency.compute(amount, company.currency_id, round=False)
-        tax_sign = math.copysign(1, (self.tax_amount * self.amount))
-        return {'value': {'tax_amount': amount * tax_sign}}
+            if self.invoice_id.type in ('out_invoice','in_invoice'):
+                amount = amount * self.account_tax_id.tax_sign
+            else:
+                amount = amount * self.account_tax_id.ref_tax_sign
+        return {'value': {'tax_amount': amount}}
 
     @api.v8
     def compute(self, invoice):
@@ -1587,6 +1596,7 @@ class account_invoice_tax(models.Model):
                     'manual': False,
                     'sequence': tax['sequence'],
                     'base': currency.round(tax['price_unit'] * line['quantity']),
+                    'account_tax_id': tax['id'],
                 }
                 if invoice.type in ('out_invoice','in_invoice'):
                     val['base_code_id'] = tax['base_code_id']


### PR DESCRIPTION
Case:
- Create supplier tax with tax_sign = -1
- Create supplier invoice with above created tax
- Edit amount of account.invoice.tax

Tax amount on journal entry has positive sign, but should have negative sign

upstream: https://github.com/odoo/odoo/pull/6924
