### PR TITLE
[FIX] website_project_issue: Order issues by message_last_post

### DIFF
--- a/addons/website_project_issue/controllers/main.py
+++ b/addons/website_project_issue/controllers/main.py
@@ -18,7 +18,7 @@ class WebsiteAccount(website_account):
             '|',
             ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
             ('message_partner_ids', 'child_of', [user.partner_id.id])
-        ])
+        ], order='message_last_post')
         response.qcontext.update({'issues': project_issues})
         return response
 


### PR DESCRIPTION
Odoo PR: https://github.com/odoo/odoo/pull/13969
## Description of the issue/feature this PR addresses:

When using the website portal to explore issues, the important
criteria should be the recent activity. For example, you can open
20 issues, but only the first one has an answer or their state
has changed, and you won't see this issue as is hidden by default
after the later 19 ones.
## Current behavior before PR:

Issues are ordered by default one (priority, create_date desc)
## Desired behavior after PR is merged:

Issues are ordered by message_last_post
