### PR TITLE
[IMP] Reference product in standard price update's accounting moves

### DIFF
--- a/addons/stock_account/product.py
+++ b/addons/stock_account/product.py
@@ -126,6 +126,7 @@ class product_template(osv.osv):
                         move_vals = {
                             'journal_id': datas['stock_journal'],
                             'company_id': location.company_id.id,
+                            'ref': prod_variant.default_code,
                         }
                         move_id = move_obj.create(cr, uid, move_vals, context=context)
 
@@ -149,13 +150,15 @@ class product_template(osv.osv):
                                         'debit': amount_diff,
                                         'credit': 0,
                                         'move_id': move_id,
+                                        'product_id': prod_variant.id,
                                         }, context=context)
                         move_line_obj.create(cr, uid, {
                                         'name': _('Standard Price changed'),
                                         'account_id': credit_account_id,
                                         'debit': 0,
                                         'credit': amount_diff,
-                                        'move_id': move_id
+                                        'move_id': move_id,
+                                        'product_id': prod_variant.id,
                                         }, context=context)
             self.write(cr, uid, rec_id, {'standard_price': new_price})
         return True


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
When changing the price of a product with realtime valuation it is not possible to track the related product when reviewing the accounting moves.

_Current behavior before PR:_
The accounting moves only mention 'Standard price change', but not the product.

_Desired behavior after PR is merged:_
When changing the price of a product with realtime valuation the move's reference is set to the product reference, and the move lines are linked to the product through the product_id field.

_Upstream PR:_ https://github.com/odoo/odoo/pull/12092
