### PR TITLE
Search for quants in top packages as well

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -4299,7 +4299,7 @@ class stock_package(osv.osv):
 
     def get_content(self, cr, uid, ids, context=None):
         child_package_ids = self.search(cr, uid, [('id', 'child_of', ids)], context=context)
-        return self.pool.get('stock.quant').search(cr, uid, [('package_id', 'in', child_package_ids)], context=context)
+        return self.pool.get('stock.quant').search(cr, uid, [('package_id', 'in', ids + child_package_ids)], context=context)
 
     def get_content_package(self, cr, uid, ids, context=None):
         quants_ids = self.get_content(cr, uid, ids, context=context)


### PR DESCRIPTION
OCA version of https://github.com/odoo/odoo/pull/13410

Description of the issue/feature this PR addresses:
An issue when using packages. Basically, a list that was filled with given quants in https://github.com/odoo/odoo/blob/9.0/addons/stock/stock.py#L1263 will be looked up by using the first element in pack_quants.
However, this pack_quants will not contain any quants in the "top" packages, as it only returns a list of IDs for the child packages (or empty, if no packages have child packages).

Current behavior before PR:
An error tuple is out of range is raised when looking up the first element of pack_quants.

Desired behavior after PR is merged:
The top-level packages' quants are also in the list.
