### PR TITLE
[FIX] Make action_assign callable from XML-RPC (regression) 

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -2253,6 +2253,7 @@ class stock_move(osv.osv):
 
     def action_assign(self, cr, uid, ids, context=None):
         """ Checks the product type and accordingly writes the state.
+        @return: True
         """
         context = context or {}
         quant_obj = self.pool.get("stock.quant")
@@ -2316,6 +2317,7 @@ class stock_move(osv.osv):
         #force assignation of consumable products and incoming from supplier/inventory/production
         if to_assign_moves:
             self.force_assign(cr, uid, list(to_assign_moves), context=context)
+        return True
 
     def action_cancel(self, cr, uid, ids, context=None):
         """ Cancels the moves and if all moves are cancelled it cancels the picking.


### PR DESCRIPTION
In previous versions, action_assign used to return True but since v8 it didn't have an explicit return value anymore, so it returned None.
This is a problem for XML-RPC clients because None is usually not serializable.
Upstream PR: https://github.com/odoo/odoo/pull/8876
