### PR TITLE
[FIX] Default website.company_id to base.main_company instead of base.public_user

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -172,7 +172,7 @@ class website(osv.osv):
     }
 
     _defaults = {
-        'company_id': lambda self,cr,uid,c: self.pool['ir.model.data'].xmlid_to_res_id(cr, openerp.SUPERUSER_ID, 'base.public_user'),
+        'company_id': lambda self,cr,uid,c: self.pool['ir.model.data'].xmlid_to_res_id(cr, openerp.SUPERUSER_ID, 'base.main_company'),
     }
 
     # cf. Wizard hack in website_views.xml


### PR DESCRIPTION
Fix https://github.com/odoo/odoo/issues/7308

**website company_id defaults to a res.users record**

Impacted versions:
- 8.0

Steps to reproduce:
1. Create a new website using XML file, like this one:

```
<?xml version="1.0" encoding="UTF-8"?>
<openerp>
    <data noupdate="1">
        <record id="website_alternative" model="website">
           <field name="name">alternative.localdomain</field>
           <field name="language_ids" eval="[(6,0,[ref('base.lang_en')])]" />
           <field name="default_lang_id" ref="base.lang_en" />
           <field name="user_id" ref="base.public_user" />
       </record>
    </data>
</openerp>
```
1. External XML differs: `base.public_user != base.main_company`, in my case :
2. base.public_user = 3
3. base.main_company = 1

Current behavior:

```
  File "/opt/odoo/common/openerp/v8/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
ParseError: "insert or update on table "website" violates foreign key constraint "website_company_id_fkey"
DETAIL:  Key (company_id)=(3) is not present in table "res_company".
```

Expected behavior:
- Create a new record in `website` table using default company_id, for instance `base.main_company`

I propuse to change this statement `addons/website/models/website.py`:

```
    _defaults = {
        'company_id': lambda self,cr,uid,c: self.pool['ir.model.data'].xmlid_to_res_id(cr, openerp.SUPERUSER_ID, 'base.public_user'),
    }
```

replacing `base.public_user` by `base.main_company`
