### PR TITLE
[10.0] archive orderpoints

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -364,6 +364,14 @@ class Product(models.Model):
     def action_view_routes(self):
         return self.mapped('product_tmpl_id').action_view_routes()
 
+    @api.multi
+    def write(self, vals):
+        res = super(Product, self).write(vals)
+        if 'active' in vals and not vals['active']:
+            orderpoints = self.mapped('orderpoint_ids')
+            orderpoints.write({'active': False})
+        return res
+
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'


### PR DESCRIPTION
This is a forward port of #620 

The upstream PR for 9.0 is odoo#16954

When a product is archived, the orderpoints must be archived too, otherwise you will get purchase orders for the deactivated products. 
