### PR TITLE
[9.0] only run postinstall tests for updated modules (updated)

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -415,8 +415,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         t0 = time.time()
         t0_sql = openerp.sql_db.sql_counter
         if openerp.tools.config['test_enable']:
-            if update_module and mods:
-                cr.execute("SELECT name FROM ir_module_module WHERE state='installed' and name in %s", (tuple(mods),))
+            if update_module:
+                cr.execute("SELECT name FROM ir_module_module WHERE state='installed' and name = ANY(%s)", (mods,))
             else:
                 cr.execute("SELECT name FROM ir_module_module WHERE state='installed'")
             for module_name in cr.fetchall():


### PR DESCRIPTION
Updated the code to follow improvement made in odoo#11378 suggested by odony.

Merging this should avoid a conflict if the updated patch is merged upstream.
