### PR TITLE
Add due date for imported payment lines

### DIFF
--- a/addons/account_payment/wizard/account_payment_populate_statement.py
+++ b/addons/account_payment/wizard/account_payment_populate_statement.py
@@ -86,6 +86,7 @@ class account_payment_populate_statement(osv.osv_memory):
             'partner_id': payment_line.partner_id.id,
             'statement_id': statement.id,
             'ref': payment_line.communication,
+            'date': payment_line.ml_maturity_date,
         }
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
This PR is to use the due date when importing payment lines in a bank statement, instead of the current date.

Done in https://github.com/odoo/odoo/pull/8821 as well.
