### PR TITLE
[FIX] The price computation is not consistent with the cost structure

### DIFF
--- a/addons/product_extended/product_extended.py
+++ b/addons/product_extended/product_extended.py
@@ -83,7 +83,8 @@ class product_template(osv.osv):
             for wline in bom.routing_id.workcenter_lines:
                 wc = wline.workcenter_id
                 cycle = wline.cycle_nbr
-                hour = (wc.time_start + wc.time_stop + cycle * wc.time_cycle) *  (wc.time_efficiency or 1.0)
+                hour = wline.hour_nbr
+                hour = (wc.time_start + wc.time_stop + cycle * wc.time_cycle + hour) *  (wc.time_efficiency or 1.0)
                 price += wc.costs_cycle * cycle + wc.costs_hour * hour
                 price = self.pool.get('product.uom')._compute_price(cr,uid,bom.product_uom.id, price, bom.product_id.uom_id.id)
         


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix the price computation is not consistent with the cost structure
of BOM, as it not include the hour_nbr of routing.

Current behavior before PR:

The product cost computation from BOM and routing have not include the hour_nbr of routing

Desired behavior after PR is merged:

Corrected this inconsistent with cost structure of BOM.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

of BOM, as it not include the hour_nbr of routing.
