### PR TITLE
[FIX] #9035: on list view editable, set focus to input

### DIFF
--- a/addons/web/static/src/js/view_list_editable.js
+++ b/addons/web/static/src/js/view_list_editable.js
@@ -257,7 +257,17 @@ openerp.web.list_editable = function (instance) {
                         if (!focus_field){
                             focus_field = _.find(self.editor.form.fields_order, function(field){ return fields[field] && fields[field].$el.is(':visible:has(input)'); });
                         }
-                        if (focus_field  && fields[focus_field]) fields[focus_field].$el.find('input').select();
+                        if (focus_field  && fields[focus_field]){
+                            var input = fields[focus_field].$el.find('input');
+                            if(input[0]){
+                                if(input[0].type === 'text' ||
+                                   input[0].type === 'textarea'){
+                                    input[0].select();
+                                }else{
+                                    input[0].focus();
+                                }
+                           }
+                        }
                         return record.attributes;
                     });
                 }).fail(function () {

--- a/addons/web/static/test/list-editable.js
+++ b/addons/web/static/test/list-editable.js
@@ -356,3 +356,68 @@ openerp.testing.section('list.edition.onwrite', {
         });
     });
 });
+
+openerp.testing.section('list.edition.focus', {
+    dependencies: ['web.list_editable'],
+    rpc: 'mock',
+    templates: true,
+}, function (test) {
+    test('edition focus char field', {asserts: 2}, function (instance, $fix, mock) {
+        mock('demo:read', function () {
+            return [{ id: 1, a: 'foo', b: 'bar', c: 'baz' }];
+        });
+        mock('demo:fields_view_get', function () {
+            return {
+                type: 'tree',
+                fields: {
+                    a: {type: 'char', string: "A"},
+                    b: {type: 'char', string: "B"},
+                    c: {type: 'char', string: "C"}
+                },
+                arch: '<tree><field name="a"/><field name="b"/><field name="c"/></tree>',
+            };
+        });
+        var ds = new instance.web.DataSetStatic(null, 'demo', null, [1]);
+        var l = new instance.web.ListView({}, ds, false, {editable: 'top'});
+        return l.appendTo($fix)
+            .then(l.proxy('reload_content'))
+            .then(function () {
+                l.start_edition(l.records.get(1));
+            })
+            .then(function () {
+                var input =  $fix.find('input')[0];
+                strictEqual(document.activeElement, input);
+                strictEqual(input.value.substring(input.selectionStart,
+                                                  input.selectionEnd),
+                            'foo',
+                            "Text in char field must be selected");
+            });
+    });
+  test('edition focus boolean field', {asserts: 1}, function (instance, $fix, mock) {
+        mock('demo:read', function () {
+            return [{ id: 1, a: true, b: 'bar', c: 'baz' }];
+        });
+        mock('demo:fields_view_get', function () {
+            return {
+                type: 'tree',
+                fields: {
+                    a: {type: 'boolean', string: "A"},
+                    b: {type: 'char', string: "B"},
+                    c: {type: 'char', string: "C"}
+                },
+                arch: '<tree><field name="a"/><field name="b"/><field name="c"/></tree>',
+            };
+        });
+        var ds = new instance.web.DataSetStatic(null, 'demo', null, [1]);
+        var l = new instance.web.ListView({}, ds, false, {editable: 'top'});
+        return l.appendTo($fix)
+            .then(l.proxy('reload_content'))
+            .then(function () {
+                l.start_edition(l.records.get(1));
+            })
+            .then(function () {
+                strictEqual(document.activeElement, $fix.find('input')[0]);
+            });
+    });
+
+});


### PR DESCRIPTION
type which are not in (text or textarea) when those kind of fields is in the first position
this occur when moving to the next editing line

see issue odoo/odoo#9035 to get more information to reproduce it
