### PR TITLE
[FIX] Use product sequence in website shop, too

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -202,10 +202,7 @@ class website_sale(http.Controller):
         if attrib_list:
             post['attrib'] = attrib_list
         pager = request.website.pager(url=url, total=product_count, page=page, step=PPG, scope=7, url_args=post)
-        product_ids = product_obj.search(
-            cr, uid, domain, limit=PPG, offset=pager['offset'],
-            order=product_obj._order,
-            context=context)
+        product_ids = product_obj.search(cr, uid, domain, limit=PPG, offset=pager['offset'], context=context)
         products = product_obj.browse(cr, uid, product_ids, context=context)
 
         style_obj = pool['product.style']

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -202,7 +202,10 @@ class website_sale(http.Controller):
         if attrib_list:
             post['attrib'] = attrib_list
         pager = request.website.pager(url=url, total=product_count, page=page, step=PPG, scope=7, url_args=post)
-        product_ids = product_obj.search(cr, uid, domain, limit=PPG, offset=pager['offset'], order='website_published desc, website_sequence desc', context=context)
+        product_ids = product_obj.search(
+            cr, uid, domain, limit=PPG, offset=pager['offset'],
+            order=product_obj._order,
+            context=context)
         products = product_obj.browse(cr, uid, product_ids, context=context)
 
         style_obj = pool['product.style']


### PR DESCRIPTION
The order of the products in the shop is redefined (and forced) in the search in the controller. The module website_sale set a different order of the product but this order is ignored by website side.

With this change is possibile to personalize the order of the product.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

same patch like https://github.com/odoo/odoo/pull/11646/files
