### PR TITLE
[FIX] test for refund base on amount total not amount untaxed

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -339,6 +339,8 @@ class SaleOrder(models.Model):
         for invoice in invoices.values():
             if not invoice.invoice_line_ids:
                 raise UserError(_('There is no invoicable line.'))
+            # Compute taxes to check total amount
+            invoice.compute_taxes()
             # If invoice is negative, do a refund invoice instead
             if invoice.amount_total < 0:
                 invoice.type = 'out_refund'

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -340,7 +340,7 @@ class SaleOrder(models.Model):
             if not invoice.invoice_line_ids:
                 raise UserError(_('There is no invoicable line.'))
             # If invoice is negative, do a refund invoice instead
-            if invoice.amount_untaxed < 0:
+            if invoice.amount_total < 0:
                 invoice.type = 'out_refund'
                 for line in invoice.invoice_line_ids:
                     line.quantity = -line.quantity


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This is for correction a bug, when you transform a sale order with a voucher into invoice.
Current behavior before PR:
When you create an sale order with a voucher, and if the voucher is greater than
the amount of items you order, the amount untaxed is negative, but in some case the amount with taxes is positive, the system must not create an refund but a normal invoice.
Desired behavior after PR is merged:
The invoice will be created as a customer invoice , not a refund.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
