### PR TITLE
[FIX] stock_history report database view when stock_move quantity = 0

### DIFF
--- a/addons/stock_account/wizard/stock_valuation_history.py
+++ b/addons/stock_account/wizard/stock_valuation_history.py
@@ -125,7 +125,7 @@ class stock_history(osv.osv):
                 product_categ_id,
                 SUM(quantity) as quantity,
                 date,
-                SUM(price_unit_on_quant * quantity) / SUM(quantity) as price_unit_on_quant,
+                SUM(price_unit_on_quant * quantity) / NULLIF(SUM(quantity), 0) as price_unit_on_quant,
                 source
                 FROM
                 ((SELECT


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
An error of division by zero in the database view of stock_history.

Current behavior before PR:
To reproduce the issue, in a database with stock_account module installed, we create a stock picking where we select the same source and destination location for a move (Should this be possible?). Then when we go to Warehouse > Inventory Control > Current Inventory Valuation. There should be a error of division by 0.

Desired behavior after PR is merged:
Even if there is a stock move with the same source and destination location, we should be able to access the Current Inventory Valuation.

Odoo PR: https://github.com/odoo/odoo/pull/12423
