### PR TITLE
[FIX] allow call of popup from PoS

### DIFF
--- a/addons/web/static/src/js/views.js
+++ b/addons/web/static/src/js/views.js
@@ -1489,7 +1489,7 @@ instance.web.View = instance.web.Widget.extend({
             }
             args.push(context);
             return dataset.call_button(action_data.name, args).then(handler).then(function () {
-                if (instance.webclient) {
+                if (instance.webclient && instance.webclient.menu) {
                     instance.webclient.menu.do_reload_needaction();
                 }
             });


### PR DESCRIPTION
In PoS, instance.webclient.menu is undefined.

So if we call a popup (via do_action), when we close the popup (without canceling it), it will raise an error.

This commit fix the bug.

**screenshot**
![web-fix](https://cloud.githubusercontent.com/assets/3407482/9597758/52f5fd3e-5085-11e5-91f6-7791e1225f32.png)

**Main part of JS code, that generated bug**

```
module.ProductCategoriesWidget.include({

    init: function (parent, options) {
        this._super(parent, options);
        var self = this;
        // Add handler to the click button
        $('#button_pos_test').click(function () {
            action = 'pos_test.action_create_pos_test'; // A custom action, that target a view with a button type='object'
            option = {}
            instance.client.action_manager.do_action(action, option);

        });
    },
})
```
