### PR TITLE
fix(account.voucher): only select journals that belong to cash or ban…

### DIFF
--- a/addons/account_voucher/account_voucher.py
+++ b/addons/account_voucher/account_voucher.py
@@ -71,7 +71,8 @@ class account_voucher(osv.osv):
         if context.get('invoice_id', False):
             invoice = invoice_pool.browse(cr, uid, context['invoice_id'], context=context)
             journal_id = journal_pool.search(cr, uid, [
-                ('currency', '=', invoice.currency_id.id), ('company_id', '=', invoice.company_id.id)
+                ('currency', '=', invoice.currency_id.id), ('company_id', '=', invoice.company_id.id),
+                ('type', 'in', ['bank', 'cash'])
             ], limit=1, context=context)
             return journal_id and journal_id[0] or False
         if context.get('journal_id', False):


### PR DESCRIPTION
CURRENT BEHAVIOR

1.- Set up a journal in the next way... name (for instance) CFDI set up a currency (whatever) and set up as a sale journal
2.- Create an invoice using this journal

At the moment of paying the invoice, from the invoice form using the bottom pay invoice, the default
value for journal_id field does not have a restriction to select only cash or bank journals, and in this case
the returned value is CFDI journal but since there is a domain in the view to select only bank or cash journals,
the payment method is not displayed as CFDI in place of a journal name known is displayed

If the user forgotten to select the right payment method  it would create a journal item but incorrectly

DESIRED BEHAVIOR

Not  be able of selecting CFDI journal because is a sale journal, and unknown journal does not exist
