### PR TITLE
Test running fix: port odoo/pull/11378 to OCB/9.0

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -415,8 +415,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         t0 = time.time()
         t0_sql = openerp.sql_db.sql_counter
         if openerp.tools.config['test_enable']:
-            if update_module and mods:
-                cr.execute("SELECT name FROM ir_module_module WHERE state='installed' and name in %s", (tuple(mods),))
+            if update_module:
+                cr.execute("SELECT name FROM ir_module_module WHERE state='installed' and name = ANY(%s)", (processed_modules,))
             else:
                 cr.execute("SELECT name FROM ir_module_module WHERE state='installed'")
             for module_name in cr.fetchall():


### PR DESCRIPTION
the version in OCB is different from the one which will be
forward ported to odoo/9.0. This PR is here to proactively prevent a merge
conflict.
