### PR TITLE
Cleanup of idle DB connections

### DIFF
--- a/openerp/service/server.py
+++ b/openerp/service/server.py
@@ -220,6 +220,7 @@ class ThreadedServer(CommonServer):
                     acquired = openerp.addons.base.ir.ir_cron.ir_cron._acquire_job(db_name)
                     if not acquired:
                         break
+            openerp.sql_db.cleanup()
 
     def cron_spawn(self):
         """ Start the above runner function in a daemon thread.

--- a/openerp/sql_db.py
+++ b/openerp/sql_db.py
@@ -546,7 +546,7 @@ class ConnectionPool(object):
                 self._connections.append((cnx, False))
                 _logger.info('%r: Free leaked connection to %r', self, cnx.dsn)
 
-        for i, (cnx, used) in enumerate(self._connections):
+        for i, (cnx, used) in tools.reverse_enumerate(self._connections):
             if not used and cnx._original_dsn == connection_info:
                 try:
                     cnx.reset()

--- a/openerp/tools/config.py
+++ b/openerp/tools/config.py
@@ -205,6 +205,8 @@ class configmanager(object):
                          help="specify the the maximum number of physical connections to posgresql")
         group.add_option("--db-template", dest="db_template", my_default="template1",
                          help="specify a custom database template to create a new database")
+        group.add_option("--db-cleanup-timeout", dest="db_cleanup_timeout",
+                         help="enable cleanup of DB connections older than N seconds")
         parser.add_option_group(group)
 
         group = optparse.OptionGroup(parser, "Internationalisation options",
@@ -359,7 +361,7 @@ class configmanager(object):
 
         # if defined dont take the configfile value even if the defined value is None
         keys = ['xmlrpc_interface', 'xmlrpc_port', 'longpolling_port',
-                'db_name', 'db_user', 'db_password', 'db_host',
+                'db_name', 'db_user', 'db_password', 'db_host', 'db_cleanup_timeout',
                 'db_port', 'db_template', 'logfile', 'pidfile', 'smtp_port',
                 'email_from', 'smtp_server', 'smtp_user', 'smtp_password',
                 'db_maxconn', 'import_partial', 'addons_path',


### PR DESCRIPTION
## NOTE: This PR is experimental. Do NOT use in production. I'm not responsible for lost data.

If you run an Odoo process with uneven access patterns, particularly sharp peaks (e.g. a daily time when everyone submits their timesheets), you know that it opens a lot of connections to the database to handle the concurrent requests, which are then left indefinitely open, wasting resources (particularly RAM).

One way to solve this is to use a intermediate pooling system like PgBouncer, which handles the "real" connections to the database. But that solutions has drawbacks: it's extra complexity, it prevents using the "peer" authentication system that Postgres supports, and it's another point of failure in the whole system.

But Odoo already implements connection pooling, so why would we need an extra one? With a small fix, we can adjust its behaviour to cut back on the number of connections after they stop being needed.

This commit adds a new CLI/config option (`db_cleanup_timeout`) which will configure how many seconds a connection can be idle until it's automatically closed and removed from the pool.

We are in an early test phase, but the current results seem positive, and we're looking for feedback from potential interested users.
