### PR TITLE
[FIX] Use a more accurate regex expression for detecting email urls

### DIFF
--- a/addons/website/static/src/js/website.editor.js
+++ b/addons/website/static/src/js/website.editor.js
@@ -1007,6 +1007,11 @@
             });
             return this._super().then(this.proxy('bind_data'));
         },
+        is_email: function(val) {
+            // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
+            var re = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+            return re.test(val);
+        },
         get_data: function (test) {
             var self = this,
                 def = new $.Deferred(),
@@ -1025,7 +1030,7 @@
             var size = this.$("input[name='link-style-size']:checked").val();
             var classes = (style && style.length ? "btn " : "") + style + " " + size;
 
-            if ($e.hasClass('email-address') && $e.val().indexOf("@") !== -1) {
+            if ($e.hasClass('email-address') && this.is_email($e.val())) {
                 def.resolve('mailto:' + val, false, label, classes);
             } else if ($e.val() && $e.val().length && $e.hasClass('page')) {
                 var data = $e.select2('data');
@@ -1140,7 +1145,7 @@
         },
         onkeyup: function (e) {
             var $e = $(e.target);
-            var is_link = ($e.val()||'').length && $e.val().indexOf("@") === -1;
+            var is_link = !this.is_email($e.val())
             this.$('input.window-new').closest("div").toggle(is_link);
             this.preview();
         },


### PR DESCRIPTION
- Description of the issue/feature this PR addresses:

On website editor and link edit form, if you set a link with an '@' inside, for example, any link from maps.google.com for sharing a map, then editor adds 'mailto:' prefix, because it identifies link as an email address
- Current behavior before PR:

When change URL in a website editor and set it as: https://www.google.es/maps/place/Odoo+%2F+OpenERP/@49.7379672,3.7080045,5z/data=!4m8!1m2!2m1!1sodoo!3m4!1s0x0000000000000000:0xea2e188a12590d5f!8m2!3d50.6355264!4d4.8641968?hl=es

Then URL changes to **mailto:**https://www.google.es/maps/place/Odoo+%2F+OpenERP/@49.7379672,3.7080045,5z/data=!4m8!1m2!2m1!1sodoo!3m4!1s0x0000000000000000:0xea2e188a12590d5f!8m2!3d50.6355264!4d4.8641968?hl=es
- Desired behavior after PR is merged:

URL is not an email address, so `mailto:` must not be added as prefix
- Fix

This PR define a new JS method to check if URL value is an email or not, following this regex: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript

Odoo PR: https://github.com/odoo/odoo/pull/11984

@Tecnativa
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
