### PR TITLE
[FIX] support psutils >= 4.0.

### DIFF
--- a/openerp/netsvc.py
+++ b/openerp/netsvc.py
@@ -51,7 +51,8 @@ _logger = logging.getLogger(__name__)
 def memory_info(process):
     """ psutil < 2.0 does not have memory_info, >= 3.0 does not have
     get_memory_info """
-    return (getattr(process, 'memory_info', None) or process.get_memory_info)()
+    pmem = (getattr(process, 'memory_info', None) or process.get_memory_info)()
+    return (pmem.rss, pmem.vms)
 
 
 def close_socket(sock):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Odoo does not run in virtual env due to incompatible psutils.

Current behavior before PR:
Server does not start properly, unless workers=0

Desired behavior after PR is merged:
## Server starts properly. No matter the value for option workers.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

backport of 8.0 fix created by stephen144.
