### PR TITLE
[FIX]mrp: action_scrap should returns a list of ids instead a list of lists.

### DIFF
--- a/addons/mrp/stock.py
+++ b/addons/mrp/stock.py
@@ -227,7 +227,7 @@ class StockMove(osv.osv):
                 production_obj.signal_workflow(cr, uid, [prod_id], 'button_produce')
             if move.production_id.id:
                 self.write(cr, uid, new_moves, {'production_id': move.production_id.id}, context=context)
-            res.append(new_moves)
+            res.extend(new_moves)
         return res
 
     def write(self, cr, uid, ids, vals, context=None):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix the return of methos action_scrap in mrp module.

Current behavior before PR:methos action_scrap:
Method action_scrap() returns a list o list of ids ç

Desired behavior after PR is merged:
Method action_scrap() returns list of ids 
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

… lists
