### PR TITLE
[FIX] Sale_margin vals['product_uom'] error at sale line creation

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -47,8 +47,8 @@ class SaleOrderLine(models.Model):
         if 'purchase_price' not in vals:
             order_id = self.env['sale.order'].browse(vals['order_id'])
             product_id = self.env['product.product'].browse(vals['product_id'])
-            product_uom_id = self.env['product.uom'].browse(vals['product_uom'])
-
+            product_uom_id = product_id.uom_id if not vals.get('product_uom')\
+                else self.env['product.uom'].browse(vals.get('product_uom'))
             vals['purchase_price'] = self._compute_margin(order_id, product_id, product_uom_id)
 
         return super(SaleOrderLine, self).create(vals)

--- a/addons/sale_margin/tests/test_sale_margin.py
+++ b/addons/sale_margin/tests/test_sale_margin.py
@@ -23,14 +23,22 @@ class TestSaleMargin(common.TransactionCase):
         sale_order_so11 = self.SaleOrder.create({
             'date_order': datetime.today(),
             'name': 'Test_SO011',
-            'order_line': [(0, 0, {
-                'name': '[CARD] Graphics Card',
-                'purchase_price': 700.0,
-                'price_unit': 1000.0,
-                'product_uom': self.product_uom_id,
-                'product_uom_qty': 10.0,
-                'state': 'draft',
-                'product_id': self.product_id})],
+            'order_line': [
+                (0, 0, {
+                    'name': '[CARD] Graphics Card',
+                    'purchase_price': 700.0,
+                    'price_unit': 1000.0,
+                    'product_uom': self.product_uom_id,
+                    'product_uom_qty': 10.0,
+                    'state': 'draft',
+                    'product_id': self.product_id}),
+                (0, 0, {
+                    'name': 'Line without product_uom',
+                    'price_unit': 1000.0,
+                    'purchase_price': 700.0,
+                    'product_uom_qty': 10.0,
+                    'state': 'draft',
+                    'product_id': self.product_id})],
             'partner_id': self.partner_id,
             'partner_invoice_id': self.partner_invoice_address_id,
             'partner_shipping_id': self.partner_invoice_address_id,
@@ -38,4 +46,4 @@ class TestSaleMargin(common.TransactionCase):
         # Confirm the sale order.
         sale_order_so11.action_confirm()
         # Verify that margin field gets bind with the value.
-        self.assertEqual(sale_order_so11.margin, 3000.00, "Sale order margin should be 3000.00")
+        self.assertEqual(sale_order_so11.margin, 6000.00, "Sale order margin should be 6000.00")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to fix the folowing bug:
`   File "/home/travis/odoo-10.0/addons/sale_margin/models/sale_order.py", line 50, in create
`     product_uom_id = self.env['product.uom'].browse(vals['product_uom'])
` KeyError: 'product_uom'

Current behavior before PR:
In several module tests we create sale order line without given a product_uom in vals. 
So when one module has a denpendency with the module sale_margin, test will fail. https://github.com/OCA/sale-workflow/pull/429 and https://github.com/OCA/sale-workflow/pull/494.
In the module sale the method create of sale order line trigger product onchange if product_uom is not present in vals.
Desired behavior after PR is merged:
affter this PR if product_uom is not present in vals in create method (in sale_margin) we use the uom of product.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
