### PR TITLE
[FIX] prefer quants from same location in removal strategies

### DIFF
--- a/addons/product_expiry/product_expiry.py
+++ b/addons/product_expiry/product_expiry.py
@@ -105,7 +105,7 @@ class stock_quant(osv.osv):
 
     def apply_removal_strategy(self, cr, uid, location, product, qty, domain, removal_strategy, context=None):
         if removal_strategy == 'fefo':
-            order = 'removal_date, in_date, id'
+            order = 'removal_date, location_id, package_id, lot_id, in_date, id'
             return self._quants_get_order(cr, uid, location, product, qty, domain, order, context=context)
         return super(stock_quant, self).apply_removal_strategy(cr, uid, location, product, qty, domain, removal_strategy, context=context)
 

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -484,10 +484,10 @@ class stock_quant(osv.osv):
 
     def apply_removal_strategy(self, cr, uid, location, product, quantity, domain, removal_strategy, context=None):
         if removal_strategy == 'fifo':
-            order = 'in_date, id'
+            order = 'in_date, location_id, package_id, lot_id, id'
             return self._quants_get_order(cr, uid, location, product, quantity, domain, order, context=context)
         elif removal_strategy == 'lifo':
-            order = 'in_date desc, id desc'
+            order = 'in_date desc, location_id desc, package_id desc, lot_id desc, id desc'
             return self._quants_get_order(cr, uid, location, product, quantity, domain, order, context=context)
         raise osv.except_osv(_('Error!'), _('Removal strategy %s not implemented.' % (removal_strategy,)))
 


### PR DESCRIPTION
Previously the quants got ordered by id when all other sorting keys were equal. The problem with that is that when a quant gets split, one part gets a new ID which is much bigger that the other part. If this quant is not reserved and a removal is demanded, it will be considered after all the other quants. The result is that users may well be proposed to pick from several locations when in fact all the goods could have been reserved from the same location.
This fixes this bad proposal by sorting by location_id as a second-to-last resort (last resort still being the quant id).

The proposed changes don't seam to be significantly slower (discussed in upstream PR).

Upstream PR: https://github.com/odoo/odoo/pull/7823
