### PR TITLE
[10.0][FIX][web] Stop recursively adding contexts.

### DIFF
--- a/addons/web/static/src/js/views/list_view.js
+++ b/addons/web/static/src/js/views/list_view.js
@@ -629,6 +629,7 @@ var ListView = View.extend({
             return field.name === name;
         });
         if (!action) { return; }
+        action = $.extend(true, {}, action);
         if ('confirm' in action && !window.confirm(action.confirm)) {
             return;
         }


### PR DESCRIPTION
https://github.com/OCA/OCB/pull/548 for 10.0
Some lines below this patch, there is this:

    if (action.context) {
        c.add(action.context);
    }
    action.context = c;

Since the `action` variable was coming by reference, this means that each time you press a button, it added its context to itself, making that after pressing too many times the same button, recursiveness turned the system slow.

Also, a bigger side effect of this is that if you had a one2many tree view with a button on it that had a context like `{'default_other': some_field}`, the context was not being updated when you clicked on a different row.

With this patch, further modifications on the action are made on a copy, so no recursion happens and the original action is kept intact.
