### PR TITLE
[IMP] Groupby tax on tax account code, account and tax name.

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -723,7 +723,7 @@ class account_invoice(models.Model):
             for tax in self.tax_line:
                 if tax.manual:
                     continue
-                key = (tax.tax_code_id.id, tax.base_code_id.id, tax.account_id.id)
+                key = (tax.tax_code_id.id, tax.base_code_id.id, tax.account_id.id, tax.name)
                 tax_key.append(key)
                 if key not in compute_taxes:
                     raise except_orm(_('Warning!'), _('Global taxes defined, but they are not in invoice lines !'))
@@ -1613,7 +1613,7 @@ class account_invoice_tax(models.Model):
                 if not val.get('account_analytic_id') and line.account_analytic_id and val['account_id'] == line.account_id.id:
                     val['account_analytic_id'] = line.account_analytic_id.id
 
-                key = (val['tax_code_id'], val['base_code_id'], val['account_id'])
+                key = (val['tax_code_id'], val['base_code_id'], val['account_id'], val['name'])
                 if not key in tax_grouped:
                     tax_grouped[key] = val
                 else:


### PR DESCRIPTION
Issue: #630
odoo V8

Description of the issue/feature this PR addresses:
I created invoice line using ST11 and ST1 tax (UK charts of account). Both taxes use same account tax code and tax account. Odoo groupby tax line on account tax code and tax account and show only one tax line. 
Customer often gets confuse and ask for separate tax line on invoice to verify tax easily and efficiently. I am not sure about other countries but in UK it is standard practice to show separate tax on separate line. 

Current behavior before PR:
    * Odoo currently[8.0] group by tax entries on base account code and tax account.
    * There could be tax with same tax account and tax code but would still like to show them separately and invoice.

Desired behavior after PR is merged:
   *  The tax group by should be done on tax code e.g ST11, ST1 and so on
    * There should two tax line one for ST11 and second for ST1

REF : https://bugs.launchpad.net/openobject-addons/+bug/1108801

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
