### PR TITLE
[FIX] try to focus/select any input found

### DIFF
--- a/addons/web/static/src/js/view_list_editable.js
+++ b/addons/web/static/src/js/view_list_editable.js
@@ -259,14 +259,15 @@ openerp.web.list_editable = function (instance) {
                         }
                         if (focus_field  && fields[focus_field]){
                             var input = fields[focus_field].$el.find('input');
-                            if(input[0]){
+                            input.each(function(){
+                                var input = jQuery(this);
                                 if(input[0].type === 'text' ||
                                    input[0].type === 'textarea'){
                                     input[0].select();
                                 }else{
                                     input[0].focus();
                                 }
-                           }
+                           });
                         }
                         return record.attributes;
                     });


### PR DESCRIPTION
Description of the issue/feature this PR addresses: focusing doesn't work for compound widgets like the date widget.

Current behavior before PR: when you create a new line in an editable tree view and the first line is a date field, it is not focused. A good model to reproduce this is bank statements

Desired behavior after PR is merged: date fields are focused when a new line is created in an editable list.

This is an OCA regression introduced by #345, no upstream PR as this was never merged there
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
