### PR TITLE
[FIX] fixed exception when searching in task kanban view

### DIFF
--- a/addons/web/static/lib/py.js/lib/py.js
+++ b/addons/web/static/lib/py.js/lib/py.js
@@ -1315,8 +1315,11 @@ var py = {};
         switch (expr.id) {
         case '(name)':
             var val = context[expr.value];
-            if (val === undefined && expr.value in PY_builtins) {
-                return PY_builtins[expr.value];
+            if (val === undefined) {
+                if (expr.value in PY_builtins) {
+                    return PY_builtins[expr.value];
+                }
+                return py.False;
             }
             return PY_ensurepy(val, expr.value);
         case '(string)':


### PR DESCRIPTION
When entering a search term in the search field, in the task's kanban
view, an error message is thrown. This is fixed by letting the
evaluation function in the py.js javascript return false when a value is
undefined (instead of checking it against correctness, as before). The
problem may possibly have been mistake in an if-clause.

This fixes issue #9642 (Exception when searching in Project/Tasks in kanban view)
