### PR TITLE
[FIX] Don't allow modification of posted entries, even with entry_posted

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -1275,7 +1275,7 @@ class account_move_line(osv.osv):
         done = {}
         for line in self.browse(cr, uid, ids, context=context):
             err_msg = _('Move name (id): %s (%s)') % (line.move_id.name, str(line.move_id.id))
-            if line.move_id.state <> 'draft' and (not line.journal_id.entry_posted):
+            if line.move_id.state <> 'draft':
                 raise osv.except_osv(_('Error!'), _('You cannot do this modification on a confirmed entry. You can just change some non legal fields or you must unconfirm the journal entry first.\n%s.') % err_msg)
             if line.reconcile_id:
                 raise osv.except_osv(_('Error!'), _('You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.\n%s.') % err_msg)


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
Posted moves are not protected from modification if the journal is set to 'autopost'.

_Current behavior before PR:_
I post an accounting move in a journal with 'Autopost' set. I remove one of the move lines. In the system, there is now a posted, but unbalanced move.

_Desired behavior after PR is merged:_
There will be an error when I remove a move line of a posted move. A posted move can not be unbalanced anymore.

This reverts https://github.com/odoo/odoo/commit/4e95e42233a6728401d58359d71f791f79aea703

Upstream PR: https://github.com/odoo/odoo/pull/12014
