### PR TITLE
[9.0][FIX] web: Fix module arg in test_js

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -2,4 +2,4 @@ import openerp.tests
 
 class WebSuite(openerp.tests.HttpCase):
     def test_01_js(self):
-        self.phantom_js('/web/tests?mod=web',"","", login='admin')
+        self.phantom_js('/web/tests?module=web',"","", login='admin')


### PR DESCRIPTION
I'm not sure if this is the proper procedure, but I just submitted a [PR](https://github.com/odoo/odoo/pull/13194) to Odoo for this. I am duplicating it here, let me know if that was dumb please 😄 

Description of the issue/feature this PR addresses:

PhantomJS runner is being called with incorrect modules parameter, so all PhantomJS tests are being run instead of just `web`.

Current behavior before PR:

Duplicate tests run

Desired behavior after PR is merged:

Tests run only once
