### PR TITLE
[FIX] Fixed XML data recreation when inherited part are not deleted

### DIFF
--- a/openerp/addons/base/ir/ir_model.py
+++ b/openerp/addons/base/ir/ir_model.py
@@ -1049,10 +1049,31 @@ class ir_model_data(osv.osv):
                     },context=context)
         else:
             if mode=='init' or (mode=='update' and xml_id):
+                inherit_xml_ids = []
+                for table, field_name in model_obj._inherits.items():
+                    xml_ids = self.pool['ir.model.data'].search(cr, uid, [
+                        ('module', '=', module),
+                        ('name', '=', xml_id + '_' + table.replace('.', '_')),
+                    ], context=context)
+                    # XML ID found in the database, try to recover an existing record
+                    if xml_ids:
+                        found_xml_id = self.pool['ir.model.data'].browse(cr, uid, xml_ids[0], context=context)
+                        record = self.pool[found_xml_id.model].browse(cr, uid, [found_xml_id.res_id], context=context)[0]
+                        # The record exists, store the id and don't recreate the XML ID
+                        if record.exists():
+                            inherit_xml_ids.append(found_xml_id.model)
+                            values[field_name] = found_xml_id.res_id
+                        # Orphan XML ID, delete it
+                        else:
+                            found_xml_id.unlink()
+
                 res_id = model_obj.create(cr, uid, values, context=context)
                 if xml_id:
                     if model_obj._inherits:
                         for table in model_obj._inherits:
+                            if table in inherit_xml_ids:
+                                continue
+
                             inherit_id = model_obj.browse(cr, uid,
                                     res_id,context=context)[model_obj._inherits[table]]
                             self.create(cr, SUPERUSER_ID, {


### PR DESCRIPTION
PR proposed here for upstream : https://github.com/odoo/odoo/pull/8966

When updating the product module, if the "Service" product.product has been deleted, but not the corresponding "product.template" part, the update will crash on a "duplicate xml id" error.

This commit fixes the bug by :
- Adding the link to existing inherited model XML ID in values
- Avoid creating the duplicated XML ID

Steps to reproduce the bug on runbot :
- Go to a 8.0 "base" database
- Install the "product" module
- Go to the "Sales / Products" menu
- Search for "Service" and open the form view
- In the "Variants" tab, add at least one attribute with at least two values
  => Odoo will delete the default "Service" variant, and create some new ones
- Go to the "Settings / Local modules" menu, and update the "product" module
  => The update will crash
