### PR TITLE
[FIX] website_portal_sale: Order list indicates "Invoiced" state when…

### DIFF
--- a/addons/website_portal_sale/i18n/af.po
+++ b/addons/website_portal_sale/i18n/af.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/ar.po
+++ b/addons/website_portal_sale/i18n/ar.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/bg.po
+++ b/addons/website_portal_sale/i18n/bg.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/bs.po
+++ b/addons/website_portal_sale/i18n/bs.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/ca.po
+++ b/addons/website_portal_sale/i18n/ca.po
@@ -69,8 +69,8 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr ""
+"In preparation</span>"
+msgstr "En preparació"
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/cs.po
+++ b/addons/website_portal_sale/i18n/cs.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/da.po
+++ b/addons/website_portal_sale/i18n/da.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/de.po
+++ b/addons/website_portal_sale/i18n/de.po
@@ -71,8 +71,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Abgerechnet</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/el.po
+++ b/addons/website_portal_sale/i18n/el.po
@@ -70,7 +70,7 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/en_GB.po
+++ b/addons/website_portal_sale/i18n/en_GB.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es.po
+++ b/addons/website_portal_sale/i18n/es.po
@@ -71,8 +71,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/>Facturado</span>"
+"In preparation</span>"
+msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/>En preparación</span>"
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/es_AR.po
+++ b/addons/website_portal_sale/i18n/es_AR.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_BO.po
+++ b/addons/website_portal_sale/i18n/es_BO.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_CL.po
+++ b/addons/website_portal_sale/i18n/es_CL.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_CO.po
+++ b/addons/website_portal_sale/i18n/es_CO.po
@@ -70,8 +70,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Facturada</span>"
+"In preparation</span>"
+msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> En preparación</span>"
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/es_CR.po
+++ b/addons/website_portal_sale/i18n/es_CR.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_DO.po
+++ b/addons/website_portal_sale/i18n/es_DO.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_EC.po
+++ b/addons/website_portal_sale/i18n/es_EC.po
@@ -72,8 +72,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/>Facturado</span>"
+"In preparation</span>"
+msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/>En preparación</span>"
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/es_MX.po
+++ b/addons/website_portal_sale/i18n/es_MX.po
@@ -70,7 +70,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_PE.po
+++ b/addons/website_portal_sale/i18n/es_PE.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_PY.po
+++ b/addons/website_portal_sale/i18n/es_PY.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/es_VE.po
+++ b/addons/website_portal_sale/i18n/es_VE.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/et.po
+++ b/addons/website_portal_sale/i18n/et.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/eu.po
+++ b/addons/website_portal_sale/i18n/eu.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/fa.po
+++ b/addons/website_portal_sale/i18n/fa.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/fi.po
+++ b/addons/website_portal_sale/i18n/fi.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/fo.po
+++ b/addons/website_portal_sale/i18n/fo.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/fr.po
+++ b/addons/website_portal_sale/i18n/fr.po
@@ -72,8 +72,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Facturées</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/gl.po
+++ b/addons/website_portal_sale/i18n/gl.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/he.po
+++ b/addons/website_portal_sale/i18n/he.po
@@ -70,7 +70,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/hr.po
+++ b/addons/website_portal_sale/i18n/hr.po
@@ -70,8 +70,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Izdani računi</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/hu.po
+++ b/addons/website_portal_sale/i18n/hu.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/id.po
+++ b/addons/website_portal_sale/i18n/id.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/it.po
+++ b/addons/website_portal_sale/i18n/it.po
@@ -71,8 +71,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Fatturato</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/ja.po
+++ b/addons/website_portal_sale/i18n/ja.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/kab.po
+++ b/addons/website_portal_sale/i18n/kab.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/ko.po
+++ b/addons/website_portal_sale/i18n/ko.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/lt.po
+++ b/addons/website_portal_sale/i18n/lt.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/lv.po
+++ b/addons/website_portal_sale/i18n/lv.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/mk.po
+++ b/addons/website_portal_sale/i18n/mk.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/mn.po
+++ b/addons/website_portal_sale/i18n/mn.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/nb.po
+++ b/addons/website_portal_sale/i18n/nb.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/nl.po
+++ b/addons/website_portal_sale/i18n/nl.po
@@ -70,8 +70,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Gefactureerd</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/nl_BE.po
+++ b/addons/website_portal_sale/i18n/nl_BE.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/pl.po
+++ b/addons/website_portal_sale/i18n/pl.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/pt.po
+++ b/addons/website_portal_sale/i18n/pt.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/pt_BR.po
+++ b/addons/website_portal_sale/i18n/pt_BR.po
@@ -72,8 +72,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Faturado</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/ro.po
+++ b/addons/website_portal_sale/i18n/ro.po
@@ -70,7 +70,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/ru.po
+++ b/addons/website_portal_sale/i18n/ru.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/sk.po
+++ b/addons/website_portal_sale/i18n/sk.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/sl.po
+++ b/addons/website_portal_sale/i18n/sl.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/sr.po
+++ b/addons/website_portal_sale/i18n/sr.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/sr@latin.po
+++ b/addons/website_portal_sale/i18n/sr@latin.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/sv.po
+++ b/addons/website_portal_sale/i18n/sv.po
@@ -70,7 +70,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/th.po
+++ b/addons/website_portal_sale/i18n/th.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/tr.po
+++ b/addons/website_portal_sale/i18n/tr.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/uk.po
+++ b/addons/website_portal_sale/i18n/uk.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/vi.po
+++ b/addons/website_portal_sale/i18n/vi.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/website_portal_sale.pot
+++ b/addons/website_portal_sale/i18n/website_portal_sale.pot
@@ -53,7 +53,7 @@ msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
-msgid "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> Invoiced</span>"
+msgid "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/i18n/zh_CN.po
+++ b/addons/website_portal_sale/i18n/zh_CN.po
@@ -74,8 +74,8 @@ msgstr "<span class=\"label label-info orders_label_text_align\"><i class=\"fa f
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
-msgstr "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> 已开票</span>"
+"In preparation</span>"
+msgstr ""
 
 #. module: website_portal_sale
 #: model:ir.ui.view,arch_db:website_portal_sale.invoices

