### PR TITLE
project form: display project manager field even if developer mode is disable

### DIFF
--- a/addons/project/project_view.xml
+++ b/addons/project/project_view.xml
@@ -114,8 +114,7 @@
                                 <field name="partner_id" on_change="onchange_partner_id(partner_id)" string="Customer"/>
                                 <field name="user_id" string="Project Manager"
                                         attrs="{'readonly':[('state','in',['close', 'cancelled'])]}"
-                                        context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'project.group_project_manager']}"
-                                        groups="base.group_no_one"/>
+                                        context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'project.group_project_manager']}"/>
                             </group>
                             <group name="misc">
                                 <group string="Time Scheduling" groups="project.group_time_work_estimation_tasks">


### PR DESCRIPTION
In project form, it seems that Odoo decided to hide "Project Manager"  field except in developer mode. But it seems to me that be able to select a project manager when creating a project was a pretty good feature...

Current behavior before PR:
Can't choose a project manager when creating a project without developer mode.

Desired behavior after PR is merged:
Like V8, can choose a project manager when creating a project
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
