### PR TITLE
[FIX] incorrect rule on project_issue

### DIFF
--- a/addons/project_issue/security/project_issue_security.xml
+++ b/addons/project_issue/security/project_issue_security.xml
@@ -17,7 +17,7 @@
                                                 ('project_id.privacy_visibility', 'in', ['public', 'employees']),
                                                 '&amp;',
                                                     ('project_id.privacy_visibility', '=', 'followers'),
-                                                    ('message_follower_ids', 'in', [user.partner.id]),
+                                                    ('message_follower_ids', 'in', [user.partner_id.id]),
                                             ('user_id', '=', user.id),
                                         ]</field>
             <field name="groups" eval="[(4,ref('base.group_user'))]"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This bug has been introduced by 26d6e90b790c7ef1fe1448565b9e3a0d7ced31e9.
CC : @pedrobaeza. the security domain is not valid because partner doesn't exist in res.users model.

Current behavior before PR:
access right Error after installing the module project_issue.

Desired behavior after PR is merged:
No more access right error.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
