### PR TITLE
Pass the context parameter to constraint functions.

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1555,9 +1555,7 @@ class BaseModel(object):
         error_msgs = []
         for constraint in self._constraints:
             fun, msg, fields = constraint
-            # We don't pass around the context here: validation code
-            # must always yield the same results.
-            if not fun(self, cr, uid, ids):
+            if not fun(self, cr, uid, ids, context):
                 # Check presence of __call__ directly instead of using
                 # callable() because it will be deprecated as of Python 3.0
                 if hasattr(msg, '__call__'):


### PR DESCRIPTION
Pass the context parameter when constraint functions are called in order to be able to use context variables for checks.
