### PR TITLE
8.0 FIX Wrong taxes and account when partner has a FP, but FP=false on SO

### DIFF
--- a/addons/account_asset/account_asset_view.xml
+++ b/addons/account_asset/account_asset_view.xml
@@ -161,7 +161,7 @@
                                     </group>
                                 </form>
                             </field>
-                            <button type="object" name="compute_depreciation_board" string="Compute" icon="terp-stock_format-scientific" colspan="2" attrs="{'invisible':[('state','=','close')]}"/>
+                            <button type="object" name="compute_depreciation_board" string="Compute" icon="terp-stock_format-scientific" colspan="2" invisible="1"/>
                         </page>
                         <page string="History">
                             <field name="account_move_line_ids" readonly="1"/>

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -1140,9 +1140,7 @@ class sale_order_line(osv.osv):
                 uos = False
 
         fpos = False
-        if not fiscal_position:
-            fpos = partner.property_account_position or False
-        else:
+        if fiscal_position:
             fpos = self.pool.get('account.fiscal.position').browse(cr, uid, fiscal_position)
 
         if uid == SUPERUSER_ID and context.get('company_id'):

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -150,7 +150,7 @@ class sale_advance_payment_inv(osv.osv_memory):
                 'currency_id': sale.pricelist_id.currency_id.id,
                 'comment': sale.note,
                 'payment_term': sale.payment_term.id,
-                'fiscal_position': sale.fiscal_position.id or sale.partner_id.property_account_position.id,
+                'fiscal_position': sale.fiscal_position.id,
                 'section_id': sale.section_id.id,
             }
             result.append((sale.id, inv_values))

--- a/addons/stock_account/stock.py
+++ b/addons/stock_account/stock.py
@@ -132,9 +132,10 @@ class stock_move(osv.osv):
         return move_line.product_id.lst_price
 
     def _get_invoice_line_vals(self, cr, uid, move, partner, inv_type, context=None):
+        if context is None:
+            context = {}
         fp_obj = self.pool.get('account.fiscal.position')
         # Get account_id
-        fp = fp_obj.browse(cr, uid, context.get('fp_id')) if context.get('fp_id') else False
         name = False
         if inv_type in ('out_invoice', 'out_refund'):
             account_id = move.product_id.property_account_income.id
@@ -146,7 +147,10 @@ class stock_move(osv.osv):
             account_id = move.product_id.property_account_expense.id
             if not account_id:
                 account_id = move.product_id.categ_id.property_account_expense_categ.id
-        fiscal_position = fp or partner.property_account_position
+        if 'fp_id' in context:
+            fiscal_position = fp_obj.browse(cr, uid, context['fp_id']) if context['fp_id'] else False
+        else:
+            fiscal_position = partner.property_account_position
         account_id = fp_obj.map_account(cr, uid, fiscal_position, account_id)
 
         # set UoS if it's a sale and the picking doesn't have one


### PR DESCRIPTION
The related PR on Odoo with a detailed explaination is available here:

https://github.com/odoo/odoo/pull/11409

One of my French users found this bug with the following scenario: one of his regular customers based in Algeria took the opportunity of a trip in France to come to the factory in France and order some good on site ; as it is a "local" order, we have to invoice with VAT.

This is a important bug because it has an impact on accounting (wrong account selected).
