### PR TITLE
[7.0][FIX] Issue #611 - do not copy move_ids on duplicate of statement.

### DIFF
--- a/addons/account/account_bank_statement.py
+++ b/addons/account/account_bank_statement.py
@@ -577,11 +577,11 @@ class account_bank_statement_line(osv.osv):
         'type': 'general',
     }
 
-    def copy(self, cr, uid, id, default=None, context=None):
+    def copy_data(self, cr, uid, id, default=None, context=None):
         if default is None:
             default = {}
         default = dict(default, move_ids=[])
-        return super(account_bank_statement_line, self).copy(
+        return super(account_bank_statement_line, self).copy_data(
             cr, uid, id, default=default, context=context)
 
 account_bank_statement_line()


### PR DESCRIPTION
The overriden copy() for account.bank.statement.line is not called when the copy() for account.bank.statement is called.
By setting move_ids to [] in copy_data, this is active on direct copy of line, or through copy of complete statement.

Description of the issue/feature this PR addresses: #611 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
