### PR TITLE
[fix+imp] `render_tag_field`: allow to use `t-record` + variable as field name

### DIFF
--- a/openerp/addons/base/ir/ir_qweb.py
+++ b/openerp/addons/base/ir/ir_qweb.py
@@ -497,10 +497,18 @@ class QWeb(orm.AbstractModel):
             "RTE widgets do not work correctly on %r elements" % node_name
         assert node_name != 't',\
             "t-field can not be used on a t element, provide an actual HTML node"
-
-        record, field_name = template_attributes["field"].rsplit('.', 1)
+        try:
+            record, field_name = template_attributes["field"].rsplit('.', 1)
+        except:
+            # record comes from t-record attribute
+            record, field_name = template_attributes["record"], template_attributes['field']
         record = self.eval_object(record, qwebcontext)
-        field = record._fields[field_name]
+        try:
+            field = record._fields[field_name]
+        except:
+            # field_name could be a variable
+            field_name = self.eval_object(field_name, qwebcontext)
+            field = record._fields[field_name]
         foptions = self.eval_format(template_attributes.get('field-options') or '{}', qwebcontext)
         options = json.loads(foptions)
 


### PR DESCRIPTION
`render_tag_field` [docstring](https://github.com/odoo/odoo/blob/9.0/openerp/addons/base/ir/ir_qweb.py#L493) says 
```
 eg: <span t-record="browse_record(res.partner, 1)" t-field="phone">+1 555 555 8069</span>
```
**Current behavior before PR:**
The problem is that `t-record` is not taken into account at all (here's the bug!)

So, you are forced to provide `t-field` value as `record.field_name`.
This prevents to:
1. specify a record on the fly via variable
2. specify a field name on the fly via variable (here's the improvement)

**Desired behavior after PR is merged:**
You can do:
```
<t t-set="fname" t-value="'my_field_name'" />
<span t-record="my_object" t-field="fname" />
```
which is handy to do something like:
```
<t t-foreach="['f1','f2','f3']" t-as="fname">
    <span t-record="object" t-field="fname" />
</t>
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
Parallel odoo PR: odoo/odoo/pull/15235