### PR TITLE
[8.0] fix sending email from invoice when template mail is deleted

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -395,7 +395,7 @@ class account_invoice(models.Model):
             default_model='account.invoice',
             default_res_id=self.id,
             default_use_template=bool(template),
-            default_template_id=template.id,
+            default_template_id=template and template.id or False,
             default_composition_mode='comment',
             mark_invoice_as_sent=True,
         )


### PR DESCRIPTION
Description of the issue/feature this PR addresses: sending mail template of account invoice

Current behavior before PR: if mail template of account invoice is deleted, raise an error when sending mail from invoice

Desired behavior after PR is merged: if mail template is deleted, no template is proposed


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
