### PR TITLE
[FIX] Tests. l10n_nz cannot be installed side by side with l10n_au.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ python:
   - "2.7"
 
 env:
-  - VERSION="9.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0" EXTRA_EXCLUDE="theme_bootswatch"
+  - VERSION="9.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0" EXTRA_EXCLUDE="theme_bootswatch,l10n_nz"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
These localizations both contain the a tax template with the same name, which violates
a constraint. This is OCB specific, as Odoo runbot does not install any of the localizations.

The NZ localization was only added a month ago.

Upstream issue: https://github.com/odoo/odoo/issues/12600
