### PR TITLE
[FIX] product: Pricelist based on supplier prices (2)

### DIFF
--- a/addons/product/pricelist.py
+++ b/addons/product/pricelist.py
@@ -313,7 +313,10 @@ class product_pricelist(osv.osv):
                             continue
                         seller = seller_id
                     if not seller:
-                        continue
+                        if pricelist.type == 'purchase':
+                            continue
+                        elif product.seller_ids:
+                            seller = product.seller_ids[0]
                     if seller:
                         qty_in_seller_uom = qty
                         seller_uom = seller.product_uom.id


### PR DESCRIPTION
You can base both supplier and customer pricelists on supplier info prices. 

For supplier pricelists, the existing patch introduced in https://github.com/OCA/OCB/pull/165 is perfectly valid.

But for customer pricelists, this patch prevents the use of variable standard price based on the supplier info records. This patch covers both possibilities.

Fixes https://github.com/odoo/odoo/issues/4506 without side effects
