### PR TITLE
[8.0][FIX][web_kanban] Do not call name_get with temporal IDs

### DIFF
--- a/addons/web_kanban/static/src/js/kanban.js
+++ b/addons/web_kanban/static/src/js/kanban.js
@@ -550,11 +550,13 @@ instance.web_kanban.KanbanView = instance.web.View.extend({
                     }
                     var rel = relations[field.relation];
                     field.raw_value.forEach(function(id) {
-                        rel.ids.push(id);
-                        if (!rel.elements[id]) {
-                            rel.elements[id] = [];
+                        if (id === parseInt(id, 10)) {
+                            rel.ids.push(id);
+                            if (!rel.elements[id]) {
+                                rel.elements[id] = [];
+                            }
+                            rel.elements[id].push($el[0]);
                         }
-                        rel.elements[id].push($el[0]);
                     });
                 });
             });


### PR DESCRIPTION
- Description of the issue/feature this PR addresses:

If in a kanban view (inside a form), like contacts in res.partner form, wants to show a m2m field (like categories), then name_get will call for ids like [6, False, ...]
- Current behavior before PR:

name_get raise an error 
- Desired behavior after PR is merged:

name_get only have to call for proper integer list of ids

Odoo PR: https://github.com/odoo/odoo/pull/12605

@Tecnativa
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
