### PR TITLE
[FIX] show pencil for all editable partners

### DIFF
--- a/addons/mail/static/src/xml/mail_followers.xml
+++ b/addons/mail/static/src/xml/mail_followers.xml
@@ -37,7 +37,7 @@
     <div t-name="mail.followers.partner" class='oe_partner'>
         <img class="oe_mail_thumbnail oe_mail_frame" t-att-src="record.avatar_url"/>
         <a t-attf-href="#model=res.partner&amp;id=#{record.id}" t-att-title="record.name" t-att-data-partner="record.id"><t t-esc="record.name"/></a>
-        <span t-if="record.is_editable and (widget.records_length &gt; 1)" class="oe_edit_subtype oe_e oe_hidden" title="Edit subscription" t-att-data-id="record.id">&amp;</span>
+        <span t-if="record.is_editable" class="oe_edit_subtype oe_e oe_hidden" title="Edit subscription" t-att-data-id="record.id">&amp;</span>
         <span t-if="widget.view_is_editable" class="oe_remove_follower oe_e" title="Remove this follower" t-att-data-id="record.id">X</span>
     </div>
     


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Pencils to edit followed subtypes not showing up

Current behavior before PR: If you don't follow a record, you cannot edit its followers' subscriptions

Desired behavior after PR is merged: You can edit subscriptions on editable partners


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

--
The issue is caused by `records_length` only being set in https://github.com/OCA/OCB/blob/8.0/addons/mail/static/src/js/mail_followers.js#L300, but this is called by `fetch_subtypes`, which is called before `display_followers`, where the rendering of this view happens: https://github.com/OCA/OCB/blob/8.0/addons/mail/static/src/js/mail_followers.js#L184