### PR TITLE
[8.0][FIX][mrp] On production qty change wizard also change UoS qty

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -72,7 +72,11 @@ class change_production_qty(osv.osv_memory):
         uom_obj = self.pool.get('product.uom')
         for wiz_qty in self.browse(cr, uid, ids, context=context):
             prod = prod_obj.browse(cr, uid, record_id, context=context)
-            prod_obj.write(cr, uid, [prod.id], {'product_qty': wiz_qty.product_qty})
+            data = {'product_qty': wiz_qty.product_qty}
+            if prod.product_uos.id:
+                data['product_uos_qty'] = uom_obj._compute_qty(
+                    cr, uid, prod.product_uom.id, wiz_qty.product_qty, prod.product_uos.id)
+            prod_obj.write(cr, uid, [prod.id], data)
             prod_obj.action_compute(cr, uid, [prod.id])
 
             for move in prod.move_lines:
@@ -95,7 +99,11 @@ class change_production_qty(osv.osv_memory):
                     if r['product_id'] == move.product_id.id:
                         move_obj.write(cr, uid, [move.id], {'product_uom_qty': r['product_qty']})
             if prod.move_prod_id:
-                move_obj.write(cr, uid, [prod.move_prod_id.id], {'product_uom_qty' :  wiz_qty.product_qty})
+                data = {'product_uom_qty': wiz_qty.product_qty}
+                if prod.move_prod_id.product_uos.id:
+                    data['product_uos_qty'] = uom_obj._compute_qty(
+                        cr, uid, prod.move_prod_id.product_uom.id, wiz_qty.product_qty, prod.move_prod_id.product_uos.id)
+                move_obj.write(cr, uid, [prod.move_prod_id.id], data)
             self._update_product_to_produce(cr, uid, prod, wiz_qty.product_qty, context=context)
         return {}
 


### PR DESCRIPTION
**When changing production qty using wizard only UoM qty changes, not UoS qty**

Impacted versions:
- 8.0

Steps to reproduce:
1. Define a product to be manufacture, like 'PC Assemble + Custom (PC on Demand)'
2. Create a new sale order
3. Add a line with product 'PC Assemble + Custom (PC on Demand)', quantity 15, unit price 1000
4. Validate the sale order
5. Goes to manufacture order automatically created
6. Edit manufacture order and change production Qty to 18
7. Check availability or Force reservation
8. Produce and confirm qty 18
9. Goes to delivery order, now is ready to tranfer
10. Transfer and confirm qty 18
11. Edit and set 'Invoice Control' as 'To be invoiced'
12. Create invoice

Current behavior:
- Qty is 15
- Unit price is 1200

Expected behavior:
- Qty is 18
- Unit price is 1000

Fix description

When changing production qty, wizard is only considering manufacture orders with no UoS defined. But when a manufacture order is created by a sale order UoS is defined, even if it is equal to UoM. So, wizard must change UoS qty also, applying conversion factor between UoM and UoS. UoS is taken into account (instead of UoM) when the invoice is created from delivery order (related to original sale order and manufacture order).

Odoo PR: https://github.com/odoo/odoo/pull/11592
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
