### PR TITLE
[FIX] manage unicode errors

### DIFF
--- a/openerp/service/model.py
+++ b/openerp/service/model.py
@@ -136,6 +136,8 @@ def check(f):
             except IntegrityError, inst:
                 registry = openerp.registry(dbname)
                 for key in registry._sql_error.keys():
+                    if isinstance(key, unicode):
+                        key = key.encode('utf-8')
                     if key in inst[0]:
                         raise ValidationError(tr(registry._sql_error[key], 'sql_constraint') or inst[0])
                 if inst.pgcode in (errorcodes.NOT_NULL_VIOLATION, errorcodes.FOREIGN_KEY_VIOLATION, errorcodes.RESTRICT_VIOLATION):


### PR DESCRIPTION
upstream PR: https://github.com/odoo/odoo/pull/13501

Description of the issue/feature this PR addresses:

In case your add programatically dynamic SQL constraint, the key in the registry._sql_error dict will be a unicode string.
As the code check if key is in the error returned by PostgreSQL (IntegrityError), an error is raised saying:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 189: ordinal not in range(128)

Current behavior before PR:

Previous error is raised.

Desired behavior after PR is merged:

The good error (and error message) is raised (ValidationError like standard sql constraints)
