### PR TITLE
[IMP] synchronize ListView.reload_content per instance

### DIFF
--- a/addons/web/static/src/js/views/list_view.js
+++ b/addons/web/static/src/js/views/list_view.js
@@ -1742,17 +1742,16 @@ ListView.Groups = Class.extend( /** @lends instance.web.ListView.Groups# */{
 /**
  * Serializes concurrent calls to this asynchronous method. The method must
  * return a deferred or promise.
- *
- * Current-implementation is class-serialized (the mutex is common to all
- * instances of the list view). Can be switched to instance-serialized if
- * having concurrent list views becomes possible and common.
  */
 function synchronized(fn) {
-    var fn_mutex = new utils.Mutex();
     return function () {
         var obj = this;
         var args = _.toArray(arguments);
-        return fn_mutex.exec(function () {
+        if(!this._view_list_synchronized_mutex)
+        {
+            this._view_list_synchronized_mutex = new $.Mutex();
+        }
+        return this._view_list_synchronized_mutex.exec(function () {
             if (obj.isDestroyed()) { return $.when(); }
             return fn.apply(obj, args);
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Parallelize calls to reload_content

Current behavior before PR: On a form with multiple list fields, the fields are read sequentially

Desired behavior after PR is merged: Fields are read simultaneously

Upstream PR: https://github.com/odoo/odoo/pull/12185
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
