### PR TITLE
[IMP] cache call to get asset attachments

### DIFF
--- a/openerp/addons/base/ir/ir_attachment.py
+++ b/openerp/addons/base/ir/ir_attachment.py
@@ -451,4 +451,4 @@ class ir_attachment(osv.osv):
                 ('%%' if inc is None else '.%s' % inc), asset_type)
             )
         ]
-        return self.search(domain)
+        return self.search(domain, order='name asc')

--- a/openerp/addons/base/ir/ir_attachment.py
+++ b/openerp/addons/base/ir/ir_attachment.py
@@ -441,7 +441,6 @@ class ir_attachment(osv.osv):
     @api.model
     @tools.ormcache('version', 'xmlid', 'inc', 'asset_type')
     def _get_asset_attachments(self, version, xmlid, inc, asset_type):
-        print version, xmlid, inc, asset_type
         """return assets for a view given by its xmlid"""
         domain = [
             # this first proposition is not really necessary, but nudges

--- a/openerp/addons/base/ir/ir_qweb.py
+++ b/openerp/addons/base/ir/ir_qweb.py
@@ -1260,9 +1260,9 @@ class AssetsBundle(object):
 
     def get_attachments(self, type, inc=None):
         ira = self.registry['ir.attachment']
-        domain = [('url', '=like', '/web/content/%%-%s/%s%s.%s' % (self.version, self.xmlid, ('%%' if inc is None else '.%s' % inc), type))]
-        attachment_ids = ira.search(self.cr, openerp.SUPERUSER_ID, domain, order='name asc', context=self.context)
-        return ira.browse(self.cr, openerp.SUPERUSER_ID, attachment_ids, context=self.context)
+        return ira._get_asset_attachments(
+            self.cr, openerp.SUPERUSER_ID, self.version, self.xmlid, inc, type,
+        )
 
     def save_attachment(self, type, content, inc=None):
         ira = self.registry['ir.attachment']


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Performance of website pages and reports

Current behavior before PR: If your attachments table is big, multiple calls to `AssetsBundle.get_attachments` below can cost a few hundred milliseconds, combined you wait a couple of seconds per page load. 

Desired behavior after PR is merged: Web pages and reports are faster.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


No upstream PR because this is 9.0, and there performance patches won't be accepted. In 10, something very similar happens already: https://github.com/OCA/OCB/blob/10.0/odoo/addons/base/ir/ir_qweb/ir_qweb.py#L196