### PR TITLE
[IMP] api: in todo list, group records to recompute by environment

### DIFF
--- a/openerp/api.py
+++ b/openerp/api.py
@@ -892,7 +892,8 @@ class Environment(object):
             with all records to recompute for ``field``.
         """
         if field in self.all.todo:
-            return reduce(operator.or_, self.all.todo[field])
+            ids = set(rid for recs in self.all.todo[field] for rid in recs.ids)
+            return self[field.model_name].browse(ids)
 
     def check_todo(self, field, record):
         """ Check whether ``field`` must be recomputed on ``record``, and if so,
@@ -905,7 +906,12 @@ class Environment(object):
     def add_todo(self, field, records):
         """ Mark ``field`` to be recomputed on ``records``. """
         recs_list = self.all.todo.setdefault(field, [])
-        recs_list.append(records)
+        for i, recs in enumerate(recs_list):
+            if recs.env == records.env:
+                recs_list[i] |= records
+                break
+        else:
+            recs_list.append(records)
 
     def remove_todo(self, field, records):
         """ Mark ``field`` as recomputed on ``records``. """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

api.Environment.field_todo() in 8.0 is terribly slow when many records have to
be recomputed.

upstream PR https://github.com/odoo/odoo/pull/11267 thanks to @rmoehn
## Current behavior before PR:

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

The effect of this change is to trigger the recomputation of fields on larger
recordsets.  This takes advantage of batch computations within compute methods.
