### PR TITLE
Allows the use of the content of many2many fields in domains

### DIFF
--- a/addons/web/static/src/js/framework/data.js
+++ b/addons/web/static/src/js/framework/data.js
@@ -1091,10 +1091,54 @@ function compute_domain (expr, fields) {
         switch (op.toLowerCase()) {
             case '=':
             case '==':
+                if (_.isArray(field_value)) {
+                    if (val == true) {
+                        if (field_value.length != 0) {
+                            stack.push(true);
+                            break;
+                        }
+                        if (field_value.length == 0) {
+                            stack.push(false);
+                            break;
+                        }
+                    }
+                    if (val == false) {
+                        if (field_value.length == 0) {
+                            stack.push(true);
+                            break;
+                        }
+                        if (field_value.length != 0) {
+                            stack.push(false);
+                            break;
+                        }
+                    }
+                }
                 stack.push(_.isEqual(field_value, val));
                 break;
             case '!=':
             case '<>':
+                if (_.isArray(field_value)) {
+                    if (val == true) {
+                        if (field_value.length != 0) {
+                            stack.push(false);
+                            break;
+                        }
+                        if (field_value.length == 0) {
+                            stack.push(true);
+                            break;
+                        }
+                    }
+                    if (val == false) {
+                        if (field_value.length == 0) {
+                            stack.push(false);
+                            break;
+                        }
+                        if (field_value.length != 0) {
+                            stack.push(true);
+                            break;
+                        }
+                    }
+                }
                 stack.push(!_.isEqual(field_value, val));
                 break;
             case '<':
@@ -1116,6 +1160,29 @@ function compute_domain (expr, fields) {
             case 'not in':
                 if (!_.isArray(val)) val = [val];
                 stack.push(!_(val).contains(field_value));
+                break;
+            case 'child_of':
+                if ((field_value.length == 0) && (val.length == 0)) {
+                    stack.push(true);
+                    break;
+                }
+                if (field_value.length == 0) {
+                    stack.push(false);
+                    break;
+                }
+                if (!_.isArray(val)) val = [val];
+                var itens_esquerda = field_value[0][2];
+                var itens_direita = val;
+                var qtd_direita = itens_direita.length;
+                var encontrou = false;
+
+                while (qtd_direita--) {
+                    var item_direita = itens_direita[qtd_direita];
+                    encontrou = _(itens_esquerda).contains(item_direita);
+                    if (encontrou) break;
+                }
+
+                stack.push(encontrou);
                 break;
             default:
                 console.warn(

--- a/doc/cla/individual/aricaldeira.md
+++ b/doc/cla/individual/aricaldeira.md
@@ -1,0 +1,11 @@
+Brazil, 2017-01-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Aristides José Simões Caldeira aristides.caldeira@tauga.com.br https://github.com/aricaldeira


### PR DESCRIPTION
Odoo: https://github.com/odoo/odoo/pull/15211

Description of the issue/feature this PR addresses:
Today one cannot use many2many fields in domain/invisible/required view statements, as it's contents are store internally as a array structure

Current behavior before PR:
The following is not possible:

    <field name="many2many_field" /> <field name="some_other_field" attrs="{'invisible': [('many2many_field', '=', False)], 'required': [('many2many_field', '!=', False)]}" />

Desired behavior after PR is merged:
The example above will be possible, and also the following:

     <field name="some_other_field" attrs="{'invisible': ['!', ('many2many_field', 'child_of', [%(module.xml_id_1)d, %(module.xml_id_2)d, %(module.xml_id_3)d])], 'required': [('many2many_field', 'child_of', [%(module.xml_id_1)d, %(module.xml_id_2)d, %(module.xml_id_3)d])]}" />