### PR TITLE
[FIX][email_template] Generate report with relevant partner id only

### DIFF
--- a/addons/email_template/email_template.py
+++ b/addons/email_template/email_template.py
@@ -504,6 +504,9 @@ class email_template(osv.osv):
 
             # Add report in attachments: generate once for all template_res_ids
             if template.report_template:
+                # Fix : Force report to use res ids and not active_ids
+                if ctx and 'active_ids' in ctx:
+                    del ctx['active_ids']
                 for res_id in template_res_ids:
                     attachments = []
                     report_name = self.render_template(cr, uid, template.report_name, template.model, res_id, context=ctx)


### PR DESCRIPTION
When email templates are configured to print and send pdf reports it uses active ids in context to generate report resulting generating report with all ids which is wrong.
