### PR TITLE
Return all mail.messages if access_right_uid is SUPERUSER_ID

### DIFF
--- a/addons/mail/mail_message.py
+++ b/addons/mail/mail_message.py
@@ -618,7 +618,7 @@ class mail_message(osv.Model):
             - otherwise: remove the id
         """
         # Rules do not apply to administrator
-        if uid == SUPERUSER_ID:
+        if SUPERUSER_ID in (uid, access_rights_uid):
             return super(mail_message, self)._search(
                 cr, uid, args, offset=offset, limit=limit, order=order,
                 context=context, count=count, access_rights_uid=access_rights_uid)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Use case: 
Overriding access rights to get all mail.messages. E.g. adding a special user group that is allowed to read all outgoing mails. 

Current behavior before PR:
Setting `access_right_uid = SUPERUSER_ID` in `mail.message#_search()` still returns only the messages the `uid` has access to. 
Setting `uid = SUPERUSER_ID` to override access rights isn't a good option if uid does matter somewhere in the search process for the final result (we only want to override access rights, not search results). Example: dynamic computation of needaction count via computed field evaluating `self.env.user.id` inside the search function of the field.

Desired behavior after PR is merged:
Setting `access_right_uid = SUPERUSER_ID` is handled like setting `uid = SUPERUSER_ID` in `mail.message#_search()`. 
All mail.messages are returned. 
The result is computed as if search has been run with the current user. 
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
