### PR TITLE
[9.0][FIX] purchase: Avoid create purchase invoice lines from picking lines with zero delivery quantities.

### DIFF
--- a/doc/cla/individual/sergio-teruel.md
+++ b/doc/cla/individual/sergio-teruel.md
@@ -1,0 +1,9 @@
+Spain, 2017-01-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Sergio Teruel Albert sergio.teruel@tecnativa.com https://github.com/sergio-teruel


### PR DESCRIPTION
**When I create an purchase invoice from a purchase order, the lines with zero delivery quantities are transfered to invoice**

Impacted versions:

9.0
Steps to reproduce:

create a new purchase order
add 2 lines with product 'Stockable product1', quantity 10, unit price 100.0 and the other one with a diferent stockable product
validate the purchase order
Do a partial picking (Only receipt 5 unit from the first line)
Create a purchase invoice and select the purchase order
Current behavior:

Create invoice lines from picking lines with delivery quantities distinct to zero.
Expected behavior:

Only create invoice lines with delivery quantities distinct to zero
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @Tecnativa