### PR TITLE
[FIX] fiscal_position on refunds

### DIFF
--- a/addons/account/wizard/account_invoice_refund.py
+++ b/addons/account/wizard/account_invoice_refund.py
@@ -187,7 +187,7 @@ class account_invoice_refund(osv.osv_memory):
                                     'partner_insite', 'partner_contact',
                                     'partner_ref', 'payment_term', 'account_id',
                                     'currency_id', 'invoice_line', 'tax_line',
-                                    'journal_id', 'period_id'], context=context)
+                                    'journal_id', 'period_id', 'fiscal_position'], context=context)
                         invoice = invoice[0]
                         del invoice['id']
                         invoice_lines = inv_line_obj.browse(cr, uid, invoice['invoice_line'], context=context)
@@ -205,7 +205,7 @@ class account_invoice_refund(osv.osv_memory):
                             'name': description
                         })
                         for field in ('partner_id', 'account_id', 'currency_id',
-                                         'payment_term', 'journal_id'):
+                                         'payment_term', 'journal_id', 'fiscal_position'):
                                 invoice[field] = invoice[field] and invoice[field][0]
                         inv_id = inv_obj.create(cr, uid, invoice, {})
                         if inv.payment_term.id:


### PR DESCRIPTION
fiscal_position isn't passed to the newly created invoice when using 'cancel' or 'modify' refund type.
