### PR TITLE
User-friendly file names when downloading report PDFs

### DIFF
--- a/addons/report/controllers/main.py
+++ b/addons/report/controllers/main.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 from openerp.addons.web.http import Controller, route, request
-from openerp.addons.web.controllers.main import _serialize_exception
+from openerp.addons.web.controllers.main import _serialize_exception, content_disposition
 from openerp.osv import osv
 from openerp.tools import html_escape
 
@@ -119,7 +119,10 @@ class ReportController(Controller):
                     data = url_decode(url.split('?')[1]).items()  # decoding the args represented in JSON
                     response = self.report_routes(reportname, converter='pdf', **dict(data))
 
-                response.headers.add('Content-Disposition', 'attachment; filename=%s.pdf;' % reportname)
+                cr, uid = request.cr, request.uid
+                report = request.registry['report']._get_report_from_name(cr, uid, reportname)
+                filename = "%s.%s" % (report.name, "pdf")
+                response.headers.add('Content-Disposition', content_disposition(filename))
                 response.set_cookie('fileToken', token)
                 return response
             elif type =='controller':

--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -505,8 +505,11 @@ class Report(osv.Model):
         report_obj = self.pool['ir.actions.report.xml']
         qwebtypes = ['qweb-pdf', 'qweb-html']
         conditions = [('report_type', 'in', qwebtypes), ('report_name', '=', report_name)]
-        idreport = report_obj.search(cr, uid, conditions)[0]
-        return report_obj.browse(cr, uid, idreport)
+        # We won't get a context from the controller because the client would have to serialize it in the URL and that would be problematic
+        # We'll just use the user's default context, at least it will yield some language translation
+        context = self.pool['res.users'].context_get(cr, uid)
+        idreport = report_obj.search(cr, uid, conditions, context=context)[0]
+        return report_obj.browse(cr, uid, idreport, context=context)
 
     def _build_wkhtmltopdf_args(self, paperformat, specific_paperformat_args=None):
         """Build arguments understandable by wkhtmltopdf from a report.paperformat record.


### PR DESCRIPTION
In v8 the reports PDF that users download get named after the `Model` they are based on.
This is of little use tu users and looks unprofessional to partners.
This PR makes the file names after the name of the report  record instead (eg. `Sale order / quotation`).

The first commit is a already in v9 at 0399a1a8c293f9ee4ca1159a352a48719117cc89
The second commit is proposed for v9 in https://github.com/odoo/odoo/pull/9697
