### PR TITLE
fetchmail.py: use IMAP uids instead of SEEN flag

### DIFF
--- a/addons/fetchmail/fetchmail.py
+++ b/addons/fetchmail/fetchmail.py
@@ -36,8 +36,9 @@ import base64
 from openerp import addons
 
 from openerp.osv import fields, osv
-from openerp import tools, api
+from openerp import tools, api, models
 from openerp.tools.translate import _
+
 
 _logger = logging.getLogger(__name__)
 MAX_POP_MESSAGES = 50
@@ -45,6 +46,38 @@ MAIL_TIMEOUT = 60
 
 # Workaround for Python 2.7.8 bug https://bugs.python.org/issue23906
 poplib._MAXLINE = 65536
+import pickle
+
+class imap_track_seen_email_uids(models.Model):
+    _name = 'fetchmail.imap_track_seen_email_uids'
+    _description = 'UIDVALIDITY relative set for imap server account'
+    _columns = {
+            'account_fingerprint':fields.char(required=True ),
+            'uidsset': fields.char(required=True, default=pickle.dumps(set()))
+      }
+
+    def _get_record(self, account_fingerprint):
+        record = self.search([('account_fingerprint', '=', account_fingerprint)])
+        if len(record) == 0:
+            record = self.create({'account_fingerprint': account_fingerprint})
+        return record
+
+    def filter_unprocessed_email_uids_set(self, account_fingerprint, uidsset):
+        record = self._get_record(account_fingerprint)
+
+        pickled_set = record.uidsset
+        processed_set = pickle.loads(pickled_set)
+        return uidsset-processed_set
+
+    def update_processed_email_uids_set(self, account_fingerprint, uids_set):
+        if not uids_set: #No need to read and write from db when the update does not have an effect
+            return
+
+        record = self._get_record(account_fingerprint)
+
+        processed_set = pickle.loads(record.uidsset)
+        processed_set.update(uids_set)
+        record.uidsset = pickle.dumps(processed_set)
 
 class fetchmail_server(osv.osv):
     """Incoming POP/IMAP mail server account"""
@@ -186,8 +219,11 @@ openerp_mailgate: "|/path/to/openerp-mailgate.py --host=localhost -u %(uid)d -p 
             ids = self.search(cr, uid, [('state','=','done'),('type','in',['pop','imap'])])
         return self.fetch_mail(cr, uid, ids, context=context)
 
+
     def fetch_mail(self, cr, uid, ids, context=None):
         """WARNING: meant for cron usage only - will commit() after each email!"""
+        env = models.api.Environment(cr, uid, context)
+        imap_track_seen_email_uids = env['fetchmail.imap_track_seen_email_uids']
         context = dict(context or {})
         context['fetchmail_cron_running'] = True
         mail_thread = self.pool.get('mail.thread')
@@ -199,15 +235,24 @@ openerp_mailgate: "|/path/to/openerp-mailgate.py --host=localhost -u %(uid)d -p 
             imap_server = False
             pop_server = False
             if server.type == 'imap':
+                processed_email_uids = set()
                 try:
                     imap_server = server.connect()
                     imap_server.select()
-                    result, data = imap_server.search(None, '(UNSEEN)')
-                    for num in data[0].split():
+
+                    email_uids_validity = imap_server.response('UIDVALIDITY')[1][0]
+                    account_fingerprint = pickle.dumps((uid, server.name, server.type, server.id,email_uids_validity))
+
+                    inbox_email_uids = imap_server.uid('search', 'all')
+                    inbox_email_uids_set = set([int(x) for x in inbox_email_uids[1][0].split()])
+
+                    email_uids_to_fetch = imap_track_seen_email_uids.filter_unprocessed_email_uids_set(account_fingerprint, inbox_email_uids_set)
+
+                    for email_uid in email_uids_to_fetch:
                         res_id = None
-                        result, data = imap_server.fetch(num, '(RFC822)')
-                        imap_server.store(num, '-FLAGS', '\\Seen')
+                        result, data = imap_server.uid('fetch', email_uid, '(BODY.PEEK[])')
                         try:
+                            processed_email_uids.update(set([email_uid])) #Move this after res_id=... to always retry failed messages!
                             res_id = mail_thread.message_process(cr, uid, server.object_id.model,
                                                                  data[0][1],
                                                                  save_original=server.original,
@@ -216,18 +261,22 @@ openerp_mailgate: "|/path/to/openerp-mailgate.py --host=localhost -u %(uid)d -p 
                         except Exception:
                             _logger.exception('Failed to process mail from %s server %s.', server.type, server.name)
                             failed += 1
+
                         if res_id and server.action_id:
                             action_pool.run(cr, uid, [server.action_id.id], {'active_id': res_id, 'active_ids': [res_id], 'active_model': context.get("thread_model", server.object_id.model)})
-                        imap_server.store(num, '+FLAGS', '\\Seen')
                         cr.commit()
                         count += 1
                     _logger.info("Fetched %d email(s) on %s server %s; %d succeeded, %d failed.", count, server.type, server.name, (count - failed), failed)
+
                 except Exception:
                     _logger.exception("General failure when trying to fetch mail from %s server %s.", server.type, server.name)
+
                 finally:
                     if imap_server:
                         imap_server.close()
                         imap_server.logout()
+                        imap_track_seen_email_uids.update_processed_email_uids_set(account_fingerprint, processed_email_uids)
+
             elif server.type == 'pop':
                 try:
                     while True:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
IMAP mailboxes are fetching new messages relying on the SEEN flag. 
The IMAP protocol provides reliable per-email unique identifiers that can be used to determine wether a message was already seen in a more reliable way, which is even compatible with occasionally using another email client on the same account in case of need.

Current behavior before PR:
mails are fetched from IMAP mailboxes INBOX where the SEEN flag is not set. If another client messes up the SEEN flag on the mailbox, messages may be lost or processed multiple times. 

Desired behavior after PR is merged:
mails are fetched from IMAP if and only if they are new messages, based on IMAP provided unique identifiers, regardless of  and without touching the SEEN flag. 
