### PR TITLE
[ADD] respect the auto search flag

### DIFF
--- a/addons/web_graph/static/src/js/graph_widget.js
+++ b/addons/web_graph/static/src/js/graph_widget.js
@@ -66,7 +66,16 @@ openerp.web_graph.Graph = openerp.web.Widget.extend({
             self.pivot_options.col_groupby = self.create_field_values(self.pivot_options.col_groupby || []);
             self.pivot_options.measures = self.create_field_values(self.pivot_options.measures || [{field:'__count', type: 'integer', string:'Count'}]);
             self.pivot = new openerp.web_graph.PivotTable(self.model, self.domain, self.fields, self.pivot_options);
-            self.pivot.update_data().then(function () {
+            var deferred = jQuery.when();
+            if (!self.graph_view ||
+                self.graph_view.ViewManager.ActionManager.inner_action
+                .flags.auto_search === undefined ||
+                self.graph_view.ViewManager.ActionManager.inner_action
+                .flags.auto_search)
+            {
+                deferred = self.pivot.update_data();
+            }
+            deferred.then(function () {
                 self.display_data();
                 if (self.graph_view) {
                     self.graph_view.register_groupby(self.pivot.rows.groupby, self.pivot.cols.groupby);


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Don't call search twice; support auto_search

Current behavior before PR: When opening a pivot view, two searches are triggered; if auto_search is disabled, nothing is to be seen

Desired behavior after PR is merged: Only search once, and work correctly with the auto_search flag


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

