### PR TITLE
[FIX] copy move line dicts before modifying them

### DIFF
--- a/addons/account/account_bank_statement.py
+++ b/addons/account/account_bank_statement.py
@@ -836,6 +836,7 @@ class account_bank_statement_line(osv.osv):
         for mv_line_dict in mv_line_dicts:
             if mv_line_dict.get('is_tax_line'):
                 continue
+            mv_line_dict = mv_line_dict.copy()
             mv_line_dict['ref'] = move_name
             mv_line_dict['move_id'] = move_id
             mv_line_dict['period_id'] = st_line.statement_id.period_id.id


### PR DESCRIPTION
upstream PR: https://github.com/odoo/odoo/pull/17470

Description of the issue/feature this PR addresses: Missing reconciliations after fast manual reconciliation

Current behavior before PR: When you have a bank statement where most of Odoo's proposals are fine, you're tempted to click 'OK' like a maniac. This is very likely to cause serialization errors, which causes Odoo to rerun the function. But as the code in process_reconciliation modifies the list of dictionaries it got, specifically drops counterpart_move_line_id, the next call to this function will be without any counterpart_move_line_ids, ergo no reconciliations. This can hurt a lot, because it gives users a false sense of accomplishment.

Desired behavior after PR is merged: We can click 'OK' like a maniac and still have reconciled all lines that are supposed to be.