### PR TITLE
[IMP] parallelize ListView.render_dataset

### DIFF
--- a/addons/web/static/src/js/view_list.js
+++ b/addons/web/static/src/js/view_list.js
@@ -1499,46 +1499,43 @@ instance.web.ListView.Groups = instance.web.Class.extend( /** @lends instance.we
 
         var fields = _.pluck(_.select(this.columns, function(x) {return x.tag == "field";}), 'name');
         var options = { offset: page * limit, limit: limit, context: {bin_size: true} };
-        //TODO xmo: investigate why we need to put the setTimeout
-        return $.async_when().then(function() {
-            return dataset.read_slice(fields, options).then(function (records) {
-                // FIXME: ignominious hacks, parents (aka form view) should not send two ListView#reload_content concurrently
-                if (self.records.length) {
-                    self.records.reset(null, {silent: true});
-                }
-                if (!self.datagroup.openable) {
-                    view.configure_pager(dataset);
+        return dataset.read_slice(fields, options).then(function (records) {
+            // FIXME: ignominious hacks, parents (aka form view) should not send two ListView#reload_content concurrently
+            if (self.records.length) {
+                self.records.reset(null, {silent: true});
+            }
+            if (!self.datagroup.openable) {
+                view.configure_pager(dataset);
+            } else {
+                if (dataset.size() == records.length) {
+                    // only one page
+                    self.$row.find('td.oe_list_group_pagination').find('button').remove();
+                    self.$row.find('td.oe_list_group_pagination').find('span').remove();
                 } else {
-                    if (dataset.size() == records.length) {
-                        // only one page
-                        self.$row.find('td.oe_list_group_pagination').find('button').remove();
-                        self.$row.find('td.oe_list_group_pagination').find('span').remove();
-                    } else {
-                        var pages = Math.ceil(dataset.size() / limit);
-                        self.$row
-                            .find('.oe_list_pager_state')
-                                .text(_.str.sprintf(_t("%(page)d/%(page_count)d"), {
-                                    page: page + 1,
-                                    page_count: pages
-                                }))
-                            .end()
-                            .find('button[data-pager-action=previous]')
-                                .css('visibility',
-                                     page === 0 ? 'hidden' : '')
-                            .end()
-                            .find('button[data-pager-action=next]')
-                                .css('visibility',
-                                     page === pages - 1 ? 'hidden' : '');
-                    }
+                    var pages = Math.ceil(dataset.size() / limit);
+                    self.$row
+                        .find('.oe_list_pager_state')
+                            .text(_.str.sprintf(_t("%(page)d/%(page_count)d"), {
+                                page: page + 1,
+                                page_count: pages
+                            }))
+                        .end()
+                        .find('button[data-pager-action=previous]')
+                            .css('visibility',
+                                 page === 0 ? 'hidden' : '')
+                        .end()
+                        .find('button[data-pager-action=next]')
+                            .css('visibility',
+                                 page === pages - 1 ? 'hidden' : '');
                 }
+            }
 
-                self.records.add(records, {silent: true});
-                list.render();
-                if (_.isEmpty(records)) {
-                    view.no_result();
-                }
-                return list;
-            });
+            self.records.add(records, {silent: true});
+            list.render();
+            if (_.isEmpty(records)) {
+                view.no_result();
+            }
+            return list;
         });
     },
     setup_resequence_rows: function (list, dataset) {

--- a/addons/web/static/src/js/view_list.js
+++ b/addons/web/static/src/js/view_list.js
@@ -1624,8 +1624,10 @@ instance.web.ListView.Groups = instance.web.Class.extend( /** @lends instance.we
             }, function (dataset) {
                 self.render_dataset(dataset).then(function (list) {
                     self.children[null] = list;
-                    self.elements =
-                        [list.$current.replaceAll($el)[0]];
+                    // do the actual rendering outside the event handling
+                    window.requestAnimationFrame(function() {
+                        self.elements = [list.$current.replaceAll($el)[0]];
+                    });
                     self.setup_resequence_rows(list, dataset);
                 }).always(function() {
                     if (post_render) { post_render(); }

--- a/addons/web/static/test/list-editable.js
+++ b/addons/web/static/test/list-editable.js
@@ -369,12 +369,18 @@ openerp.testing.section('list.edition.onwrite', {
                 'should have id of created + on_write');
             strictEqual(l.records.length, 2,
                 'should have record of created + on_write');
-            strictEqual(
-                $fix.find('tbody tr:eq(1)').css('color'), 'rgb(255, 0, 0)',
-                'shoud have color applied');
-            notStrictEqual(
-                $fix.find('tbody tr:eq(2)').css('color'), 'rgb(255, 0, 0)',
-                'should have default color applied');
+            var d = new jQuery.Deferred();
+            // UI is updated in next animation frame
+            window.requestAnimationFrame(function() {
+                strictEqual(
+                    $fix.find('tbody tr:eq(1)').css('color'), 'rgb(255, 0, 0)',
+                    'shoud have color applied');
+                notStrictEqual(
+                    $fix.find('tbody tr:eq(2)').css('color'), 'rgb(255, 0, 0)',
+                    'should have default color applied');
+                return d.resolve();
+            });
+            return d.promise();
         });
     });
 });

--- a/addons/web/static/test/list.js
+++ b/addons/web/static/test/list.js
@@ -35,19 +35,19 @@ openerp.testing.section('list.buttons', {
         }, ds, false, {editable: 'top'});
         return l.appendTo($fix)
         .then(l.proxy('reload_content'))
-        .then(function () {
+        // we render elements within an animation frame, so we need to test
+        // it within one too
+        .then(window.requestAnimationFrame.bind(window, function () {
             var d = $.Deferred();
             l.records.bind('remove', function () {
+                strictEqual(l.records.length, 2,
+                            "should have 2 records left");
+                strictEqual($fix.find('table tbody tr[data-id]').length, 2,
+                            "should have 2 rows left");
                 d.resolve();
             });
             $fix.find('table tbody tr:eq(1) button').click();
             return d.promise();
-        })
-        .then(function () {
-            strictEqual(l.records.length, 2,
-                        "should have 2 records left");
-            strictEqual($fix.find('table tbody tr[data-id]').length, 2,
-                        "should have 2 rows left");
-        });
+        }));
     });
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Parallelize rendering datasets

Current behavior before PR: reading datasets in list views is synchronized

Desired behavior after PR is merged: reading datasets in list views is parallel

No upstream PR because it won't be accepted for 8.0 and the patch is quite different for 9.0

This speeds up loading forms with multiple x2many fields, as now they can render simultaneously instead of sequentially.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
