### PR TITLE
8.0 oca render report offline

### DIFF
--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -225,7 +225,6 @@ class Report(osv.Model):
             for node in root.xpath("//html/head/style"):
                 css += node.text
 
-            cssfiles = []
             for xmlelt in [
                 lxml.html.fromstring(
                     render_minimal(dict(css='', subst=True, body='', base_url=''))
@@ -233,11 +232,10 @@ class Report(osv.Model):
                 root,
             ]:
                 for node in xmlelt.xpath("//link[@rel='stylesheet']"):
-                    css_path = node.get('href')[1:]
-                    if css_path not in cssfiles:
-                        cssfile = file_open(css_path)
-                        css += cssfile.read()
-                        cssfiles.append(css_path)
+                    css_path = node.get('href')
+                    if css_path.startswith("/"):
+                        css_path = css_path[1:]
+                    css += file_open(css_path).read()
                     node.getparent().remove(node)
 
             for node in root.xpath(match_klass.format('header')):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This allow to render Qweb report off line

Current behavior before PR:

You needs wkhmltopdf allowed to access a running odoo server to get all css files

Desired behavior after PR is merged:

Render report somewhere wkhtml2pdf has no access to odoo server
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
