### PR TITLE
[FIX][website] Drop irrelevant important!

### DIFF
--- a/addons/website/static/src/css/website.css
+++ b/addons/website/static/src/css/website.css
@@ -274,7 +274,7 @@ ul.nav-stacked > li > a {
 
 @media (max-width: 400px) {
   section, .parallax, .row, .hr, .blockquote {
-    height: auto !important;
+    height: auto;
   }
 }
 .carousel-inner {

--- a/addons/website/static/src/css/website.sass
+++ b/addons/website/static/src/css/website.sass
@@ -216,7 +216,7 @@ ul.nav-stacked > li > a
 
 @media (max-width: 400px)
     section, .parallax, .row, .hr, .blockquote
-        height: auto !important
+        height: auto
 
 .carousel-inner
     height: 100%


### PR DESCRIPTION
This comes from https://github.com/odoo/odoo/pull/15559, fixing the issue described below, which does not exist for 10.0 or master, so this can be considered a FIX, an IMP and a backport all at once.

----

Description of the issue/feature this PR addresses: Overriding this very style in themes is impossible, removing it has no effect.

| Before | After |
| ----- | ----- |
| ![captura el 2017-02-20 a las 10 41 23](https://cloud.githubusercontent.com/assets/973709/23119591/27d71df0-f759-11e6-86bb-4f43b5963fbf.png) | ![captura el 2017-02-20 a las 10 41 29](https://cloud.githubusercontent.com/assets/973709/23119597/2d95401e-f759-11e6-9dab-6070465f524b.png) |

Above screenshot includes HTML elements that match all selectors involved.

The only noticeable difference is the height in one of the elements: a `section.s_title` snippet inside the parallax. This snippet has by default `style="height: 248px"`, so actually overriding a inline style should be considered a bug that this PR also fixes. (Note: really this should have some CSS styling for `.s_title` instead of adding inline styles, but that's another issue.)

@Tecnativa