### PR TITLE
enhancing the function of is_module_installed to be faster

### DIFF
--- a/addons/web_planner/models/web_planner.py
+++ b/addons/web_planner/models/web_planner.py
@@ -71,4 +71,4 @@ class Planner(models.Model):
 
     @api.model
     def is_module_installed(self, module_name=None):
-        return module_name in self.env['ir.module.module']._installed()
+        return module_name in self.env.registry._init_modules


### PR DESCRIPTION
Current behavior before PR:
is_module_installed goes through all modules and look to their state to create a list of all modules that have state=Active then looks for module_name in that list

Desired behavior after PR is merged:
is_module_installed checks if module_name is in registry._init_module set so it takes less time

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
