### PR TITLE
[10.0][FIX] fleet: Fix error, access to self instead of iteration record

### DIFF
--- a/addons/fleet/models/fleet.py
+++ b/addons/fleet/models/fleet.py
@@ -213,11 +213,11 @@ class FleetVehicle(models.Model):
         LogContract = self.env['fleet.vehicle.log.contract']
         Cost = self.env['fleet.vehicle.cost']
         for record in self:
-            record.odometer_count = Odometer.search_count([('vehicle_id', '=', self.id)])
-            record.fuel_logs_count = LogFuel.search_count([('vehicle_id', '=', self.id)])
-            record.service_count = LogService.search_count([('vehicle_id', '=', self.id)])
-            record.contract_count = LogContract.search_count([('vehicle_id', '=', self.id)])
-            record.cost_count = Cost.search_count([('vehicle_id', '=', self.id), ('parent_id', '=', False)])
+            record.odometer_count = Odometer.search_count([('vehicle_id', '=', record.id)])
+            record.fuel_logs_count = LogFuel.search_count([('vehicle_id', '=', record.id)])
+            record.service_count = LogService.search_count([('vehicle_id', '=', record.id)])
+            record.contract_count = LogContract.search_count([('vehicle_id', '=', record.id)])
+            record.cost_count = Cost.search_count([('vehicle_id', '=', record.id), ('parent_id', '=', False)])
 
     @api.depends('log_contracts')
     def _compute_contract_reminder(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR fix a minor fix in method _compute_count_all of fleet.vehicle
Current behavior before PR:
The error occurs if you extend the model and add other field to fleet.vhicle as Many2one with comodel fleet.vechicle, when the method _compute_count_all is called and self has two or more record generate a singleton error
**Current behavior before PR:**
Singleton error if self has more than one record
**Desired behavior after PR is merged:**
If there is more than one record in self there is no error.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @tecnativa