### PR TITLE
[FIX] mass_mailing: added missing models in form view

### DIFF
--- a/addons/mass_mailing/views/email_template.xml
+++ b/addons/mass_mailing/views/email_template.xml
@@ -15,7 +15,7 @@
                                 <field name="name" required="True"/>
                                 <field name="model_id" required="1" options="{'no_open': True, 'no_create': True}"
                                     on_change="onchange_model_id(model_id)"
-                                    domain="[('model', 'in', ['res.partner', 'mail.mass_mailing.contact'])]"/>
+                                    domain="[('model', 'in', ['res.partner', 'mail.mass_mailing.contact', 'crm.lead', 'hr.applicant'])]"/>
                                 <field name="model" invisible="True"/>
                                 <field name="use_default_to" invisible="1"/>
                             </group>


### PR DESCRIPTION
As in https://github.com/odoo/odoo/commit/fda5021e6b6b81c1f7d5de60dffc5821e521b484
for 9.0, missing models are here introduced in static domain.

Upstream PR: https://github.com/odoo/odoo/pull/10608
