### PR TITLE
[FIX] Make statusbar_colors tolerant of single quotes.

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -6073,13 +6073,20 @@ instance.web.form.FieldStatus = instance.web.form.AbstractField.extend({
             'value_folded': _.find(self.selection.folded, function(i){return i[0] === self.get('value');})
         });
         self.$el.html(content);
-        var statusbar_colors = JSON.parse((self.node.attrs || {}).statusbar_colors || "{}");
-        var color = statusbar_colors[self.get('value')];
-        if (color) {
-            var $color = $.Color(color);
-            var fr = $color.lightness(0.7);
-            var to = $color.lightness(0.4);
-            self.$(".oe_active, .oe_active > .arrow span").css("background-image", 'linear-gradient(to bottom, ' + fr.toHexString() + ', ' + to.toHexString() + ')');
+        if ('statusbar_colors' in self.node.attrs) {
+            var statusbar_colors = instance.web.py_eval(
+                    self.node.attrs.statusbar_colors
+                );
+            var color = statusbar_colors[self.get('value')];
+            if (color) {
+                var $color = $.Color(color);
+                var fr = $color.lightness(0.7);
+                var to = $color.lightness(0.4);
+                self.$(".oe_active, .oe_active > .arrow span").css(
+                    "background-image",
+                    'linear-gradient(to bottom, ' + fr.toHexString() + ', ' + to.toHexString() + ')'
+                );
+            }
         }
     },
     calc_domain: function() {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when statusbar_colors in view xml contains single quotes for the color properties (because usually xml attribute itself will be in double quotes), a JSON.parse error will be thrown with no information on the offending content.

Current behavior before PR: There might be a crash in the web UI if statusbar_color is not valid JSON.
## Desired behavior after PR is merged: Code is tolerant of single quoting color properties.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Solves issue #12909 reported on Odoo - although problem only occurs in OCA code.

Json properties must be enclosed in double quotes. View xml is more tolerant. With this code
there will be no unneeded restriction on the xml definition of statusbar_colors, and we prevent
difficult to debug errors.
