### PR TITLE
[8.0][FIX] Make on_change in address_format divs work

### DIFF
--- a/openerp/addons/base/res/res_partner.py
+++ b/openerp/addons/base/res/res_partner.py
@@ -67,10 +67,12 @@ class format_address(object):
                 doc = etree.fromstring(arch)
                 for node in doc.xpath("//div[@class='address_format']"):
                     tree = etree.fromstring(v % {'city': _('City'), 'zip': _('ZIP'), 'state': _('State')})
-                    for child in node.xpath("//field"):
-                        if child.attrib.get('modifiers'):
-                            for field in tree.xpath("//field[@name='%s']" % child.attrib.get('name')):
+                    for child in node.xpath(".//field"):
+                        for field in tree.xpath("//field[@name='%s']" % child.attrib.get("name")):
+                            if child.attrib.get("modifiers"):
                                 field.attrib['modifiers'] = child.attrib.get('modifiers')
+                            if child.attrib.get("on_change"):
+                                field.attrib["on_change"] = child.attrib.get("on_change")
                     node.getparent().replace(node, tree)
                 arch = etree.tostring(doc)
                 break


### PR DESCRIPTION
Here I open https://github.com/odoo/odoo/pull/10620 due to being long ignored there. I hope they merge but whatever.

To reproduce the bug:
- Create a partner.
- Set it state "Alaska".
- Country becomes "United States".
- Set a country for YourCompany, such as Spain.
- Create a partner.
- Set it state "Alaska".
- Country remains blank.

Also, `node.xpath("//field")` was running over every `<field>` in the
view, not just those inside the `<div class="address_format">`. Now it
only traverses the right nodes, which renders every affected view
faster.

@rafaelbn 
