### PR TITLE
[10.0] [FIX] web: pass correctly value of empty x2many

### DIFF
--- a/addons/web/static/src/js/views/list_common.js
+++ b/addons/web/static/src/js/views/list_common.js
@@ -129,7 +129,7 @@ var Record = Class.extend(/** @lends Record# */{
             if (typeof val !== 'object') {
                 output[k] = val;
             } else if (val instanceof Array) {
-                output[k] = val[0];
+                output[k] = val.length > 0 ? val[0] : null;
             } else {
                 throw new Error(_.str.sprintf(_t("Can't convert value %s to context"), val));
             }


### PR DESCRIPTION
https://github.com/OCA/OCB/pull/547 for 10.0
When pressing a button inside a tree view of a one2many field,
all the existing fields in the view are passed in context to
the action. The toContext function is the one in charge for
preparing field values. These values are passed after an
evaluation through pyeval.js.

With x2many fields, the code always return Array[0], so in
case of empty fields, the return value is `undefined`. As
pyeval.js doesn't know how to handle this value, we get
an error. We can modify toContext for not returning
`undefined`, or add how to handle this value in pyeval. I
have preferred the first one for being less broad to avoid
side effects.
