### PR TITLE
change widget in sale config view

### DIFF
--- a/addons/sale/res_config_view.xml
+++ b/addons/sale/res_config_view.xml
@@ -34,11 +34,11 @@
                         <label for="id" string="Customer portal"/>
                         <div>
                             <div>
-                                <field name="module_website_portal" class="oe_inline" widget="upgrade_boolean"/>
+                                <field name="module_website_portal" class="oe_inline" />
                                 <label for="module_website_portal"/>
                             </div>
                             <div>
-                                <field name="module_website_sale_digital" class="oe_inline" widget="upgrade_boolean"/>
+                                <field name="module_website_sale_digital" class="oe_inline" />
                                 <label for="module_website_sale_digital"/>
                             </div>
                         </div>


### PR DESCRIPTION
`website_sale_digital` and `website_portal` are in community edition, so use normal boolean
widget instead of upgrade widget.

upstream PR https://github.com/odoo/odoo/pull/9804
