### PR TITLE
[FIX][8.0] report: Company name space wider in report header

### DIFF
--- a/addons/report/views/layouts.xml
+++ b/addons/report/views/layouts.xml
@@ -78,7 +78,9 @@
             <div class="col-xs-5">
                 <div t-field="company.partner_id" 
                     t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
-                    style="border-bottom: 1px solid black;"/>
+                    style="border-bottom: 1px solid black;"
+                    class="pull-left"
+                />
             </div>
         </div>
     </div>

--- a/addons/report/views/layouts.xml
+++ b/addons/report/views/layouts.xml
@@ -75,7 +75,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-xs-3">
+            <div class="col-xs-5">
                 <div t-field="company.partner_id" 
                     t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
                     style="border-bottom: 1px solid black;"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When a company has a longer name or longer address the space into header report is very strait
This PR is: https://github.com/odoo/odoo/pull/11031
Current behavior before PR:
![bded2e58-d72d-11e5-9899-09b7636524bc](https://cloud.githubusercontent.com/assets/7689807/13201966/2acd0fe2-d888-11e5-94cc-e90601ca8cbc.jpg)

Desired behavior after PR is merged:
![d35bc0f6-d72d-11e5-8611-6c499bdc2cd0](https://cloud.githubusercontent.com/assets/7689807/13201970/38cbdd26-d888-11e5-9ccb-835cc2376642.jpg)
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
