### PR TITLE
[9.0][FIX] in the tests of purchase module the invoice created from a PO should be of type in_invoice

### DIFF
--- a/addons/purchase/tests/test_purchase_order.py
+++ b/addons/purchase/tests/test_purchase_order.py
@@ -76,10 +76,11 @@ class TestPurchaseOrder(AccountingTestCase):
         self.picking.do_new_transfer()
         self.assertEqual(self.po.order_line.mapped('qty_received'), [5.0, 5.0], 'Purchase: all products should be received"')
 
-        self.invoice = self.AccountInvoice.create({
-            'partner_id': self.partner_id.id,
-            'purchase_id': self.po.id,
-            'account_id': self.partner_id.property_account_payable_id.id,
+        self.invoice = self.AccountInvoice.with_context(
+            type='in_invoice').create({
+                'partner_id': self.partner_id.id,
+                'purchase_id': self.po.id,
+                'account_id': self.partner_id.property_account_payable_id.id,
         })
         self.invoice.purchase_order_change()
         self.assertEqual(self.po.order_line.mapped('qty_invoiced'), [5.0, 5.0], 'Purchase: all products should be invoiced"')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes a test in 'purchase' module where customer invoice is created instead of supplier invoice. 
Current behavior before PR:
The test creates a customer invoice from a PO.
Desired behavior after PR is merged:
The test creates a supplier invoice from a PO.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
