### PR TITLE
Fix move operation link creation

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -716,7 +716,7 @@ class Picking(models.Model):
                 product_qty = ops.qty_done if done_qtys else ops.product_qty
                 qty_to_assign = ops.product_uom_id._compute_quantity(product_qty, ops.product_id.uom_id)
                 precision_rounding = ops.product_id.uom_id.rounding
-                for move_dict in prod2move_ids.get(ops.product_id.id, []):
+                for move_dict in list(prod2move_ids.get(ops.product_id.id, [])):
                     move = move_dict['move']
                     for quant in move.reserved_quant_ids:
                         if float_compare(qty_to_assign, 0, precision_rounding=precision_rounding) != 1:


### PR DESCRIPTION
This fix has already been merged in version 9.
It is waiting to be merged in Odoo : https://github.com/odoo/odoo/pull/14016

I propose it for version 10 because I do not know if and when it will be merged upstream, I am not sure of the policy about it, because I can't do a PR to Odoo/10.0.
But I've seen that beyond the bug I've found in last PR (https://github.com/OCA/OCB/pull/561), it also decrease the performance of transfer of pickings (we can lose 10% time because of this bug) and can affect all Odoo users, so I think it is important to have the fix in 10.0.

@pedrobaeza @StefanRijnhart 