### PR TITLE
7.0 gh issue 7791 fix pagination

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -425,7 +425,14 @@ instance.web.FormView = instance.web.View.extend(instance.web.form.FieldManagerM
         if (hide_index) {
             $(".oe_form_pager_state", this.$pager).html("");
         } else {
-            $(".oe_form_pager_state", this.$pager).html(_.str.sprintf(_t("%d / %d"), this.dataset.index + 1, this.dataset.ids.length));
+            var list = this.ViewManager.views['list'];
+            var page = list && list.controller.page || 0;
+            var limit = list && list.controller.limit() || 0;
+            var off = page * limit;
+            var total = this.dataset.size();
+
+            $(".oe_form_pager_state", this.$pager).html(_.str.sprintf(_t("%d / %d"),
+            off + this.dataset.index + 1, total));
         }
     },
     parse_on_change: function (on_change, widget) {

--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -428,7 +428,7 @@ instance.web.FormView = instance.web.View.extend(instance.web.form.FieldManagerM
             var page = 0;
             var limit = 0;
             try {
-                controller = this.ViewManager.views['list'] && this.ViewManager.views['list'].controller;
+                var controller = this.ViewManager.views['list'] && this.ViewManager.views['list'].controller;
                 page = controller && controller.page || 0;
                 limit = controller && controller.limit() || 0;
             }

--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -425,9 +425,17 @@ instance.web.FormView = instance.web.View.extend(instance.web.form.FieldManagerM
         if (hide_index) {
             $(".oe_form_pager_state", this.$pager).html("");
         } else {
-            var controller = this.ViewManager.views['list'] && this.ViewManager.views['list'].controller;
-            var page = controller && controller.page || 0;
-            var limit = controller && controller.limit() || 0;
+            var page = 0;
+            var limit = 0;
+            try {
+                controller = this.ViewManager.views['list'] && this.ViewManager.views['list'].controller;
+                page = controller && controller.page || 0;
+                limit = controller && controller.limit() || 0;
+            }
+            catch(err){
+                page = 0;
+                limit = 0;
+            }
             var off = page * limit;
             var total = this.dataset.size();
 

--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -425,9 +425,9 @@ instance.web.FormView = instance.web.View.extend(instance.web.form.FieldManagerM
         if (hide_index) {
             $(".oe_form_pager_state", this.$pager).html("");
         } else {
-            var list = this.ViewManager.views['list'];
-            var page = list && list.controller.page || 0;
-            var limit = list && list.controller.limit() || 0;
+            var controller = this.ViewManager.views['list'] && this.ViewManager.views['list'].controller;
+            var page = controller && controller.page || 0;
+            var limit = controller && controller.limit() || 0;
             var off = page * limit;
             var total = this.dataset.size();
 

--- a/addons/web/static/src/js/view_list.js
+++ b/addons/web/static/src/js/view_list.js
@@ -580,7 +580,12 @@ instance.web.ListView = instance.web.View.extend( /** @lends instance.web.ListVi
      * @param {Object} results results of evaluating domain and process for a search
      */
     do_search: function (domain, context, group_by) {
-        this.page = 0;
+        // comapare domain with previous domain
+        // reset pagination if search domain has changed
+        // a bit hacky
+        if(JSON.stringify(this._prev_search_domain) != JSON.stringify(domain))
+            this.page = 0;
+        this._prev_search_domain = domain;
         this.groups.datagroup = new DataGroup(
             this, this.model, domain, context, group_by);
         this.groups.datagroup.sort = this.dataset._sort;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://github.com/odoo/odoo/issues/7791

Steps to reproduce (this is in all versions of Odoo btw):
- You can do that in any runbot with data
- Go to one models view with a lot of items (e.g. products or modules) 
- Switch to list view
- page another page than the very first one (e.g. 2nd, 3rd, etc)
- click on a row to select item and jump to form view: 
  - issue 1): Pager in form view displays wrong numbers.
  - issue 2): Switching back to list view gets you to the 1st page of the list and not the page where you selected the item.

Current behavior before PR:
Currently paging in form view isn't correct if reached by clicking on an item in another than the first page of an list view.
- Indexes and limits displayed in form view pager are wrong
- Switching back to list view always moves to the first list view page independent of there you came from

Desired behavior after PR is merged:
- switching forth and back from list to form view keeps global index of current item.
- the indexes displayed in the form view pager are global and not only the relative indexes of the current page

Known issues: 
- paging inside the form view still only pages inside the current page. I.e. if you are in the form view of the 1st item of the 2nd page (i.e. item 81) and click the prev button you get the last item of the current page (item 160) instead of the last of the prev page (item 79). Fixing this will need a little bit more refactoring. 
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