--- a/addons/website_portal_sale/i18n/zh_TW.po
+++ b/addons/website_portal_sale/i18n/zh_TW.po
@@ -69,7 +69,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:website_portal_sale.sale_orders
 msgid ""
 "<span class=\"label label-info\"><i class=\"fa fa-fw fa-clock-o\"/> "
-"Invoiced</span>"
+"In preparation</span>"
 msgstr ""
 
 #. module: website_portal_sale

--- a/addons/website_portal_sale/views/templates.xml
+++ b/addons/website_portal_sale/views/templates.xml
@@ -77,7 +77,7 @@
                         <td><span t-field="order.date_order"/></td>
                         <td>
                             <t t-if="order.state == 'progress'">
-                                <span class="label label-info"><i class="fa fa-fw fa-clock-o"/> Invoiced</span>
+                                <span class="label label-info"><i class="fa fa-fw fa-clock-o"/> In preparation</span>
                             </t>
                             <t t-if="order.state in ['shipping_except','invoice_except']">
                                 <span class="label label-danger"><i class="fa fa-fw fa-warning"/> Problem</span>


### PR DESCRIPTION
… order is "In progress" and not necessarily invoiced yet

**Description of the issue/feature this PR addresses:** Order list indicates "Invoiced" state when order is "In progress" and not necessarily invoiced yet.

**Current behavior before PR:** Order line shows "Invoiced" when order has just been created and it's in "progress" state.

**Desired behavior after PR is merged:** Order shows "In preparation" to inform the user his/her order has been received and it's being taken care.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Eric
