### PR TITLE
Allow CSS styling of the pager counters

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1209,7 +1209,9 @@
 </t>
 
 <div t-name="Pager">
-    <span class="o_pager_value"></span> / <span class="o_pager_limit"></span>
+    <span class="o_pager_counter">
+        <span class="o_pager_value"></span> / <span class="o_pager_limit"></span>
+    </span>
     <span class="btn-group btn-group-sm">
         <!-- accesskeys not wanted in X2Many widgets -->
         <t t-if="!widget.getParent().x2m">


### PR DESCRIPTION
Allow CSS styling of the pager counters, independently of the styling of the pager buttons

Description of the issue/feature this PR addresses:
===

If one wishes to CSS style the counter numbers of the pager (`<current> / <total>`), for example to make sure they stay in a single line without breaking into multiple lines with `white-space: nowrap` while allowing the pager buttons to break into the next line.

Or, more simply, to allow the pager counter numbers to have a different background color (along with the slash) than the pager buttons.

Current behavior before PR:
===

It's not possible to style the page counters in such a way that doesn't also interfere with the pager buttons.

Desired behavior after PR is merged:
===

It should be possible to CSS style the counters, along with the slash that separates them, differently than the pager buttons.

Notice:
===
This is a backport of odoo/odoo#14865, which as accepted upstream into master but not 10.0, even though they admitted it's unlikely to break anything.