### PR TITLE
[8.0] [FIX] account: total_invoiced field should be only for customer invoices

### DIFF
--- a/addons/account/partner.py
+++ b/addons/account/partner.py
@@ -275,6 +275,7 @@ class res_partner(osv.osv):
                          AND cr.currency_id = %%s
                          AND (COALESCE(account_invoice_report.date, NOW()) >= cr.date_start)
                          AND (COALESCE(account_invoice_report.date, NOW()) < cr.date_end OR cr.date_end IS NULL)
+                         AND account_invoice_report.type in ('out_invoice', 'out_refund')
                     """ % where_clause
 
             # price_total is in the currency with rate = 1


### PR DESCRIPTION
Upstream Odoo PR: https://github.com/odoo/odoo/pull/12044

---

Description of the issue/feature this PR addresses:
Field `total_invoiced` is used for displaying the total of the sales invoices (which is proved by the fact that the smart-button that uses the field is hidden when the partner is not customer), but it doesn't filter out the supplier invoices.

Current behavior before PR:
- Go to runbot.
- Go to supplier "ASUSTeK".
- Check the "Customer" flag.
- You will see a negative amount in the smart-button "-x.xx € Invoiced".

Desired behavior after PR is merged:
With the same steps, you have to see "0.00 € Invoiced" in the smart-button. In the rewritten to new API class for 9.0, the problem have been solved with a similar method: https://github.com/odoo/odoo/blob/4cf9e4ca832f258323acebb7035a81f9d07c3188/addons/account/models/partner.py#L309
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
