### PR TITLE
[IMP] Pass 'preserve' option for mail content extraction

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -1267,7 +1267,7 @@ class mail_thread(osv.AbstractModel):
             self.write(cr, uid, ids, update_vals, context=context)
         return True
 
-    def _message_extract_payload(self, message, save_original=False):
+    def _message_extract_payload(self, message, save_original=False, preserve=True):
         """Extract body as HTML and attachments from the mail message"""
         attachments = []
         body = u''
@@ -1286,7 +1286,7 @@ class mail_thread(osv.AbstractModel):
             body = tools.ustr(body, encoding, errors='replace')
             if message.get_content_type() == 'text/plain':
                 # text/plain -> <pre/>
-                body = tools.append_content_to_html(u'', body, preserve=True)
+                body = tools.append_content_to_html(u'', body, preserve=preserve)
         else:
             alternative = False
             mixed = False
@@ -1335,7 +1335,7 @@ class mail_thread(osv.AbstractModel):
                     attachments.append((filename or 'attachment', part.get_payload(decode=True)))
         return body, attachments
 
-    def message_parse(self, cr, uid, message, save_original=False, context=None):
+    def message_parse(self, cr, uid, message, save_original=False, preserve=True, context=None):
         """Parses a string or email.message.Message representing an
            RFC-2822 email, and returns a generic dict holding the
            message details.
@@ -1417,7 +1417,7 @@ class mail_thread(osv.AbstractModel):
             if parent_ids:
                 msg_dict['parent_id'] = parent_ids[0]
 
-        msg_dict['body'], msg_dict['attachments'] = self._message_extract_payload(message, save_original=save_original)
+        msg_dict['body'], msg_dict['attachments'] = self._message_extract_payload(message, save_original=save_original, preserve=preserve)
         return msg_dict
 
     #------------------------------------------------------

--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -1335,7 +1335,7 @@ class mail_thread(osv.AbstractModel):
                     attachments.append((filename or 'attachment', part.get_payload(decode=True)))
         return body, attachments
 
-    def message_parse(self, cr, uid, message, save_original=False, preserve=True, context=None):
+    def message_parse(self, cr, uid, message, save_original=False, context=None, preserve=True):
         """Parses a string or email.message.Message representing an
            RFC-2822 email, and returns a generic dict holding the
            message details.


### PR DESCRIPTION
Pass 'preserve' option for mail content extraction in
mail_thread.message_parse() function down to
tools.mail.append_content_to_html() function via
mail_thread._message_extract_payload() function.

Background is, that we have written our own fetch-mail routine to cache downloaded mail in a custom model. This is useful to defer alias processing. In our setting there is a list of mails like in Thunderbird and you can select the mails you want to import into Odoo models via alias processing. 

For our own fetch-mail routine, of course we try to reuse as much of the core code as possible and thus we call mail_thread.message_parse() function for parsing the downloaded messages. 
However mail_thread.message_parse()  doesn’t allow to specify how to handle plain-text messages although it's subroutines have options for that purpose. Therefore I made these options from subroutines accessible. 
