### PR TITLE
Only re-reserve moves not done or cancelled

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1389,7 +1389,8 @@ class stock_picking(osv.osv):
         This can be used to provide a button that rereserves taking into account the existing pack operations
         """
         for pick in self.browse(cr, uid, ids, context=context):
-            self.rereserve_quants(cr, uid, pick, move_ids = [x.id for x in pick.move_lines], context=context)
+            self.rereserve_quants(cr, uid, pick, move_ids = [x.id for x in pick.move_lines
+                                                             if x.state not in ('done', 'cancel')], context=context)
 
     def rereserve_quants(self, cr, uid, picking, move_ids=[], context=None):
         """ Unreserve quants then try to reassign quants."""


### PR DESCRIPTION
Copy of https://github.com/odoo/odoo/pull/9550 : 
this PR is to fix an issue with the picking workflow : if the picking is in a "Waiting Another Operation" state, the button "Recheck Availability" is available, and calls the method rereserve_pick().
However, that method then calls do_unreserve on all the moves in the picking, which will return an error message in that method if one of the moves is cancelled or done (done here: https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L1898 )

The fix is to only re-reserve moves that are not in those states, since done or cancelled moves should not be re-reserved in any case.
