### PR TITLE
[BACKPORT] add embed_company_logo function in report_webkit module

### DIFF
--- a/addons/report_webkit/report_helper.py
+++ b/addons/report_webkit/report_helper.py
@@ -42,6 +42,7 @@ class WebKitHelper(object):
         self.uid = uid
         self.pool = pooler.get_pool(self.cursor.dbname)
         self.report_id = report_id
+        self.context = context
 
     def embed_image(self, type, img, width=0, height=0, unit="px"):
         "Transform a DB image into an embedded HTML image"

--- a/addons/report_webkit/report_helper.py
+++ b/addons/report_webkit/report_helper.py
@@ -89,5 +89,10 @@ class WebKitHelper(object):
         img, type = self.get_logo_by_name(name, company_id=company_id)
         return self.embed_image(type, img, width, height, unit)
         
+    def embed_company_logo(self, width=0, height=0):
+        cr, uid, context = self.cursor, self.uid, self.context
+        my_user = self.pool.get('res.users').browse(cr, uid, uid, context=context)
+        logo = my_user.company_id.logo_web
+        return self.embed_image("png", logo, width, height)
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR backport from v8 embed_company_logo() function in report_webkit module. This function is usefull to company logo in report.

Current behavior before PR:
unable to use default data of base_header_webkit because this PR (https://github.com/OCA/webkit-tools/pull/11) call an undefined function.

Desired behavior after PR is merged:
Fix the described bug.
