### PR TITLE
On module update or init always update module list

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -289,9 +289,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         # STEP 2: Mark other modules to be loaded/updated
         if update_module:
             Module = env['ir.module.module']
-            if ('base' in tools.config['init']) or ('base' in tools.config['update']):
-                _logger.info('updating modules list')
-                Module.update_list()
+            _logger.info('updating modules list')
+            Module.update_list()
 
             _check_module_names(cr, itertools.chain(tools.config['init'].keys(), tools.config['update'].keys()))
 


### PR DESCRIPTION
Modules list is updated automatically when using option `-i` or `-u`.
This is a must-have from @dreispt and a pity it has not been merged in Odoo.

Upstream pull request: https://github.com/odoo/odoo/pull/9140

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
