### PR TITLE
prevent double clicking on statusbar widget

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -6148,7 +6148,11 @@ instance.web.form.FieldStatus = instance.web.form.AbstractField.extend({
     on_click_stage: function (ev) {
         var self = this;
         var $li = $(ev.currentTarget);
+        var ul = $li.parent('ul');
         var val;
+        if (ul.attr('disabled'))
+            return;
+        ul.attr('disabled', true);
         if (this.field.type == "many2one") {
             val = parseInt($li.data("id"), 10);
         }
@@ -6160,12 +6164,14 @@ instance.web.form.FieldStatus = instance.web.form.AbstractField.extend({
                this.view.datarecord.id.toString().match(instance.web.BufferedDataSet.virtual_id_regex)) {
                 // don't save, only set value for not-yet-saved many2ones
                 self.set_value(val);
+                ul.removeAttr('disabled');
             }
             else {
                 this.view.recursive_save().done(function() {
                     var change = {};
                     change[self.name] = val;
                     self.view.dataset.write(self.view.datarecord.id, change).done(function() {
+                        ul.removeAttr('disabled');
                         self.view.reload();
                     });
                 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

this fixes an issue where a double click could trigger two calls to write() on the record.
When the write method has side effects, this can have unintended consequences such as
emails being sent twice (tracking notifications) or worse.

Current behavior before PR:

double clic causes 2 calls to write()

Desired behavior after PR is merged:

double clic on status bar causes 1 call to write()

upstream PR: https://github.com/odoo/odoo/pull/13134
