### PR TITLE
[FIX] Exceptions do not share the same fields

### DIFF
--- a/addons/procurement/procurement.py
+++ b/addons/procurement/procurement.py
@@ -215,10 +215,14 @@ class procurement_order(osv.osv):
                             cr.rollback()
                             type, value, traceback = exc_info()
                             self.write(cr, uid, [procurement.id], {'state': 'exception'}, context=context)
+                            if issubclass(type, osv.except_osv):
+                                message = _('Cannot run procurement: %s\n%s') \
+                                    % (value.name, value.value)
+                            else:
+                                message = _('Cannot run procurement: %s') \
+                                    % (value.message,)
                             self.message_post(cr, uid, [procurement.id],
-                                body=(_('Cannot run procurement: %s\n%s')
-                                    % (value.name, value.value)),
-                                context=context)
+                                              body=message, context=context)
                         except:
                             # only interfere in batch mode
                             if not autocommit:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This fixes a bug in https://github.com/OCA/OCB/issues/439 (the related PR is not yet merged upstream and has been updated accordingly).

Current behavior before PR:
If a Warning is raised, the scheduler still crashes. This is because a Warning has different fields than an except_osv.

Desired behaviour after PR is merged:
Procurement should be put in the Exception state, scheduler continues.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr