### PR TITLE
don't autoinstall bus

### DIFF
--- a/addons/bus/__openerp__.py
+++ b/addons/bus/__openerp__.py
@@ -11,5 +11,5 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
odoo 8.0 sets the addon `bus` to `auto_install=True`, which can be an issue because this addon requires the odoo db user to be able to connect to the `postgres` database, which is not something you always want to do (or that your DBA will let you do). 

Since OCB does not have `im_chat` auto installed, and this is the only module depending on `bus`, I think it makes sense to disable autoinstallation of `bus` too. 
