### PR TITLE
[7.0] issue15820 delivery with realtime stock

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -30,6 +30,7 @@ from openerp.tools.translate import _
 from openerp import netsvc
 from openerp import tools
 from openerp.tools import float_compare, float_round, DEFAULT_SERVER_DATETIME_FORMAT
+from openerp import SUPERUSER_ID
 import openerp.addons.decimal_precision as dp
 import logging
 _logger = logging.getLogger(__name__)
@@ -2488,7 +2489,21 @@ class stock_move(osv.osv):
                             self.action_done(cr, uid, [move.move_dest_id.id], context=context)
 
             self._update_average_price(cr, uid, move, context=context)
-            self._create_product_valuation_moves(cr, uid, move, context=context)
+            # Use SUPERUSER_ID, otherwise warehouse users would need to
+            # be given access to Finance objects.
+            # We need to force company_id to company_id of present user,
+            # because SUPERUSER_ID might have a different company.
+            local_context = context.copy()
+            if ((not uid == SUPERUSER_ID)
+            and ('force_company' not in local_context)):
+                users_model = self.pool.get('res.users')
+                user_record = users_model.read(
+                    cr, uid, uid, ['company_id'], context=context)
+                assert user_record, _('User %d does not exist') % uid
+                local_context['force_company'] = (
+                    user_record['company_id'][0])
+            self._create_product_valuation_moves(
+                cr, SUPERUSER_ID, move, context=local_context)
             if move.state not in ('confirmed','done','assigned'):
                 self.action_confirm(cr, uid, [move.id], context=context)
             self.write(cr, uid, [move.id], 

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -2499,7 +2499,6 @@ class stock_move(osv.osv):
                 users_model = self.pool.get('res.users')
                 user_record = users_model.read(
                     cr, uid, uid, ['company_id'], context=context)
-                assert user_record, _('User %d does not exist') % uid
                 local_context['force_company'] = (
                     user_record['company_id'][0])
             self._create_product_valuation_moves(


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/15820

Current behavior before PR: Users with authority for stock cannot do outgoing deliveries when real time stock accounting is enabled, unless also given accounting authorities

Desired behavior after PR is merged: Stock users can do deliveries, without authority to accounting.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
