### PR TITLE
8.0 fix inherance

### DIFF
--- a/addons/procurement/procurement.py
+++ b/addons/procurement/procurement.py
@@ -154,7 +154,8 @@ class procurement_order(osv.osv):
             else:
                 raise osv.except_osv(_('Invalid Action!'),
                         _('Cannot delete Procurement Order(s) which are in %s state.') % s['state'])
-        return osv.osv.unlink(self, cr, uid, unlink_ids, context=context)
+        return super(procurement_order, self). \
+            unlink(cr, uid, unlink_ids, context=context)
 
     def do_view_procurements(self, cr, uid, ids, context=None):
         '''

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -278,7 +278,8 @@ class sale_order(osv.osv):
             else:
                 raise osv.except_osv(_('Invalid Action!'), _('In order to delete a confirmed sales order, you must cancel it before!'))
 
-        return osv.osv.unlink(self, cr, uid, unlink_ids, context=context)
+        return super(sale_order, self). \
+            unlink(cr, uid, unlink_ids, context=context)
 
     def copy_quotation(self, cr, uid, ids, context=None):
         id = self.copy(cr, uid, ids[0], context=context)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix old code that doesn't use `super` to call base functions. 

Current behavior before PR:
- `_inherit = ['some.abstract.base.class', 'sale.order']`
- `some.abstract.base.class#unlink` does **not** get called on call to `sale.order#unlink`

Desired behavior after PR is merged:
- `_inherit = ['some.abstract.base.class', 'sale.order']`
- `some.abstract.base.class#unlink` gets called on call to `sale.order#unlink`
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
