### PR TITLE
[FIX] Replace PIL by pillow.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def py2exe_options():
                         'mock',
                         'openerp',
                         'openid',
-                        'PIL',
+                        'pillow',
                         'poplib',
                         'psutil',
                         'python-chart',
@@ -125,7 +125,7 @@ setup(
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'mako',
         'mock',
-        'PIL', # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
+        'pillow', # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list
         'psycopg2 >= 2.2',
         'python-chart',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Use of PIL library, instead of pillow, is deprecated and leads to failure when installing odoo through buildout

Current behavior before PR:

Buildout fails with message: 
Getting distribution for 'PIL'.
anybox.recipe.odoo.base: Could not find or install 'PIL'. You don't need to require it for Odoo any more, since the recipe automatically adds a dependency to Pillow. If you really need it for other reasons, installing it system-wide is a good option.  Original exception zc.buildout.easy_install.MissingDistribution says: Couldn't find a distribution for 'PIL'.
While:
  Installing odoo.
Error: Couldn't find a distribution for 'PIL'.

Desired behavior after PR is merged:

Buildout succeeds.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
