### PR TITLE
Missing context in Report._check_attachment_use

### DIFF
--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -179,7 +179,7 @@ class Report(osv.Model):
         # Get the ir.actions.report.xml record we are working on.
         report = self._get_report_from_name(cr, uid, report_name)
         # Check if we have to save the report or if we have to get one from the db.
-        save_in_attachment = self._check_attachment_use(cr, uid, ids, report)
+        save_in_attachment = self._check_attachment_use(cr, uid, ids, report, context=context)
         # Get the paperformat associated to the report, otherwise fallback on the company one.
         if not report.paperformat_id:
             user = self.pool['res.users'].browse(cr, uid, uid)
@@ -298,7 +298,7 @@ class Report(osv.Model):
     # Report generation helpers
     #--------------------------------------------------------------------------
     @api.v7
-    def _check_attachment_use(self, cr, uid, ids, report):
+    def _check_attachment_use(self, cr, uid, ids, report, context=None):
         """ Check attachment_use field. If set to true and an existing pdf is already saved, load
         this one now. Else, mark save it.
         """


### PR DESCRIPTION
Context is not passed to _check_attachment_use method in report models.

So it's impossible to access to context when inheriting.

Upstream PR: https://github.com/odoo/odoo/pull/13263
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
