### PR TITLE
Fix kanban css - since firefox and chromium update

### DIFF
--- a/addons/web_kanban/static/src/css/kanban.css
+++ b/addons/web_kanban/static/src/css/kanban.css
@@ -162,7 +162,6 @@
   color: #666666;
 }
 .openerp .oe_kanban_view .oe_kanban_group_title_vertical {
-  writing-mode: tb-rl;
   -webkit-transform: rotate(90deg);
   -moz-transform: rotate(90deg);
   -o-transform: rotate(90deg);


### PR DESCRIPTION
With Firefox 44.0 & Chromium 48.0.2564.82 (latest versions), in Kanban view vertical labels are horizontal and written from right to left.
Steps to reproduce:
- have the latests versions of firefox or chromium
- open a Kanban view like "project -> issue"
- and you see the labels that are not in the good position

The css rules are writing the text vertically (top->bottom) and then make a 90 degrees rotation. This has been corrected in odoo v8. The PR is based on the odoo v8 css rule.
A PR has been done in odoo/odoo https://github.com/odoo/odoo/pull/10687

You can see the bug on runbot

With the error
![screenshot from 2016-01-29 14 22 55](https://cloud.githubusercontent.com/assets/3664638/12676815/145bb09c-c695-11e5-9e29-c351145dc3bd.png)
Once fixed
![screenshot from 2016-01-29 14 23 38](https://cloud.githubusercontent.com/assets/3664638/12676816/171d3b8e-c695-11e5-8a3f-16964d7fb91b.png)
