### PR TITLE
[FIX] change context on seq_obj get to use correct sequence

### DIFF
--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -1558,7 +1558,7 @@ class procurement_order(osv.osv):
                         po_line_id = po_line_obj.create(cr, SUPERUSER_ID, line_vals, context=context)
                         linked_po_ids.append(procurement.id)
                 else:
-                    name = seq_obj.get(cr, uid, 'purchase.order', context=context) or _('PO: %s') % procurement.name
+                    name = seq_obj.get(cr, uid, 'purchase.order', context=ctx_company) or _('PO: %s') % procurement.name
                     po_vals = {
                         'name': name,
                         'origin': procurement.origin,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Creating a Purchase order with purchase scheduler, name sequence of purchase order is the admin's one
Current behavior before PR: 
Creating a Purchase order with purchase scheduler, name sequence of purchase order is the admin's one
Desired behavior after PR is merged:
Creating a Purchase order with purchase scheduler, name sequence of purchase order is the current user's one
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
