### PR TITLE
[IMP] point_of_sale, add partner check available in pos

### DIFF
--- a/addons/point_of_sale/point_of_sale.py
+++ b/addons/point_of_sale/point_of_sale.py
@@ -1520,6 +1520,14 @@ class product_template(osv.osv):
 class res_partner(osv.osv):
     _inherit = 'res.partner'
 
+    _columns = {
+        'available_in_pos': fields.boolean('Available in the Point of Sale')
+    }
+
+    _defaults = {
+        'available_in_pos': True
+    }
+
     def create_from_ui(self, cr, uid, partner, context=None):
         """ create or modify a partner from the point of sale ui.
             partner contains the partner's fields. """

--- a/addons/point_of_sale/res_partner_view.xml
+++ b/addons/point_of_sale/res_partner_view.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        
+
         <record id="view_partner_property_form" model="ir.ui.view">
             <field name="name">res.partner.product.property.form.inherit</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
                 <notebook position="inside">
-                    <page string="Point of Sale"> 
+                    <page string="Point of Sale">
                         <group>
+                            <field name="available_in_pos"/>
                             <field name="ean13" />
                             <button name="%(action_edit_ean)d" type="action" string="Set a Custom EAN" />
                         </group>

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -170,7 +170,7 @@ function openerp_pos_models(instance, module){ //module is instance.point_of_sal
         },{
             model:  'res.partner',
             fields: ['name','street','city','state_id','country_id','vat','phone','zip','mobile','email','ean13','write_date'],
-            domain: [['customer','=',true]],
+            domain: [['customer','=',true],['available_in_pos','=',true]],
             loaded: function(self,partners){
                 self.partners = partners;
                 self.db.add_partners(partners);


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When you have many partners, it takes too long to load all of them in the pos. As in products, I've added a check in order to allow partners be loaded or not.

**Current behavior before PR:**
POS loads all partners.

**Desired behavior after PR is merged:**
POS only loads the partners with the check 'available_in_pos' field set to true.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
