### PR TITLE
fix wrong sale order shipped computation

### DIFF
--- a/addons/sale_stock/__openerp__.py
+++ b/addons/sale_stock/__openerp__.py
@@ -59,6 +59,7 @@ You can choose flexible invoicing methods:
     'test': [
         'test/sale_stock_users.yml',
         'test/cancel_order_sale_stock.yml',
+        'test/cancel_order_sale_stock2.yml',
         'test/picking_order_policy.yml',
         'test/prepaid_order_policy.yml',
         'test/sale_order_onchange.yml',

--- a/addons/sale_stock/sale_stock.py
+++ b/addons/sale_stock/sale_stock.py
@@ -40,6 +40,9 @@ class sale_order(osv.osv):
     def _get_shipped(self, cr, uid, ids, name, args, context=None):
         res = {}
         for sale in self.browse(cr, uid, ids, context=context):
+            if sale.state == 'shipping_except':
+                res[sale.id] = False
+                continue
             group = sale.procurement_group_id
             if group:
                 res[sale.id] = all([proc.state in ['cancel', 'done'] for proc in group.procurement_ids])
@@ -57,7 +60,7 @@ class sale_order(osv.osv):
     def _get_orders_procurements(self, cr, uid, ids, context=None):
         res = set()
         for proc in self.pool.get('procurement.order').browse(cr, uid, ids, context=context):
-            if proc.state =='done' and proc.sale_line_id:
+            if proc.state in ('cancel', 'done') and proc.sale_line_id:
                 res.add(proc.sale_line_id.order_id.id)
         return list(res)
 
@@ -92,7 +95,8 @@ class sale_order(osv.osv):
             ], 'Create Invoice', required=True, readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
             help="""On demand: A draft invoice can be created from the sales order when needed. \nOn delivery order: A draft invoice can be created from the delivery order when the products have been delivered. \nBefore delivery: A draft invoice is created from the sales order and must be paid before the products can be delivered."""),
         'shipped': fields.function(_get_shipped, string='Delivered', type='boolean', store={
-                'procurement.order': (_get_orders_procurements, ['state'], 10)
+                'procurement.order': (_get_orders_procurements, ['state'], 10),
+                'sale.order': (lambda s, cr, uid, ids, ctx=None: ids, ['state'], 20),
             }),
         'warehouse_id': fields.many2one('stock.warehouse', 'Warehouse', required=True),
         'picking_ids': fields.function(_get_picking_ids, method=True, type='one2many', relation='stock.picking', string='Picking associated to this sale'),

--- a/addons/sale_stock/test/cancel_order_sale_stock.yml
+++ b/addons/sale_stock/test/cancel_order_sale_stock.yml
@@ -57,6 +57,7 @@
 -
   !assert {model: sale.order, id: sale.sale_order_8, string: Sale order should be in shipping exception}:
     - state == "shipping_except"
+    - shipped == False
 -
   Now I regenerate shipment.
 -
@@ -92,3 +93,4 @@
 -
   !assert {model: sale.order, id: sale.sale_order_8, string: Sale order should be In progress state}:
     - state == 'progress'
+    - shipped == False

--- a/addons/sale_stock/test/cancel_order_sale_stock2.yml
+++ b/addons/sale_stock/test/cancel_order_sale_stock2.yml
@@ -1,0 +1,98 @@
+-
+  create a so similar to sale.sale_order_8
+-
+  !record {model: sale.order, id: sale_order_8}:
+     partner_id: base.res_partner_15
+     partner_invoice_id: base.res_partner_address_25
+     partner_shipping_id: base.res_partner_address_25
+     user_id: base.user_demo
+     pricelist_id: product.list0
+     order_policy: manual
+     section_id: sales_team.crm_case_section_1
+     order_line:
+     - name: Laptop Customized
+       product_id: product.product_product_27
+       product_uom_qty: 2
+       product_uos_qty: 2
+       product_uom: product.product_uom_unit
+       price_unit: 3645.00
+     - name: Mouse, Wireless
+       product_id: product.product_product_12
+       product_uom_qty: 2
+       product_uos_qty: 2
+       product_uom: product.product_uom_unit
+       price_unit: 12.50
+-
+  In order to test the cancel sale order with that user which have salesman rights.
+  First I confirm order.
+-
+  !context
+    uid: 'res_sale_stock_salesman'
+-
+  !workflow {model: sale.order, action: order_confirm, ref: sale_order_8}
+-
+  I do a partial delivery order as a stock user.
+-
+  !context
+    uid: 'res_stock_user'
+-
+  !python {model: stock.picking}: |
+    so_name = self.pool['sale.order'].browse(cr, 1, ref('sale_order_8')).name
+    domain = [('origin', '=', so_name)]
+    picks = self.search(cr, uid, domain, context=context)
+    pick = self.browse(cr, uid, picks[-1], context=context)
+    self.pool.get('stock.pack.operation').create(cr, uid, {
+        'picking_id': pick.id,
+        'product_id': ref('product.product_product_27'),
+        'product_uom_id': ref('product.product_uom_unit'),
+        'product_qty': 1,
+        'location_id': pick.location_id.id,
+        'location_dest_id': pick.location_dest_id.id,
+    })
+    pick.do_transfer()
+-
+  I test that I have two pickings, one done and one backorder to do
+-
+  !python {model: stock.picking}: |
+    so_name = self.pool['sale.order'].browse(cr, 1, ref('sale_order_8')).name
+    picks = self.search(cr, uid, [('origin','=',so_name)])
+    print picks
+    assert len(picks)>1, 'Only one picking, partial picking may have failed!'
+    picks = self.search(cr, uid, [('origin','=',so_name), ('state','=','done')])
+    assert len(picks)==1, 'You should have one delivery order which is done!'
+    picks = self.search(cr, uid, [('origin','=',so_name), ('backorder_id','=',picks[0])])
+    assert len(picks)==1, 'You should have one backorder to process!'
+-
+  I cancel the backorder
+-
+  !python {model: stock.picking}: |
+    so_name = self.pool['sale.order'].browse(cr, 1, ref('sale_order_8')).name
+    picks = self.search(cr, uid, [('origin','=',so_name),('backorder_id','<>',False)])
+    self.action_cancel(cr, uid, picks)
+-
+  I run the scheduler.
+-
+  !python {model: procurement.order}: |
+
+     self.run_scheduler(cr, uid)
+-
+  Salesman can also check order therefore test with that user which have salesman rights,
+-
+  !context
+    uid: 'res_sale_stock_salesman'
+-
+  I check order status in "Ship Exception".
+-
+  !assert {model: sale.order, id: sale_order_8, string: Sale order should be in shipping exception}:
+    - state == "shipping_except"
+    - shipped == False
+-
+  Now I say shipping was corrected
+-
+  !workflow {model: sale.order, action: ship_corrected, ref: sale_order_8}
+-
+  I check state of order in 'To Invoice' and SO is shipped
+-
+  !assert {model: sale.order, id: sale_order_8, string: Sale order should be In Progress state}:
+    - state == 'manual'
+    - shipped == True


### PR DESCRIPTION
the trigger does not allow recomputation on procurement cancel -> canceling
some shipping would not recompute shipped. Also take the state of the SO into account
so that the SO is not considered shipped when in state shipping_except.

The idea is that when the SO is not in state shipping_except and all the procurements are either done or cancelled, then the SO must be considered shipped. 

upstream PR: odoo#9953
