### PR TITLE
[8.0][FIX] account: bank statement reconciling bug

### DIFF
--- a/addons/account/account_bank_statement.py
+++ b/addons/account/account_bank_statement.py
@@ -902,8 +902,12 @@ class account_bank_statement_line(osv.osv):
         # If the reconciliation is performed in another currency than the company currency, the amounts are converted to get the right debit/credit.
         # If there is more than 1 debit and 1 credit, this can induce a rounding error, which we put in the foreign exchane gain/loss account.
         if st_line_currency.id != company_currency.id:
-            diff_amount = bank_st_move_vals['debit'] - bank_st_move_vals['credit'] \
-                + sum(aml['debit'] for aml in to_create) - sum(aml['credit'] for aml in to_create)
+            diff_amount = (
+                company_currency.round(bank_st_move_vals['debit']) -
+                company_currency.round(bank_st_move_vals['credit']) +
+                sum(company_currency.round(aml['debit']) for aml in to_create)
+                - sum(company_currency.round(aml['credit']) for aml in
+                      to_create))
             if not company_currency.is_zero(diff_amount):
                 diff_aml = self.get_currency_rate_line(cr, uid, st_line, diff_amount, move_id, context=context)
                 diff_aml['name'] = _('Rounding error from currency conversion')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When reconciling a bank statement an error is raised 

> Entry "1864: DSH17H3T111" is not valid!

**Current behavior before PR:** .
After calculating the bank statement's entry, it is calculated if there is a difference between the sum of debit and the sum of credit, in case there is a difference an additional line is added to post the entry. In some cases, when the amount have a lot of decimals, the difference calculated in this way is not the same as calculated rounding amounts per line, so the entry is not balanced.

**Desired behavior after PR is merged:**
When rounding per line, the difference is right calculated and the entry is posted.

Upstrean PR is here: odoo#18132

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
