### PR TITLE
[FIX] faulty filter derived from custom filter

### DIFF
--- a/addons/web_graph/static/src/js/graph_view.js
+++ b/addons/web_graph/static/src/js/graph_view.js
@@ -116,7 +116,9 @@ instance.web_graph.GraphView = instance.web.View.extend({
 
         _.each(searchdata.groupbys, function (data) {
             data = (_.isString(data)) ? py.eval(data) : data;
-            result.group_by = result.group_by.concat(data.group_by);
+            if (!_.isEmpty(data.group_by)) {
+                result.group_by = result.group_by.concat(data.group_by);
+            }
             if (data.col_group_by) {
                 result.col_group_by = result.col_group_by.concat(data.col_group_by);
             }


### PR DESCRIPTION
Before PRing this to odoo, I'd like to ask the community's opinion: The issue is that when you save a filter where no grouping is active, you'll get an empty context in this saved filter. Now select the filter and switch to a graph view, where it will choke because the code below appends an empty object to the `group_by` list.

I have the idea that this might be fixed in https://github.com/OCA/OCB/blob/8.0/addons/web/static/src/js/search.js#L1791 too.

What do you think?
