### PR TITLE
[8.0][9.0][FIX] default multicompany in fiscal_position

### DIFF
--- a/addons/account/partner.py
+++ b/addons/account/partner.py
@@ -46,6 +46,7 @@ class account_fiscal_position(osv.osv):
 
     _defaults = {
         'active': True,
+        'company_id': lambda self, cr, uid, ctx: self.pool['res.company']._company_default_get(cr, uid, object='account', context=ctx)
     }
 
     def _check_country(self, cr, uid, ids, context=None):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: multicompany not selected by default in fiscal position

Current behavior before PR: field company_id not filled by default in fiscal.position

Desired behavior after PR is merged: field company_id filled by default in fiscal.position
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
