### PR TITLE
[FIX] Fix issue #538. Compatibility with Odoo _get_invoice_vals.

### DIFF
--- a/addons/stock_account/stock.py
+++ b/addons/stock_account/stock.py
@@ -283,7 +283,7 @@ class stock_picking(osv.osv):
     def _get_invoice_vals(self, cr, uid, key, inv_type, journal_id, move, context=None):
         if context is None:
             context = {}
-        partner, currency_id, company_id = key
+        partner, currency_id, company_id, user_id = key  # ignore user_id
         if inv_type in ('out_invoice', 'out_refund'):
             account_id = partner.property_account_receivable.id
             payment_term = partner.property_payment_term.id or False
@@ -315,7 +315,7 @@ class stock_picking(osv.osv):
             origin = move.picking_id.name
             partner, user_id, currency_id = move_obj._get_master_data(cr, uid, move, company, context=context)
 
-            key = (partner, currency_id, company.id)
+            key = (partner, currency_id, company.id, user_id)
             invoice_vals = self._get_invoice_vals(cr, uid, key, inv_type, journal_id, move, context=context)
 
             if key not in invoices:

--- a/addons/stock_account/stock.py
+++ b/addons/stock_account/stock.py
@@ -283,7 +283,7 @@ class stock_picking(osv.osv):
     def _get_invoice_vals(self, cr, uid, key, inv_type, journal_id, move, context=None):
         if context is None:
             context = {}
-        partner, currency_id, company_id, user_id = key  # ignore user_id
+        partner, currency_id, company_id, user_id = key
         if inv_type in ('out_invoice', 'out_refund'):
             account_id = partner.property_account_receivable.id
             payment_term = partner.property_payment_term.id or False
@@ -293,7 +293,7 @@ class stock_picking(osv.osv):
         return {
             'origin': move.picking_id.name,
             'date_invoice': context.get('date_inv', False),
-            'user_id': uid,
+            'user_id': user_id,
             'partner_id': partner.id,
             'account_id': account_id,
             'payment_term': payment_term,
@@ -315,7 +315,7 @@ class stock_picking(osv.osv):
             origin = move.picking_id.name
             partner, user_id, currency_id = move_obj._get_master_data(cr, uid, move, company, context=context)
 
-            key = (partner, currency_id, company.id, user_id)
+            key = (partner, currency_id, company.id, uid)
             invoice_vals = self._get_invoice_vals(cr, uid, key, inv_type, journal_id, move, context=context)
 
             if key not in invoices:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/OCA/OCB/issues/538

Current behavior before PR: A crash can occur when modules override _invoice_create_line from stock.py in account_stock
## Desired behavior after PR is merged: OCB and standard Odoo are again fully compatible at this point.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
