### PR TITLE
[FIX] purchase: add transition invoice_end to cancel in the workflow

### DIFF
--- a/addons/purchase/purchase_workflow.xml
+++ b/addons/purchase/purchase_workflow.xml
@@ -202,6 +202,12 @@
             <field name="act_to" ref="act_done"/>
             <field name="condition">invoiced</field>
         </record>
+        <record id="trans_invoice_end_cancel" model="workflow.transition">
+            <field name="act_from" ref="act_invoice_end"/>
+            <field name="act_to" ref="act_cancel"/>
+            <field name="signal">purchase_cancel</field>
+            <field name="condition">invoice_method&lt;&gt;'order'</field>
+        </record>
 
     <!-- Procurement -->
         <record id="act_buy" model="workflow.activity">


### PR DESCRIPTION
If the state of the PO is 'approved', there is no transition foreseen in
order to cancel the PO.

The user might be blocked in the following situation:
- Create a purchase order with invoicing set as Based on incoming shipment
- Validate the purchase order, create the shipment
- Then, cancel it (the shipment)
- Return back in the purchase order, the PO should be in shipping exception
- Hit the "manually corrected"
- Then, try to cancel the PO: nothing happens.

opw-641014
