### PR TITLE
[8.0] Fix extra moves created on canceled to draft repair orders

### DIFF
--- a/addons/mrp_repair/mrp_repair.py
+++ b/addons/mrp_repair/mrp_repair.py
@@ -270,6 +270,7 @@ class mrp_repair(osv.osv):
         for repair in self.browse(cr, uid, ids):
             mrp_line_obj.write(cr, uid, [l.id for l in repair.operations], {'state': 'draft'})
         self.write(cr, uid, ids, {'state': 'draft'})
+        self.delete_workflow(cr, uid, ids)
         return self.create_workflow(cr, uid, ids)
 
     def action_confirm(self, cr, uid, ids, *args):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Undeleted workflow causes extra moves when cancelled repair orders are set to draft

Fixes #14813

Current behavior before PR:

    Cancel a repair order
    Set to draft
    When completed there exists duplicate moves

Desired behavior after PR is merged:

    Cancel a repair order
    Set to draft
    When completed no duplicate moves created
