### PR TITLE
Add multi-company security rule for employees

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -40,6 +40,12 @@
         <field eval="True" name="global"/>
         <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
     </record>
+    <record id="hr_employee_comp_rule" model="ir.rule">
+        <field name="name">Employee multi company rule</field>
+        <field name="model_id" ref="model_hr_employee"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|',('user_id.company_id','=',False),('user_id.company_id','child_of',[user.company_id.id])]</field>
+    </record>
 
 </data>
 </openerp>

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -44,7 +44,7 @@
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('user_id.company_id','=',False),('user_id.company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
     </record>
 
 </data>


### PR DESCRIPTION
OCA version of https://github.com/odoo/odoo/pull/13191

Description of the issue/feature this PR addresses:
Employees don't have any multi-company security rules, but their related users do. Which means that in some cases, for example assigning leaves per employee tag when logged as a user from company A, employees from companies A, B, C will try to access their user to follow the newly created leave assignment, and fail since the user does not have access to company B or C.

Current behavior before PR:
An "user rights" access rule is raised when assigning leaves on an employee tag containing employees from multiple companies. Also, they are all displayed on the "Employees" view.

Desired behavior after PR is merged:
Only access employees from the current user's company.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
