### PR TITLE
[FIX] use the column._symbol-c as placeholder for the column value

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3908,7 +3908,7 @@ class BaseModel(object):
                 if column._classic_write and not hasattr(column, '_fnct_inv'):
                     if not (has_trans and column.translate and not callable(column.translate)):
                         # vals[field] is not a translation: update the table
-                        updates.append((field, '%s', column._symbol_set[1](vals[field])))
+                        updates.append((field, column._symbol_set[0], column._symbol_set[1](vals[field])))
                     direct.append(field)
                 else:
                     upd_todo.append(field)
@@ -4461,7 +4461,7 @@ class BaseModel(object):
                                 value[v] = value[v][0]
                             except:
                                 pass
-                        updates.append((v, '%s', column._symbol_set[1](value[v])))
+                        updates.append((v, column._symbol_set[0], column._symbol_set[1](value[v])))
                     if updates:
                         query = 'UPDATE "%s" SET %s WHERE id = %%s' % (
                             self._table, ','.join('"%s"=%s' % u[:2] for u in updates),

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -4228,7 +4228,7 @@ class BaseModel(object):
         for field in vals:
             current_field = self._columns[field]
             if current_field._classic_write:
-                updates.append((field, '%s', current_field._symbol_set[1](vals[field])))
+                updates.append((field, current_field._symbol_set[0], current_field._symbol_set[1](vals[field])))
 
                 #for the function fields that receive a value, we set them directly in the database
                 #(they may be required), but we also need to trigger the _fct_inv()


### PR DESCRIPTION
When generating the SQL query in  the low level '_create' method from
BaseModel, column._synbol-c must be used as placeholder as for the
method 'set' of the column itself. Otherwise it's no more possible to define specialized column.

Same patch as https://github.com/OCA/OCB/pull/350 for 9.0
