### PR TITLE
[8.0][FIX][delivery] Calculate delivery product purchase price using grid

### DIFF
--- a/addons/delivery/delivery.py
+++ b/addons/delivery/delivery.py
@@ -203,6 +203,31 @@ class delivery_grid(osv.osv):
     }
     _order = 'sequence'
 
+    def get_cost(self, cr, uid, id, order, dt, context=None):
+        total = 0
+        weight = 0
+        volume = 0
+        quantity = 0
+        total_delivery = 0.0
+        product_uom_obj = self.pool.get('product.uom')
+        for line in order.order_line:
+            if line.state == 'cancel':
+                continue
+            if line.is_delivery:
+                total_delivery += line.price_subtotal + self.pool['sale.order']._amount_line_tax(cr, uid, line, context=context)
+            if not line.product_id or line.is_delivery:
+                continue
+            q = product_uom_obj._compute_qty(cr, uid, line.product_uom.id, line.product_uom_qty, line.product_id.uom_id.id)
+            weight += (line.product_id.weight or 0.0) * q
+            volume += (line.product_id.volume or 0.0) * q
+            quantity += q
+        total = (order.amount_total or 0.0) - total_delivery
+
+        ctx = context.copy()
+        ctx['date'] = order.date_order
+        total = self.pool['res.currency'].compute(cr, uid, order.currency_id.id, order.company_id.currency_id.id, total, context=ctx)
+        return self.get_cost_from_picking(cr, uid, id, total,weight, volume, quantity, context=context)
+
     def get_price(self, cr, uid, id, order, dt, context=None):
         total = 0
         weight = 0
@@ -227,6 +252,24 @@ class delivery_grid(osv.osv):
         ctx['date'] = order.date_order
         total = self.pool['res.currency'].compute(cr, uid, order.currency_id.id, order.company_id.currency_id.id, total, context=ctx)
         return self.get_price_from_picking(cr, uid, id, total,weight, volume, quantity, context=context)
+
+    def get_cost_from_picking(self, cr, uid, id, total, weight, volume, quantity, context=None):
+        grid = self.browse(cr, uid, id, context=context)
+        cost = 0.0
+        ok = False
+        price_dict = {'price': total, 'volume':volume, 'weight': weight, 'wv':volume*weight, 'quantity': quantity}
+        for line in grid.line_ids:
+            test = eval(line.type+line.operator+str(line.max_value), price_dict)
+            if test:
+                if line.price_type=='variable':
+                    cost = line.standard_price * price_dict[line.variable_factor]
+                else:
+                    cost = line.standard_price
+                ok = True
+                break
+        if not ok:
+            raise osv.except_osv(_("Unable to fetch delivery method!"), _("Selected product in the delivery method doesn't fulfill any of the delivery grid(s) criteria."))
+        return cost
 
     def get_price_from_picking(self, cr, uid, id, total, weight, volume, quantity, context=None):
         grid = self.browse(cr, uid, id, context=context)

--- a/addons/delivery/sale.py
+++ b/addons/delivery/sale.py
@@ -98,7 +98,11 @@ class sale_order(osv.Model):
                                              qty=values['product_uom_qty'], uom=False, qty_uos=0, uos=False, name='', partner_id=order.partner_id.id,
                                              lang=False, update_tax=True, date_order=False, packaging=False, fiscal_position=False, flag=False, context=None)
             if res['value'].get('purchase_price'):
-                values['purchase_price'] = res['value'].get('purchase_price')
+                cost = grid_obj.get_cost(cr, uid, grid.id, order, time.strftime('%Y-%m-%d'), context)
+                if cost and order.company_id.currency_id.id != order.pricelist_id.currency_id.id:
+                    cost = currency_obj.compute(cr, uid, order.company_id.currency_id.id, order.pricelist_id.currency_id.id,
+                        cost, context=dict(context or {}, date=order.date_order))
+                values['purchase_price'] = cost or res['value'].get('purchase_price')
             if order.order_line:
                 values['sequence'] = order.order_line[-1].sequence + 1
             line_id = line_obj.create(cr, uid, values, context=context)


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/11246

Description of the issue/feature this PR addresses:
- When adding a delivery product to sale.order, purchase price is copied from associated product standard price. But user expect to see purchase price (cost) computed using the same delivery grid used to calculate sale price
- You need `delivery` and `sale_margin` addons installed to reproduce this issue

Current behavior before PR:
- Purchase price of delivery product is copied from product.standard_price

Desired behavior after PR is merged:
- Purchase price is calculated using the same grid used to calculate delivery sale price 
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
