### PR TITLE
prevent double clicking on statusbar widget

### DIFF
--- a/addons/web/static/src/js/views/form_widgets.js
+++ b/addons/web/static/src/js/views/form_widgets.js
@@ -1550,8 +1550,9 @@ var FieldStatus = common.AbstractField.extend({
                 this.view.recursive_save().done(function() {
                     var change = {};
                     change[self.name] = val;
-                    self.view.dataset.write(self.view.datarecord.id, change).done(function() {
+                    self.view.dataset.write(self.view.datarecord.id, change).always(function(){
                         ul.removeAttr('disabled');
+                    }).done(function() {
                         self.view.reload();
                     });
                 });

--- a/addons/web/static/src/js/views/form_widgets.js
+++ b/addons/web/static/src/js/views/form_widgets.js
@@ -1530,6 +1530,10 @@ var FieldStatus = common.AbstractField.extend({
             return;
         }
         var val;
+        var ul = $li.parent('ul');
+        if (ul.attr('disabled'))
+            return;
+        ul.attr('disabled', true);
         if (this.field.type == "many2one") {
             val = parseInt($li.data("id"), 10);
         }
@@ -1547,6 +1551,7 @@ var FieldStatus = common.AbstractField.extend({
                     var change = {};
                     change[self.name] = val;
                     self.view.dataset.write(self.view.datarecord.id, change).done(function() {
+                        ul.removeAttr('disabled');
                         self.view.reload();
                     });
                 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

this fixes an issue where a double click could trigger two calls to write() on the record.
When the write method has side effects, this can have unintended consequences such as
emails being sent twice (tracking notifications) or worse.

Current behavior before PR:

double clic causes 2 calls to write()

Desired behavior after PR is merged:

double clic on status bar causes 1 call to write()

Upstream PR https://github.com/odoo/odoo/pull/13135

Port of #528 to v9
