### PR TITLE
[8.0][FIX] account_asset: Do not include inactive asset lines on asse…

### DIFF
--- a/addons/account_asset/report/account_asset_report.py
+++ b/addons/account_asset/report/account_asset_report.py
@@ -75,6 +75,7 @@ class asset_asset_report(osv.osv):
                 from account_asset_depreciation_line dl
                     left join account_asset_asset a on (dl.asset_id=a.id)
                     left join (select min(d.id) as id,ac.id as ac_id from account_asset_depreciation_line as d inner join account_asset_asset as ac ON (ac.id=d.asset_id) group by ac_id) as dlmin on dlmin.ac_id=a.id
+                where dl.move_check is True or a.active is True
                 group by 
                     dl.amount,dl.asset_id,dl.depreciation_date,dl.name,
                     a.purchase_date, dl.move_check, a.state, a.category_id, a.partner_id, a.company_id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Not reported
Current behavior before PR:
Inactive asset lines are computed on asset analysis report
Desired behavior after PR is merged:
Do not include inactive asset lines on asset analysis report

#16092

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
