### PR TITLE
Respect batch size on email queue

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -836,9 +836,9 @@ class account_move_line(osv.osv):
                 ret_line['credit_currency'] = actual_credit
                 ret_line['debit_currency'] = actual_debit
                 if target_currency == company_currency:
-                    actual_debit = debit
-                    actual_credit = credit
-                    total_amount = debit or credit
+                    actual_debit = debit > 0 and amount or 0.0
+                    actual_credit = credit > 0 and amount or 0.0
+                    total_amount = abs(debit - credit)
                 else:
                     ctx = context.copy()
                     ctx.update({'date': line.date})

--- a/addons/mail/mail_mail.py
+++ b/addons/mail/mail_mail.py
@@ -111,6 +111,12 @@ class mail_mail(osv.Model):
                                 filter to further restrict the outgoing
                                 messages to send (by default all 'outgoing'
                                 messages are sent).
+
+                                If a 'mail_batch_size' key is present in
+                                context, it will be used to determine how many
+                                mails will be sent each time the queue is
+                                processed. Otherwise, the system parameter
+                                'mail.batch_size' will be used.
         """
         if context is None:
             context = {}
@@ -118,7 +124,11 @@ class mail_mail(osv.Model):
             filters = [('state', '=', 'outgoing')]
             if 'filters' in context:
                 filters.extend(context['filters'])
-            ids = self.search(cr, uid, filters, context=context)
+            limit = (context.get('mail_batch_size') or
+                     int(self.pool['ir.config_parameter']
+                         .get_param(cr, SUPERUSER_ID, 'mail.batch_size')) or
+                     None)
+            ids = self.search(cr, uid, filters, limit=limit, context=context)
         res = None
         try:
             # Force auto-commit - this is meant to be called by

--- a/doc/cla/corporate/grupoesoc.md
+++ b/doc/cla/corporate/grupoesoc.md
@@ -1,0 +1,15 @@
+Spain, 2015-05-07
+
+Grupo ESOC agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Nuria Pastor <n.pastor@grupoesoc.es> https://github.com/grupoesoc/
+
+List of contributors:
+
+Jairo Llopis <j.llopis@grupoesoc.es> https://github.com/Yajo

--- a/doc/cla/individual/Yajo.md
+++ b/doc/cla/individual/Yajo.md
@@ -1,0 +1,11 @@
+Spain, september 24th 2015
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jairo Llopis yajo.sk8@gmail.com https://github.com/Yajo


### PR DESCRIPTION
[Odoo already has a system parameter called `mail.batch_size`](https://github.com/odoo/odoo/blob/8.0/addons/mail/wizard/mail_compose_message.py#L227). However, it's only respected in the `mail.compose.message` wizard.

It's a bit weird because where it could be most useful is in mass mailing. Setting limits can prevent some mail servers from banning your account.

This patch applies that limit every time the mail queue is processed, and thus it applies to `crm.mass_mailing` too. In core Odoo the admin can configure how often that queue is processed, so if for example your mail server limits you to send 500 mails per minute, you can configure it to have no problems.

This PR is a copy of https://github.com/odoo/odoo/pull/6386 after it has been ignored for a long while.
