### PR TITLE
[MOD] account_analytic_analysis: payment_mode and bank to invoices

### DIFF
--- a/addons/account_analytic_analysis/account_analytic_analysis.py
+++ b/addons/account_analytic_analysis/account_analytic_analysis.py
@@ -703,6 +703,8 @@ class account_analytic_account(osv.osv):
            'origin': contract.code,
            'fiscal_position': fpos_id,
            'payment_term': partner_payment_term,
+           'payment_mode_id': partner.customer_payment_mode.id,
+           'partner_bank_id': partner.customer_payment_mode.bank_id.id,
            'company_id': contract.company_id.id or False,
            'user_id': contract.manager_id.id or uid,
            'comment': contract.description,


### PR DESCRIPTION
Current behavior before PR: 
If you create a recurring invoice from contracts, the invoice is not created with payment mode and bank value of the partner.

Desired behavior after PR is merged:
The recurring invoice from contracts is created with payment mode and bank value of the partner.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
