### PR TITLE
[IMP] barcodes: controller use the elaphe lib to generate barcode

### DIFF
--- a/addons/report/__openerp__.py
+++ b/addons/report/__openerp__.py
@@ -7,6 +7,9 @@
 Report
         """,
     'depends': ['base', 'web'],
+    "external_dependencies": {
+        'python': ['elaphe']
+    },
     'data': [
         'views/layouts.xml',
         'views/views.xml',

--- a/addons/report/controllers/main.py
+++ b/addons/report/controllers/main.py
@@ -51,22 +51,37 @@ class ReportController(Controller):
     #------------------------------------------------------
     # Misc. route utils
     #------------------------------------------------------
-    @route(['/report/barcode', '/report/barcode/<type>/<path:value>'], type='http', auth="user")
-    def report_barcode(self, type, value, width=600, height=100, humanreadable=0):
-        """Contoller able to render barcode images thanks to reportlab.
-        Samples: 
+    @route(['/report/barcode', '/report/barcode/<type>/<path:value>'],
+           type='http', auth="user")
+    def report_barcode(self, type, value, barmargin=0, backgroundcolor='FFFFFF',
+                       barcolor='000000', textalign=None, textmargin=None,
+                       width=600, height=100, scale=2.0, humanreadable=0):
+        """Controller able to render barcode images thanks to elaphe.
+        Samples:
             <img t-att-src="'/report/barcode/QR/%s' % o.name"/>
-            <img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % 
+            <img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' %
                 ('QR', o.name, 200, 200)"/>
 
-        :param type: Accepted types: 'Codabar', 'Code11', 'Code128', 'EAN13', 'EAN8', 'Extended39',
-        'Extended93', 'FIM', 'I2of5', 'MSI', 'POSTNET', 'QR', 'Standard39', 'Standard93',
-        'UPCA', 'USPS_4State'
+        :param type: Accepted types: 'auspost', 'azteccode', 'codabar',
+        'code11', 'code128', 'code25', 'code39', 'code93', 'datamatrix', 'ean',
+        'i2of5', 'japanpost', 'kix', 'maxicode', 'msi', 'onecode', 'pdf417',
+        'pharmacode', 'plessey', 'postnet', 'qrcode', 'royalmail', 'rss14',
+        'symbol', 'upc'
+        :param barmargin: Accepted positive and negative values
+        :param backgroundcolor: Accepted hex color codes: from 000000 to FFFFFF
+        :param barcolor: Accepted hex color codes: from 000000 to FFFFFF
+        :param textalign: Accepted values: left, center or right. Used to specify where to
+        horizontally position the text.
+        :param textmargin: Accepted positive and negative values
+        :param scale: Accepted value: float number to set the image scale
         :param humanreadable: Accepted values: 0 (default) or 1. 1 will insert the readable value
         at the bottom of the output image
         """
         try:
-            barcode = request.registry['report'].barcode(type, value, width=width, height=height, humanreadable=humanreadable)
+            barcode = request.registry['report'].barcode(
+                type, value, barmargin=barmargin, backgroundcolor=backgroundcolor,
+                barcolor=barcolor, textalign=textalign, textmargin=textmargin,
+                width=width, height=height, scale=scale, humanreadable=humanreadable)
         except (ValueError, AttributeError):
             raise exceptions.HTTPException(description='Cannot convert into barcode.')
 

--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -21,6 +21,7 @@ import tempfile
 import lxml.html
 import os
 import subprocess
+import cStringIO
 from contextlib import closing
 from distutils.version import LooseVersion
 from functools import partial
@@ -34,7 +35,7 @@ from reportlab.graphics.barcode import createBarcodeDrawing
 # here to init the T1 fonts cache at the start-up of Odoo so that rendering of barcode in multiple
 # thread does not lock the server.
 try:
-    createBarcodeDrawing('Code128', value='foo', format='png', width=100, height=100, humanReadable=1).asString('png')
+    from elaphe import barcode
 except Exception:
     pass
 
@@ -570,17 +571,36 @@ class Report(osv.Model):
 
         return merged_file_path
 
-    def barcode(self, barcode_type, value, width=600, height=100, humanreadable=0):
+    def barcode(self, barcode_type, value, barmargin=0,
+                    backgroundcolor='FFFFFF',
+                    barcolor='000000', textalign=None, textmargin=None,
+                    width=600,
+                    height=100, scale=2.0, humanreadable=0):
+
         if barcode_type == 'UPCA' and len(value) in (11, 12, 13):
             barcode_type = 'EAN13'
             if len(value) in (11, 12):
                 value = '0%s' % value
         try:
-            width, height, humanreadable = int(width), int(height), bool(int(humanreadable))
-            barcode = createBarcodeDrawing(
-                barcode_type, value=value, format='png', width=width, height=height,
-                humanReadable=humanreadable
-            )
-            return barcode.asString('png')
+            width, height, scale, margin, humanreadable = int(
+                width), int(height), float(scale), int(barmargin), bool(int(
+                humanreadable))
+            opts = dict(barcolor=barcolor, backgroundcolor=backgroundcolor)
+
+            if humanreadable:
+                opts.update(includetext=True)
+                if textalign:
+                    opts.update(textxalign=textalign)
+                if textmargin:
+                    textmargin = int(textmargin)
+                    opts.update(textxoffset=textmargin)
+
+            barcode_out = cStringIO.StringIO()
+            barcode_img = barcode(barcode_type, str(value), opts, scale=scale,
+                                  margin=margin)
+            barcode_img = barcode_img.resize((width, height))
+            barcode_img.save(barcode_out, "png", resolution=100.0)
+
+            return barcode_out.getvalue()
         except (ValueError, AttributeError):
             raise ValueError("Cannot convert into barcode.")

--- a/doc/cla/corporate/bloopark.md
+++ b/doc/cla/corporate/bloopark.md
@@ -1,4 +1,4 @@
-Germany 2015-02-25
+Germany 2015-08-15
 
 bloopark systems GmbH & Co. KG agrees to the terms of the Odoo Corporate 
 Contributor License Agreement v1.0.
@@ -18,3 +18,4 @@ Benjamin Bachmann bBachmann@bloopark.de https://github.com/benniphx
 Robert Rübner rruebner@bloopark.de https://github.com/rruebner
 Florian Fischer ffischer@bloopark.de https://github.com/florianfischer
 Mercerdes Scenna mscenna@bloopark.de https://github.com/mscenna
+Jeferson Moura jmoura@bloopark.de https://github.com/jefmoura

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ pyusb==1.0.0b2
 qrcode==5.1
 reportlab==3.1.44
 requests==2.6.0
+elaphe==0.6.0
 six==1.9.0
 suds-jurko==0.6
 vatnumber==1.2


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is a framework to generate barcode, useful in many cases, e.g. if I want to generate Aztec/DataMatrix/Pharmacode barcode or many other types, I have these options in the elaphe library to use. The elaphe is a python binding of Barcode Writer In Pure PostScript. This framework provides a lot of settings to customize and create a barcode, just passing this information as options in the generating method.

Current behaviour before PR:
The current barcode generating method in Odoo uses the Reportlab and if I want to generate a Data Matrix code I need to update the Reportlab library to 3.3.0 version, but if I want to change the version/format I can't because it doesn't provide these options. This is only one of much more examples that we can find.

Desired behaviour after PR is merged:
Keep the current behaviour only adding more settings and options of barcode types, initially.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
