### PR TITLE
[9.0][IMP] purchase: Avoid purchase account invoice lines with zero quantities

### DIFF
--- a/addons/purchase/invoice.py
+++ b/addons/purchase/invoice.py
@@ -36,8 +36,7 @@ class AccountInvoice(models.Model):
         else:
             qty = line.qty_received - line.qty_invoiced
         if float_compare(qty, 0.0, precision_rounding=line.product_uom.rounding) <= 0:
-            # If received quantities or quantities is zero is better not create invoice lines
-            return {}
+            qty = 0.0
         taxes = line.taxes_id
         invoice_line_tax_ids = self.purchase_id.fiscal_position_id.map_tax(taxes)
         invoice_line = self.env['account.invoice.line']
@@ -73,7 +72,7 @@ class AccountInvoice(models.Model):
             if line in self.invoice_line_ids.mapped('purchase_line_id'):
                 continue
             data = self._prepare_invoice_line_from_po_line(line)
-            if data:
+            if data.get('quantity', 0.0):
                 # Only create lines with units
                 new_line = new_lines.new(data)
                 new_line._set_additional_fields(self)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fix inheritance _prepare_invoice_line_from_po_line method

--
cc @Tecnativa @jbeficent 
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
