### PR TITLE
stock: fix modification of frozendict in do_enter_transfer_details

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1406,7 +1406,8 @@ class stock_picking(osv.osv):
     def do_enter_transfer_details(self, cr, uid, picking, context=None):
         if not context:
             context = {}
-
+        else:
+            context = context.copy()
         context.update({
             'active_model': self._name,
             'active_ids': picking,


### PR DESCRIPTION
when called with self.with_context with new API code, the code would crash
because context is a frozendict. Copying it before updating fixes the issue

upstream PR odoo#9872
