### PR TITLE
[FIX] allow defering of parent computation after load call

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -896,7 +896,10 @@ class BaseModel(object):
             cr.execute('ROLLBACK TO SAVEPOINT model_load')
             ids = False
 
-        if ids and self._context.get('defer_parent_store_computation'):
+        # bypass forced parent_store_compute to do it manually later
+        # by setting `manually` in `defer_parent_store_computation` key
+        defer_parent_compute = self._context.get('defer_parent_store_computation')
+        if ids and defer_parent_compute and defer_parent_compute != 'manually':
             self._parent_store_compute()
 
         return {'ids': ids, 'messages': messages}


### PR DESCRIPTION
Restore the ability to import a large amount of data in an efficient
way by splitted in small files with multiple workers and avoid
concurent error blocking on parent fields update

PR on official branch: https://github.com/odoo/odoo/pull/16001

