### PR TITLE
8.0 Restore context in mail.thread message_route_process()

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -1098,8 +1098,9 @@ class mail_thread(osv.AbstractModel):
             )
 
     def message_route_process(self, cr, uid, message, message_dict, routes, context=None):
+        if context is None:
+            context = {}
         # postpone setting message_dict.partner_ids after message_post, to avoid double notifications
-        context = dict(context or {})
         partner_ids = message_dict.pop('partner_ids', [])
         thread_id = False
         for model, thread_id, custom_values, user_id, alias in routes or ():


### PR DESCRIPTION
I believe the change made to this function in cbe2dbb was wrong.
I don't see why this change was necessary, however its negative impact is that it breaks the possibility to get the model name that corresponds to the thread_id returned by the function from the context as before. 

Create same PR also against upstream:
https://github.com/odoo/odoo/pull/9046
