### PR TITLE
[FIX] Repair references in demo data to create_date field in model data.

### DIFF
--- a/addons/crm/crm_action_rule_demo.xml
+++ b/addons/crm/crm_action_rule_demo.xml
@@ -22,7 +22,7 @@
             <field name="sequence">1</field>
             <field name="kind">on_time</field>
             <field name="filter_id" ref="filter_draft_lead"/>
-            <field name="trg_date_id" ref="field_crm_lead_create_date"/>
+            <field name="trg_date_id" search="[('model','=','crm.lead'),('name','=','create_date')]"/>
             <field name="trg_date_range">5</field>
             <field name="trg_date_range_type">day</field>
             <field name="server_action_ids" eval="[(6,0,[ref('action_email_reminder_lead')])]"/>

--- a/addons/gamification_sale_crm/sale_crm_goals.xml
+++ b/addons/gamification_sale_crm/sale_crm_goals.xml
@@ -20,7 +20,7 @@
             <field name="computation_mode">count</field>
             <field name="suffix">leads</field>
             <field name="model_id" eval="ref('crm.model_crm_lead')" />
-            <field name="field_date_id" eval="ref('crm.field_crm_lead_create_date')" />
+            <field name="field_date_id" search="[('model','=','crm.lead'),('name','=','create_date')]" />
             <!-- lead AND opportunity as don't want to be penalised for lead converted to opportunity -->
             <field name="domain">[('user_id','=',user.id), '|', ('type', '=', 'lead'), ('type', '=', 'opportunity')]</field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/12192 Incorrect definition of demo data in crm.

Current behavior before PR: Demo data not created and server will no longer be updated when crm with demo data installed.

Desired behavior after PR is merged: Demo data defined and updates work again.

Upstream PR is here: https://github.com/odoo/odoo/pull/12198
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
