### PR TITLE
[FIX] Fix check_xml when inheriting from views created in the same mo…

### DIFF
--- a/openerp/addons/base/base_demo.xml
+++ b/openerp/addons/base/base_demo.xml
@@ -53,5 +53,26 @@ Mr Demo</field>
             <field eval="time.strftime('%Y-06-06')" name="name"/>
         </record>
 
+        <record id="extended_view" model="ir.ui.view">
+            <field name="model">ir.ui.view</field>
+            <field name="inherit_id" ref="view_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="check_xml_bug">not fixed</attribute>
+                </xpath>
+            </field>
+        </record>
+        <record id="bugged_view" model="ir.ui.view">
+            <field name="model">ir.ui.view</field>
+            <field name="mode">primary</field>
+            <field name="inherit_id" ref="extended_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@check_xml_bug='not fixed']" position="attributes">
+                    <attribute name="check_xml_bug">fixed</attribute>
+                </xpath>
+            </field>
+        </record>
+        <delete id="bugged_view" model="ir.ui.view"/>
+        <delete id="extended_view" model="ir.ui.view"/>
     </data>
 </openerp>

--- a/openerp/addons/base/ir/ir_ui_view.py
+++ b/openerp/addons/base/ir/ir_ui_view.py
@@ -509,10 +509,15 @@ class view(osv.osv):
                     requested (similar to ``id``)
         """
         if context is None: context = {}
+        context = context.copy()
 
         # if view_id is not a root view, climb back to the top.
         base = v = self.browse(cr, uid, view_id, context=context)
+        check_view_ids = context.setdefault('check_view_ids', [])
         while v.mode != 'primary':
+            # Add inherited views to the list of loading forced views
+            # Otherwise, inherited views could not find elements created in their direct parents if that parent is defined in the same module
+            check_view_ids.append(v.id)
             v = v.inherit_id
         root_id = v.id
 


### PR DESCRIPTION
…dule

When inheriting from a view in extension mode created in the same module, this
view was not loaded during check_xml of the last view.
This caused an error when the last view wants to modify elements added
by its direct parent view.

Example :
- View1, created in module "account"
- View2, mode extension, created in module "customer", inherits View1
- View3, created in module "customer", inherits View2

During update of module "customer", when loading View3, the check_xml
call didn't load View2, because it's defined in the same module (and,
obviously, this module has not be totally loaded at this point)

This is fixed by adding direct parent of each loaded view in the
check_view_ids list in context, to force them to be loaded.
