### PR TITLE
[FIX] Pass context when creating procurement order

### DIFF
--- a/addons/stock/wizard/make_procurement_product.py
+++ b/addons/stock/wizard/make_procurement_product.py
@@ -77,7 +77,7 @@ class make_procurement(osv.osv_memory):
                 'warehouse_id': proc.warehouse_id.id,
                 'location_id': wh.lot_stock_id.id,
                 'company_id': wh.company_id.id,
-            })
+            }, context=context)
             procurement_obj.signal_workflow(cr, uid, [procure_id], 'button_confirm')
 
         id2 = data_obj._get_id(cr, uid, 'procurement', 'procurement_tree_view')


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
Context is not passed when creating a procurement manually.

_Current behavior before PR:_
A default value added to the context in an override to this method is ignored.

_Desired behavior after PR is merged:_
A default value added to the context in an override to this method is honoured.

Upstream PR: https://github.com/odoo/odoo/pull/12858
