### PR TITLE
auth_ldap: encode the filter in utf-8

### DIFF
--- a/addons/auth_ldap/users_ldap.py
+++ b/addons/auth_ldap/users_ldap.py
@@ -102,7 +102,7 @@ class CompanyLDAP(osv.osv):
             _logger.warning('Could not format LDAP filter. Your filter should contain one \'%s\'.')
             return False
         try:
-            results = self.query(conf, filter)
+            results = self.query(conf, filter.encode('utf-8'))
 
             # Get rid of (None, attrs) for searchResultReference replies
             results = [i for i in results if i[0]]


### PR DESCRIPTION
This prevents a UnicodeDecode error in python-ldap when the
filter contains non ascii characters.
