### PR TITLE
Clean and improve account_payment

### DIFF
--- a/addons/account_payment/wizard/account_payment_populate_statement.py
+++ b/addons/account_payment/wizard/account_payment_populate_statement.py
@@ -31,26 +31,6 @@ class account_payment_populate_statement(osv.osv_memory):
         'lines': fields.many2many('payment.line', 'payment_line_rel_', 'payment_id', 'line_id', 'Payment Lines')
     }
 
-    def fields_view_get(self, cr, uid, view_id=None, view_type='form', context=None, toolbar=False, submenu=False):
-        line_obj = self.pool.get('payment.line')
-
-        res = super(account_payment_populate_statement, self).fields_view_get(cr, uid, view_id=view_id, view_type=view_type, context=context, toolbar=toolbar, submenu=False)
-        line_ids = line_obj.search(cr, uid, [
-            ('move_line_id.reconcile_id', '=', False),
-            ('bank_statement_line_id', '=', False),
-            ('move_line_id.state','=','valid')])
-        line_ids.extend(line_obj.search(cr, uid, [
-            ('move_line_id.reconcile_id', '=', False),
-            ('order_id.mode', '=', False),
-            ('move_line_id.state','=','valid')]))
-        domain = '[("id", "in", '+ str(line_ids)+')]'
-        doc = etree.XML(res['arch'])
-        nodes = doc.xpath("//field[@name='lines']")
-        for node in nodes:
-            node.set('domain', domain)
-        res['arch'] = etree.tostring(doc)
-        return res
-
     def populate_statement(self, cr, uid, ids, context=None):
         line_obj = self.pool.get('payment.line')
         statement_obj = self.pool.get('account.bank.statement')

--- a/addons/account_payment/wizard/account_payment_populate_statement_view.xml
+++ b/addons/account_payment/wizard/account_payment_populate_statement_view.xml
@@ -8,7 +8,7 @@
              <field name="arch" type="xml">
                 <form string="Populate Statement:" version="7.0">
                     <group>
-                        <field name="lines"/>
+                        <field name="lines" domain="['|', ('order_id.mode', '=', False), ('bank_statement_line_id', '=', False), ('ml_reconcile_id', '=', False), ('ml_state', '=', 'valid')]"/>
                     </group>
                     <footer>
                         <button name="populate_statement" string="ADD" type="object" class="oe_highlight"/>


### PR DESCRIPTION
OCA version of https://github.com/odoo/odoo/pull/9654

This PR was, at first, to fix an issue with the old "populate statement with payment lines" wizard. The main issue I got is that the `search()` used "move_line_id.state" and "move_line_id.reconcile_id" as parameters, which meant that if was translated as `AND move_line_id IN (...)` in SQL, with a list of all move lines as a parameter.
However, that meant 2.5 million move lines for our customer ; the wizard crashed with a massive MemoryError.

To fix that, I created 2 new function fields with a store condition, but after seeing 3 existing function fields with no store condition and unclear functions, I decided to create a single multi function to store all 5 related fields. Also, in the wizard, the 2 domains are now regrouped as one, and only set in the XML view (so the `fields_view_get` definition is not useful anymore).

I'm not sure if this PR goes against the stable policy (as it fixes an issue if there are lots of move lines) ; if that is the case, I'll do a separate module instead.
