### PR TITLE
[8.0][FIX][base_vat] Support VAT from Switzerland like CHE-###.###.###

### DIFF
--- a/addons/base_vat/base_vat.py
+++ b/addons/base_vat/base_vat.py
@@ -161,7 +161,7 @@ class res_partner(osv.osv):
 
 
     __check_vat_ch_re1 = re.compile(r'(MWST|TVA|IVA)[0-9]{6}$')
-    __check_vat_ch_re2 = re.compile(r'E([0-9]{9}|-[0-9]{3}\.[0-9]{3}\.[0-9]{3})(MWST|TVA|IVA)$')
+    __check_vat_ch_re2 = re.compile(r'E([0-9]{9}|-[0-9]{3}\.[0-9]{3}\.[0-9]{3})(MWST|TVA|IVA)?$')
 
     def check_vat_ch(self, vat):
         '''
@@ -180,9 +180,11 @@ class res_partner(osv.osv):
         #     CHE#########MWST
         #     CHE#########TVA
         #     CHE#########IVA
+        #     CHE#########
         #     CHE-###.###.### MWST
         #     CHE-###.###.### TVA
         #     CHE-###.###.### IVA
+        #     CHE-###.###.###
         #     
         if self.__check_vat_ch_re1.match(vat):
             return True


### PR DESCRIPTION
See https://github.com/odoo/odoo/pull/11108

Description of the issue/feature this PR addresses:
- Switzerland VAT format would not have MWST/TVA/IVA suffix

Current behavior before PR:
- MWST/TVA/IVA suffix is mandatory

Desired behavior after PR is merged:
- MWST/TVA/IVA suffix is optional
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
