### PR TITLE
[FIX] stock_account: Fixed bug DataError: division by zero

### DIFF
--- a/addons/stock_account/wizard/stock_valuation_history.py
+++ b/addons/stock_account/wizard/stock_valuation_history.py
@@ -125,7 +125,7 @@ class stock_history(osv.osv):
                 product_categ_id,
                 SUM(quantity) as quantity,
                 date,
-                SUM(price_unit_on_quant * quantity) / SUM(quantity) as price_unit_on_quant,
+                COALESCE(SUM(price_unit_on_quant * quantity) / NULLIF(SUM(quantity), 0), 0) as price_unit_on_quant,
                 source
                 FROM
                 ((SELECT


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- When there are same quantity of stock quants in source and destination movements a division by 0 could happen. 
- ~~Added HAVING clausule to avoid 0 quantity lines.~~

Current behavior before PR:
- DataError: division by zero

Desired behavior after PR is merged:
- stock valuation history table

Upstream PR:  #12247
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
