### PR TITLE
[FIX] missing precision on quants

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -295,7 +295,7 @@ class stock_quant(osv.osv):
         'name': fields.function(_get_quant_name, type='char', string='Identifier'),
         'product_id': fields.many2one('product.product', 'Product', required=True, ondelete="restrict", readonly=True, select=True),
         'location_id': fields.many2one('stock.location', 'Location', required=True, ondelete="restrict", readonly=True, select=True, auto_join=True),
-        'qty': fields.float('Quantity', required=True, help="Quantity of products in this quant, in the default unit of measure of the product", readonly=True, select=True),
+        'qty': fields.float('Quantity', digits_compute=dp.get_precision('Product Unit of Measure'), required=True, help="Quantity of products in this quant, in the default unit of measure of the product", readonly=True, select=True),
         'package_id': fields.many2one('stock.quant.package', string='Package', help="The package containing this quant", readonly=True, select=True),
         'packaging_type_id': fields.related('package_id', 'packaging_id', type='many2one', relation='product.packaging', string='Type of packaging', readonly=True, store=True),
         'reservation_id': fields.many2one('stock.move', 'Reserved for Move', help="The move the quant is reserved for", readonly=True, select=True),


### PR DESCRIPTION
The quantities on products, moves... have a user-configurable precision () but the quants don't have an explicit precision set.
When using a precision other than 0.01, this lets users manipulate quantities that get displayed rounded to 0.00 in the view.
