### PR TITLE
[FIX] mail, change _get_access_link to get the action id

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -675,7 +675,8 @@ class mail_thread(osv.AbstractModel):
         query = {'db': cr.dbname}
         fragment = {
             'login': partner.user_ids[0].login,
-            'action': 'mail.action_mail_redirect',
+            'action': self.pool.get('ir.model.data').get_object_reference(
+                cr, uid, 'mail', 'action_mail_redirect')[1],
         }
         if mail.notification:
             fragment['message_id'] = mail.mail_message_id.id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When sending an email, for example an invitation to follow a sale order, the address of the related document is wrong. Specifically, the action is the `xml_id` instead of an integer id. So the link is not working.

Current behavior before PR:
An example of wrong url: `http://127.0.0.1:8069/web?db=odoo_test#action=mail.action_mail_redirect&login=admin%40odoo.com&res_id=35611&model=sale.order`

Desired behavior after PR is merged:
The expected url: `http://127.0.0.1:8069/web?db=odoo_test#action=103&login=admin%40odoo.com&res_id=35611&model=sale.order`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
