### PR TITLE
[FIX] encode python ldap's output as utf8

### DIFF
--- a/addons/auth_ldap/users_ldap.py
+++ b/addons/auth_ldap/users_ldap.py
@@ -168,7 +168,7 @@ class CompanyLDAP(osv.osv):
         :rtype: dict
         """
 
-        values = { 'name': ldap_entry[1]['cn'][0],
+        values = { 'name': tools.ustr(ldap_entry[1]['cn'][0]),
                    'login': login,
                    'company_id': conf['company']
                    }


### PR DESCRIPTION
Upstream PR: https://github.com/odoo/odoo/pull/12745
