### PR TITLE
[8.0] Tax calculate precision fix

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -2114,7 +2114,7 @@ class account_tax(osv.osv):
         tax_compute_precision = precision
         if taxes and taxes[0].company_id.tax_calculation_rounding_method == 'round_globally':
             tax_compute_precision += 5
-        totalin = totalex = round(price_unit * quantity, precision)
+        totalin = totalex = round(price_unit * quantity, tax_compute_precision)
         tin = []
         tex = []
         for tax in taxes:

--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -2089,7 +2089,7 @@ class account_tax(osv.osv):
         return self.compute_all(cr, uid, [tax], amount, 1) # TOCHECK may use force_exclude parameter
 
     @api.v7
-    def compute_all(self, cr, uid, taxes, price_unit, quantity, product=None, partner=None, force_excluded=False):
+    def compute_all(self, cr, uid, taxes, price_unit, quantity, product=None, partner=None, force_excluded=False, context=None):
         """
         :param force_excluded: boolean used to say that we don't want to consider the value of field price_include of
             tax. It's used in encoding by line where you don't matter if you encoded a tax with that boolean to True or
@@ -2112,7 +2112,8 @@ class account_tax(osv.osv):
         # rounding after the sum of the tax amounts of each line
         precision = self.pool.get('decimal.precision').precision_get(cr, uid, 'Account')
         tax_compute_precision = precision
-        if taxes and taxes[0].company_id.tax_calculation_rounding_method == 'round_globally':
+        context = context or {}
+        if taxes and taxes[0].company_id.tax_calculation_rounding_method == 'round_globally' or not bool(context.get("round", True)):
             tax_compute_precision += 5
         totalin = totalex = round(price_unit * quantity, tax_compute_precision)
         tin = []
@@ -2143,7 +2144,7 @@ class account_tax(osv.osv):
     def compute_all(self, price_unit, quantity, product=None, partner=None, force_excluded=False):
         return account_tax.compute_all(
             self._model, self._cr, self._uid, self, price_unit, quantity,
-            product=product, partner=partner, force_excluded=force_excluded)
+            product=product, partner=partner, force_excluded=force_excluded, context=self._context)
 
     def compute(self, cr, uid, taxes, price_unit, quantity,  product=None, partner=None):
         _logger.warning("Deprecated, use compute_all(...)['taxes'] instead of compute(...) to manage prices with tax included.")

--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -775,8 +775,9 @@ class purchase_order(osv.osv):
         product_uom = self.pool.get('product.uom')
         price_unit = order_line.price_unit
         if order_line.taxes_id:
+            ctx = dict(context or {}, round=False)
             taxes = self.pool['account.tax'].compute_all(cr, uid, order_line.taxes_id, price_unit, 1.0,
-                                                             order_line.product_id, order.partner_id)
+                                                             order_line.product_id, order.partner_id, context=ctx)
             price_unit = taxes['total']
         if order_line.product_uom.id != order_line.product_id.uom_id.id:
             price_unit *= order_line.product_uom.factor / order_line.product_id.uom_id.factor


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When round globally is selected, this method still rounds it to account precision (instead of +5). This causes product cost and account move entries to be wrong since it is being calculated from output of this method.

Current behavior before PR:

    Set Price Precision to 5 digits, Account Precision to 2 digits, currency rounding to round globally.
    Create a product with real time valuation and set input, output and valuation account on its product category.
    Create a purchase with a product with amount 100 and unit price 1.12345
    Confirm order, make the transfer, confirm invoice.
    Amount is calculated as 112.35 in invoice accounting move.
    Amount is calculated as 112.00 in inventory valuation accounting move.

Desired behavior after PR is merged:

    Set Price Precision to 5 digits, Account Precision to 2 digits, currency rounding to round globally.
    Create a product with real time valuation and set input, output and valuation account on its product category.
    Create a purchase with a product with amount 100 and unit price 1.12345
    Confirm order, make the transfer, confirm invoice.
    Amount is calculated as 112.35 in invoice accounting move.
    Amount is calculated as 112.35 in inventory valuation accounting move.
