### PR TITLE
[IMP] Ship with reasonable default thousands separator format

### DIFF
--- a/openerp/addons/base/res/res_lang.py
+++ b/openerp/addons/base/res/res_lang.py
@@ -144,7 +144,7 @@ class lang(osv.osv):
         'direction': 'ltr',
         'date_format':_get_default_date_format,
         'time_format':_get_default_time_format,
-        'grouping': '[]',
+        'grouping': '[3, 0]',
         'decimal_point': '.',
         'thousands_sep': ',',
     }


### PR DESCRIPTION
Same change as PR https://github.com/OCA/OCB/pull/278 (just cherry-picked the commit from OCB/8.0).

This change is considered conceivable for master by Odoo, but will not be merged in 9.0 : https://github.com/odoo/odoo/pull/9829
