### PR TITLE
[FIX] Avoid exception on emtpy result array to provide meaningfull error

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1957,7 +1957,7 @@ class BaseModel(object):
             else:
                 cr.execute('select name, model from ir_ui_view where (id=%s or inherit_id=%s) and arch like %s', (view_id, view_id, '%%%s%%' % field))
                 res = cr.fetchall()[:]
-                model = res[0][1]
+                __, model = res and res[0] or (None, None)
                 res.insert(0, ("Can't find field '%s' in the following view parts composing the view of object model '%s':" % (field, model), None))
                 msg = "\n * ".join([r[0] for r in res])
                 msg += "\n\nEither you wrongly customized this view, or some modules bringing those views are not compatible with your current data model"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Because of an exception while trying to unpack a tuple from empty result the true error message is obscured

Current behavior before PR:
Missleading/unhelpfull error message on broken view definitions.

Desired behavior after PR is merged:
Original error message on broken view definitions is logged. 

Upstream PR: https://github.com/odoo/odoo/pull/13444
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

message
