### PR TITLE
[FIX] website_sale: Assign ID instead of record during create

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -489,7 +489,7 @@ class WebsiteSale(http.Controller):
     def _checkout_form_save(self, mode, checkout, all_values):
         Partner = request.env['res.partner']
         if mode[0] == 'new':
-            partner_id = Partner.sudo().create(checkout)
+            partner_id = Partner.sudo().create(checkout).id
         elif mode[0] == 'edit':
             partner_id = int(all_values.get('partner_id', 0))
             if partner_id:


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/18533

Description of the issue/feature this PR addresses:

* `partner_id` is actually a recordset during the `_checkout_form_save` new address workflow, which generates inconsistent results in address messaging in https://github.com/odoo/odoo/blob/8bd56bb46628e57f41c635f20c527264d7a20d86/addons/website_sale/controllers/main.py#L597

We're only hitting this in some random edge cases & I haven't figured out true replication steps. This fix has been applied in production for about a week, and stopped all the errors.

If you trace `partner_id` in the address method, you will see that it comes from [`_checkout_form_save`](https://github.com/odoo/odoo/blob/8bd56bb46628e57f41c635f20c527264d7a20d86/addons/website_sale/controllers/main.py#L589), and is expected to be an ID when it is to be added into [`order.message_partner_ids`](https://github.com/odoo/odoo/blob/8bd56bb46628e57f41c635f20c527264d7a20d86/addons/website_sale/controllers/main.py#L597) using them ORM method `4`, which only accepts integers.

Current behavior before PR:

During address creation in e-commerce workflow, error is generated:

```
500 Internal Server Error:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/addons/website/models/ir_http.py", line 273, in _handle_exception
    response = super(Http, cls)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_http.py", line 169, in _handle_exception
    return request._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 768, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_http.py", line 195, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 827, in dispatch
    r = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 333, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 326, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 935, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 506, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/website_sale_default_country/controllers/main.py", line 12, in address
    result = super(WebsiteSale, self).address(**kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 506, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/custom/src/odoo/addons/website_sale/controllers/main.py", line 597, in address
    order.message_partner_ids = [(4, partner_id), (3, request.website.partner_id.id)]
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 909, in __set__
    record.write({self.name: write_value})
  File "/opt/odoo/custom/src/odoo/addons/mail/models/mail_thread.py", line 281, in write
    track_self.message_track(tracked_fields, initial_values)
  File "/opt/odoo/custom/src/odoo/addons/mail/models/mail_thread.py", line 484, in message_track
    tracking = self._message_track_get_changes(tracked_fields, initial_values)
  File "/opt/odoo/custom/src/odoo/addons/mail/models/mail_thread.py", line 434, in _message_track_get_changes
    result[record.id] = record._message_track(tracked_fields, initial_values[record.id])
  File "/opt/odoo/custom/src/odoo/addons/mail/models/mail_thread.py", line 465, in _message_track
    tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, initial_value, col_name, col_info)
  File "/opt/odoo/custom/src/odoo/addons/mail/models/mail_tracking_value.py", line 63, in create_tracking_values
    'old_value_char': initial_value and initial_value.name_get()[0][1] or '',
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/res/res_partner.py", line 576, in name_get
    name = partner.name or ''
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 870, in __get__
    self.determine_value(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 972, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3070, in _prefetch_field
    result = records.read([f.name for f in fs], load='_classic_write')
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3010, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3138, in _read_from_database
    cr.execute(query_str, params)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
  File "/usr/local/lib/python2.7/dist-packages/psycopg2/extensions.py", line 123, in getquoted
    pobjs = [adapt(o) for o in self._seq]
ProgrammingError: can't adapt type 'res.partner'
```


Desired behavior after PR is merged:

No error on creation
