### PR TITLE
[FIX] Remove date_cancel when invoice is draft

### DIFF
--- a/addons/membership/membership.py
+++ b/addons/membership/membership.py
@@ -477,6 +477,15 @@ class Invoice(osv.osv):
     '''Invoice'''
     _inherit = 'account.invoice'
 
+    def action_cancel_draft(self, cr, uid, ids, context=None):
+        member_line_obj = self.pool.get('membership.membership_line')
+        for invoice in self.browse(cr, uid, ids, context=context):
+            mlines = member_line_obj.search(cr, uid,
+                    [('account_invoice_line', 'in',
+                        [l.id for l in invoice.invoice_line])])
+            member_line_obj.write(cr, uid, mlines, {'date_cancel': False})
+        return super(Invoice, self).action_cancel_draft(cr, uid, ids, context=context)
+
     def action_cancel(self, cr, uid, ids, context=None):
         '''Create a 'date_cancel' on the membership_line object'''
         member_line_obj = self.pool.get('membership.membership_line')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When a membership invoice is cancelled, ```date_cancel``` of membership line associated is set. But when the invoice is set as draft ```date_cancel``` field is not reset to False.

Current behavior before PR:

```date_cancel``` has a date even when membership invoice is not cancelled

Desired behavior after PR is merged:

```date_cancel``` must be always False when membership invoice is not cancelled

Odoo PR: https://github.com/odoo/odoo/pull/14313

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

