### PR TITLE
7.0 [FIX] auth_signup module for user duplication

### DIFF
--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -272,6 +272,8 @@ class res_users(osv.Model):
                 return True
 
     def _send_invitation(self, cr, uid, ids, context=None):
+        if type(ids) in (int, long):
+            ids = [ids]
         for user in self.browse(cr, uid, ids, context=context):
             if context and context.get('reset_password') \
                     and user.email \
@@ -284,7 +286,7 @@ class res_users(osv.Model):
     def create(self, cr, uid, values, context=None):
         # overridden to automatically invite user to sign up
         user_id = super(res_users, self).create(cr, uid, values, context=context)
-        self._send_invitation(cr, uid, [user_id], context=context)
+        self._send_invitation(cr, uid, user_id, context=context)
         return user_id
 
     def write(self, cr, uid, ids, values, context=None):

--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -271,11 +271,12 @@ class res_users(osv.Model):
             else:
                 return True
 
-    def create(self, cr, uid, values, context=None):
-        # overridden to automatically invite user to sign up
-        user_id = super(res_users, self).create(cr, uid, values, context=context)
-        user = self.browse(cr, uid, user_id, context=context)
-        if context and context.get('reset_password') and user.email:
-            ctx = dict(context, create_user=True)
-            self.action_reset_password(cr, uid, [user.id], context=ctx)
-        return user_id
+    def write(self, cr, uid, ids, values, context=None):
+        res = super(res_users, self).write(cr, uid, ids, values, context=context)
+        if res:
+            for user in self.browse(cr, uid, ids, context=context):
+                if context and context.get('reset_password') and \
+                        user.email and not '__copy_data_seen' in context:
+                    ctx = dict(context, create_user=True)
+                    self.action_reset_password(cr, uid, [user.id], context=ctx)
+        return res

--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -271,14 +271,27 @@ class res_users(osv.Model):
             else:
                 return True
 
+    def _send_invitation(self, cr, uid, ids, context=None):
+        for user in self.browse(cr, uid, ids, context=context):
+            if context and context.get('reset_password') \
+                    and user.email \
+                    and not '__copy_data_seen' in context \
+                    and user.state == 'new' \
+                    and not user.partner_id.signup_token:
+                ctx = dict(context, create_user=True)
+                self.action_reset_password(cr, uid, [user.id], context=ctx)
+
+    def create(self, cr, uid, values, context=None):
+        # overridden to automatically invite user to sign up
+        user_id = super(res_users, self).create(cr, uid, values, context=context)
+        self._send_invitation(cr, uid, [user_id], context=context)
+        return user_id
+
     def write(self, cr, uid, ids, values, context=None):
+        # overridden to automatically invite user to sign up
         res = super(res_users, self).write(cr, uid, ids, values, context=context)
-        if res:
-            for user in self.browse(cr, uid, ids, context=context):
-                if context and context.get('reset_password') and \
-                        user.email and not '__copy_data_seen' in context:
-                    ctx = dict(context, create_user=True)
-                    self.action_reset_password(cr, uid, [user.id], context=ctx)
+        if res and values.get('email'):
+            self._send_invitation(cr, uid, ids, context=context)
         return res
 
     def copy(self, cr, uid, id, default=None, context=None):

--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -277,7 +277,7 @@ class res_users(osv.Model):
         for user in self.browse(cr, uid, ids, context=context):
             if context and context.get('reset_password') \
                     and user.email \
-                    and not '__copy_data_seen' in context \
+                    and '__copy_data_seen' not in context \
                     and user.state == 'new' \
                     and not user.partner_id.signup_token:
                 ctx = dict(context, create_user=True)

--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -280,3 +280,14 @@ class res_users(osv.Model):
                     ctx = dict(context, create_user=True)
                     self.action_reset_password(cr, uid, [user.id], context=ctx)
         return res
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        new_id = super(res_users, self).copy(cr, uid, id, default=default, context=context)
+        if new_id:
+            user = self.browse(cr, uid, new_id, context=context)
+            self.pool['res.partner'].write(cr, uid, user.partner_id.id, dict(
+                signup_token = False,
+                signup_type = False,
+                signup_expiration = False,
+            ), context=context)
+        return new_id

--- a/addons/auth_signup/res_users.py
+++ b/addons/auth_signup/res_users.py
@@ -285,24 +285,27 @@ class res_users(osv.Model):
 
     def create(self, cr, uid, values, context=None):
         # overridden to automatically invite user to sign up
-        user_id = super(res_users, self).create(cr, uid, values, context=context)
+        user_id = super(res_users, self).\
+            create(cr, uid, values, context=context)
         self._send_invitation(cr, uid, user_id, context=context)
         return user_id
 
     def write(self, cr, uid, ids, values, context=None):
         # overridden to automatically invite user to sign up
-        res = super(res_users, self).write(cr, uid, ids, values, context=context)
+        res = super(res_users, self).\
+            write(cr, uid, ids, values, context=context)
         if res and values.get('email'):
             self._send_invitation(cr, uid, ids, context=context)
         return res
 
     def copy(self, cr, uid, id, default=None, context=None):
-        new_id = super(res_users, self).copy(cr, uid, id, default=default, context=context)
+        new_id = super(res_users, self).\
+            copy(cr, uid, id, default=default, context=context)
         if new_id:
             user = self.browse(cr, uid, new_id, context=context)
             self.pool['res.partner'].write(cr, uid, user.partner_id.id, dict(
-                signup_token = False,
-                signup_type = False,
-                signup_expiration = False,
+                signup_token=False,
+                signup_type=False,
+                signup_expiration=False,
             ), context=context)
         return new_id


### PR DESCRIPTION
Without this patch the auth_signup module sends an invitation link for a new user account created by duplication of an existing user account to the existing users mail address instead of the new one. 
This is due to how copy() calls create() in orm.py. 
The previous version of the module just hooks into create() which isn't just correct for the case of duplicating users. Worst case: An dismissed employee may get access back to the system accidentally if his former account is used as a template to create the account for his successor. 
