### PR TITLE
[9.0][purchase] create only invoice lines when needed

### DIFF
--- a/addons/purchase/invoice.py
+++ b/addons/purchase/invoice.py
@@ -35,8 +35,8 @@ class AccountInvoice(models.Model):
             qty = line.product_qty - line.qty_invoiced
         else:
             qty = line.qty_received - line.qty_invoiced
-        if float_compare(qty, 0.0, precision_rounding=line.product_uom.rounding) <= 0:
-            # If received quantities or quantities is zero is better not create invoice lines
+        if float_compare(qty, 0.0,
+                         precision_rounding=line.product_uom.rounding) == 0:
             return {}
         taxes = line.taxes_id
         invoice_line_tax_ids = self.purchase_id.fiscal_position_id.map_tax(taxes)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Testing this PR:
OCA/account-invoicing#230

I'm facing this error, only in OCB (not testing with odoo):
https://travis-ci.org/OCA/account-invoicing/jobs/202337862#L1043

Looks like the error here: https://travis-ci.org/OCA/account-invoicing/jobs/202337862#L1008
is caused because new_lines is blank?
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
