### PR TITLE
stock: Fix _get_domain_locations child_of optimisation with unit test location

### DIFF
--- a/addons/stock/product.py
+++ b/addons/stock/product.py
@@ -85,7 +85,7 @@ class product_product(osv.osv):
         operator = context.get('compute_child', True) and 'child_of' or 'in'
         domain = context.get('force_company', False) and ['&', ('company_id', '=', context['force_company'])] or []
         locations = location_obj.browse(cr, uid, location_ids, context=context)
-        if operator == "child_of" and locations and locations[0].parent_left != 0:
+        if operator == "child_of" and locations and all(l.parent_left != 0 for l in locations):
             loc_domain = []
             dest_loc_domain = []
             for loc in locations:

--- a/addons/stock/tests/__init__.py
+++ b/addons/stock/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_stock_flow
 from . import test_owner_available
 from . import test_resupply
+from . import test_product_qty

--- a/addons/stock/tests/test_product_qty.py
+++ b/addons/stock/tests/test_product_qty.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# © 2016 Cyril Gaudin (Camptocamp)
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from openerp.tests import common
+
+
+class TestProductQty(common.TransactionCase):
+
+    def test_quant_location_context(self):
+
+        test_location = self.env['stock.location'].create({
+            'name': 'Unittest sub location',
+            'location_id': self.ref('stock.stock_location_locations'),
+            'usage': 'internal',
+        })
+
+        # Create a test product
+        test_product = self.env['product.product'].create({
+            'name': 'Unittest product',
+        })
+
+        # Put 5 qty of test product in created location
+        inventory = self.env['stock.inventory'].create({
+            'name': 'Inventory for test product',
+            'location_id': test_location.id,
+            'filter': 'partial'
+        })
+        inventory.prepare_inventory()
+
+        self.env['stock.inventory.line'].create({
+            'inventory_id': inventory.id,
+            'product_id': test_product.id,
+            'location_id': test_location.id,
+            'product_qty': 5,
+        })
+        inventory.action_done()
+
+        # Check product qty in 2 locations
+        product_qty = test_product.with_context(
+            location=[
+                # First location may already exists (parent_left is computed)
+                # Second was just created (parent_left not computed in test)
+                self.ref('stock.stock_location_components'), test_location.id
+            ]
+        ).qty_available
+        self.assertEqual(5, product_qty)


### PR DESCRIPTION
When computing product.qty_available, _get_domain_locations is called to retrieve locations filtering for quants (and moves).

In d4152c2 , an optimisation was done to use parent_left for child_of operator.
A little fix was also added for not using this optimisation if parent_left = 0
(parent_left and parent_right are not computed at initialization (so during unit tests too))

But if this method is called with fixed locations in context with:

```
1 existing location (demo data in existing database), so with parent_left compute.
1 location created in my test, so with parent_left=0
```

The returned domain will use parent_left optimisation, so the new location quantity will not be taken into account.

Currently, the existing fix check that only first location parent_left is not 0.

I changed this fix to not use parent_left optimisation if any parent_left is not computed.

Odoo PR: https://github.com/odoo/odoo/pull/11996
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
