### PR TITLE
[FIX] mrp: expected date of the manufactured product move

### DIFF
--- a/addons/mrp/mrp.py
+++ b/addons/mrp/mrp.py
@@ -1107,6 +1107,7 @@ class mrp_production(osv.osv):
         data = {
             'name': production.name,
             'date': production.date_planned,
+            'date_expected': production.date_planned,
             'product_id': production.product_id.id,
             'product_uom': production.product_uom.id,
             'product_uom_qty': production.product_qty,


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/commit/999b2c7e.

Original comment
==============

This revision is related to eafebcb308a6214330479359ee00f460387df7d1

According to the `stock.move` fields definition:
`date` is the "scheduled date until move is done, then date of actual move processing"
`date_expected` is the "Scheduled date for the processing of this move"

The scheduled date of the product being produced in a
manufacturing order is the same scheduled date than written
on the manufacturing order.

opw-674237
