### PR TITLE
[FIX] support psutils >= 4.0

### DIFF
--- a/openerp/service/server.py
+++ b/openerp/service/server.py
@@ -47,7 +47,8 @@ SLEEP_INTERVAL = 60     # 1 min
 def memory_info(process):
     """ psutil < 2.0 does not have memory_info, >= 3.0 does not have
     get_memory_info """
-    return (getattr(process, 'memory_info', None) or process.get_memory_info)()
+    pmem = (getattr(process, 'memory_info', None) or process.get_memory_info)()
+    return (pmem.rss, pmem.vms)
 
 #----------------------------------------------------------
 # Werkzeug WSGI servers patched


### PR DESCRIPTION
Upstream PR:
https://github.com/odoo/odoo/pull/11459

Description of the issue/feature this PR addresses:
#11052

Current behavior before PR:
Odoo loops with this error message when setting workers to a value greater than 1:

> Expected behavior:ERROR ? openerp.service.server: Worker (6275) Exception occured, exiting...
> Traceback (most recent call last):
> File "/home/odoo/odoo_alive/odoo/openerp/service/server.py", line 708, in run
> self.process_limit()
> File "/home/odoo/odoo_alive/odoo/openerp/service/server.py", line 663, in process_limit
> rss, vms = memory_info(psutil.Process(os.getpid()))
> ValueError: too many values to unpack

Desired behavior after PR is merged:
Workers are spawned without error
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
