### PR TITLE
[FIX] don't drop existing file_type column

### DIFF
--- a/addons/mail/ir_attachment.py
+++ b/addons/mail/ir_attachment.py
@@ -192,5 +192,5 @@ class IrAttachment(osv.Model):
 
     _columns = {
         'file_type_icon': fields.function(get_attachment_type, type='char', string='File Type Icon'),
-        'file_type': fields.related('file_type_icon', type='char'),     # FIXME remove in trunk
+        'file_type': fields.related('file_type_icon', type='char', nodrop=True),     # FIXME remove in trunk
     }


### PR DESCRIPTION
When you have `mail` and `document` installed, every update of the `mail` module will drop the column created by `document`. This is a problem when you rely on this field.

Upstream PR: https://github.com/odoo/odoo/pull/9173

This was pretty much revamped in 9.0, so nothing to do there.
