### PR TITLE
fix context mutations

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -2303,8 +2303,7 @@ class account_model(osv.osv):
         pt_obj = self.pool.get('account.payment.term')
         period_obj = self.pool.get('account.period')
 
-        if context is None:
-            context = {}
+        context = dict(context or {})
 
         if data.get('date', False):
             context = dict(context)

--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -669,8 +669,7 @@ class account_move_line(osv.osv):
 
     #TODO: ONCHANGE_ACCOUNT_ID: set account_tax_id
     def onchange_currency(self, cr, uid, ids, account_id, amount, currency_id, date=False, journal=False, context=None):
-        if context is None:
-            context = {}
+        context = dict(context or {})
         account_obj = self.pool.get('account.account')
         journal_obj = self.pool.get('account.journal')
         currency_obj = self.pool.get('res.currency')
@@ -1087,8 +1086,7 @@ class account_move_line(osv.osv):
         return r_id
 
     def view_header_get(self, cr, user, view_id, view_type, context=None):
-        if context is None:
-            context = {}
+        context = dict(context or {})
         context = self.convert_to_period(cr, user, context=context)
         if context.get('account_id', False):
             cr.execute('SELECT code FROM account_account WHERE id = %s', (context['account_id'], ))

--- a/addons/account/wizard/account_report_general_ledger.py
+++ b/addons/account/wizard/account_report_general_ledger.py
@@ -49,8 +49,7 @@ class account_report_general_ledger(osv.osv_memory):
         return res
 
     def _print_report(self, cr, uid, ids, data, context=None):
-        if context is None:
-            context = {}
+        context = dict(context or {})
         data = self.pre_print_report(cr, uid, ids, data, context=context)
         data['form'].update(self.read(cr, uid, ids, ['landscape',  'initial_balance', 'amount_currency', 'sortby'])[0])
         if not data['form']['fiscalyear_id']:# GTK client problem onchange does not consider in save record

--- a/addons/document/document.py
+++ b/addons/document/document.py
@@ -620,9 +620,8 @@ class node_context(object):
     def __init__(self, cr, uid, context=None):
         self.dbname = cr.dbname
         self.uid = uid
+        context = dict(context or {})
         self.context = context
-        if context is None:
-            context = {}
         context['uid'] = uid
         self._dirobj = openerp.registry(cr.dbname).get('document.directory')
         self.node_file_class = node_file

--- a/addons/l10n_be/wizard/l10n_be_partner_vat_listing.py
+++ b/addons/l10n_be/wizard/l10n_be_partner_vat_listing.py
@@ -45,6 +45,7 @@ class partner_vat(osv.osv_memory):
     _name = "partner.vat"
 
     def get_partner(self, cr, uid, ids, context=None):
+        context = dict(context or {})
         obj_period = self.pool.get('account.period')
         obj_partner = self.pool.get('res.partner')
         obj_vat_lclient = self.pool.get('vat.listing.clients')

--- a/addons/point_of_sale/point_of_sale.py
+++ b/addons/point_of_sale/point_of_sale.py
@@ -442,8 +442,7 @@ class pos_session(osv.osv):
         """
         call the Point Of Sale interface and set the pos.session to 'opened' (in progress)
         """
-        if context is None:
-            context = dict()
+        context = dict(context or {})
 
         if isinstance(ids, (int, long)):
             ids = [ids]
@@ -536,8 +535,7 @@ class pos_session(osv.osv):
         return True
 
     def open_frontend_cb(self, cr, uid, ids, context=None):
-        if not context:
-            context = {}
+        context = dict(context or {})
         if not ids:
             return {}
         for session in self.browse(cr, uid, ids, context=context):


### PR DESCRIPTION
when extending these methods with the new api, the context is a frozendict
so we need to copy before mutating.

this patch was made by searching for key addition to context and calls to the
update() method on the 8.0 addons, and checking if a copy was made before in
the method.
