### PR TITLE
7.0-fix-procurement-sale-workflow-phantom-bom

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -2496,6 +2496,8 @@ class stock_move(osv.osv):
                        {'state': 'done', 
                        'date': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)}, 
                        context=context)
+        for id in move_ids:
+             wf_service.trg_trigger(uid, 'stock.move', id, cr)
         for pick_id in picking_ids:
             wf_service.trg_write(uid, 'stock.picking', pick_id, cr)
 


### PR DESCRIPTION
Hello,

The bug is easy to reproduce : 
Create  a database with modules sale, stock, mrp
Create a product with a phantom bom and one component.
Make sure you have enought stock
create a sale order
Deliver the delivery order
=> The procurement of the bom is still 'waiting' and the order is not 'shipped'

I am not sure, but I think it has not been removed intentionally.
It comes from there : 
https://github.com/pedrobaeza/odoo/commit/524655ac10b6bece1e39962fd3dbfe5102d51672
http://bazaar.launchpad.net/~ocb/ocb-addons/7.0/revision/9598

I hope it can be merged soon unless there is an explanation.
(On odoo official branch, the code is still there and it works well)

thanks
