### PR TITLE
[IMP] Print the document name on report footers

### DIFF
--- a/addons/report/views/layouts.xml
+++ b/addons/report/views/layouts.xml
@@ -105,6 +105,7 @@
             </t>
 
             <ul class="list-inline">
+                <li t-if="o and o.name"><span t-field="o.name"/></li>
                 <li>Page:</li>
                 <li><span class="page"/></li>
                 <li>/</li>
@@ -133,6 +134,7 @@
             </div>
             <div class="col-xs-2 col-xs-offset-3 text-right">
                 <ul class="list-inline">
+                    <li t-if="o and o.name"><span t-field="o.name"/></li>
                     <li><span class="page"/></li>
                     <li>/</li>
                     <li><span class="topage"/></li>


### PR DESCRIPTION
It's very useful for users and partners to have the document's name (usually a reference number) printed on every document: printed pages get mixed up very often and this is the only way people can put them back together.
