### PR TITLE
[FIX] account_move_line _invoice_search not working correctly

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -419,12 +419,12 @@ class account_move_line(osv.osv):
                 else:
                     qu1.append(' (False)')
         if qu1:
-            qu1 = ' AND' + ' AND'.join(qu1)
+            qu1 = ' WHERE' + ' AND'.join(qu1)
         else:
             qu1 = ''
         cursor.execute('SELECT l.id ' \
-                'FROM account_move_line l, account_invoice i ' \
-                'WHERE l.move_id = i.move_id ' + qu1, qu2)
+                'FROM account_move_line l LEFT JOIN account_invoice i ' \
+                'ON l.move_id = i.move_id ' + qu1, qu2)
         res = cursor.fetchall()
         if not res:
             return [('id', '=', '0')]


### PR DESCRIPTION
Using a search function with a domain as follows:
self.env['account.move.line].search([('invoice','=', False)])
always returns a empty list.

Function _invoice_search was prepared to left join but query is built as inner join.
