### PR TITLE
8.0 voucher writeoff calculation fix

### DIFF
--- a/addons/account_voucher/account_voucher.py
+++ b/addons/account_voucher/account_voucher.py
@@ -214,6 +214,8 @@ class account_voucher(osv.osv):
             if line_id and self.pool.get('account.move.line').browse(cr, uid, line_id, context=context).currency_id:
                 is_multi_currency = True
                 break
+        # See https://github.com/odoo/odoo/issues/6216
+        amount = context['default_amount']
         return {'value': {'writeoff_amount': self._compute_writeoff_amount(cr, uid, line_dr_ids, line_cr_ids, amount, type), 'is_multi_currency': is_multi_currency}}
 
     def _get_journal_currency(self, cr, uid, ids, name, args, context=None):

--- a/doc/cla/individual/daramousk.md
+++ b/doc/cla/individual/daramousk.md
@@ -1,0 +1,11 @@
+Netherlands, 2017-06-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+George Daramouskas gdaramouskas@therp.nl https://github.com/daramousk


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
When we have an invoice and we want to partially reconcile the total amount, the amount
Current behavior before PR:
Open an Invoice -> Register Payment -> Change the paid amount to something less than the total, the different amount will not be calculated properly.
Desired behavior after PR is merged:
Proper calculation of the Difference amount
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
