### PR TITLE
[FIX] mail: _get_reply_to always uses catchall

### DIFF
--- a/addons/crm/crm_lead.py
+++ b/addons/crm/crm_lead.py
@@ -982,11 +982,12 @@ class crm_lead(format_address, osv.osv):
     # Mail Gateway
     # ----------------------------------------
 
-    def message_get_reply_to(self, cr, uid, ids, context=None):
+    def message_get_reply_to(self, cr, uid, ids, default=None, context=None):
         """ Override to get the reply_to of the parent project. """
         leads = self.browse(cr, SUPERUSER_ID, ids, context=context)
         section_ids = set([lead.section_id.id for lead in leads if lead.section_id])
-        aliases = self.pool['crm.case.section'].message_get_reply_to(cr, uid, list(section_ids), context=context)
+        ctx = dict(context, thread_model='crm.case.section')
+        aliases = self.pool['crm.case.section'].message_get_reply_to(cr, uid, list(section_ids), default=default, context=ctx)
         return dict((lead.id, aliases.get(lead.section_id and lead.section_id.id or 0, False)) for lead in leads)
 
     def get_formview_id(self, cr, uid, id, context=None):

--- a/addons/hr_recruitment/hr_recruitment.py
+++ b/addons/hr_recruitment/hr_recruitment.py
@@ -367,11 +367,12 @@ class hr_applicant(osv.Model):
         action['domain'] = str(['&', ('res_model', '=', self._name), ('res_id', 'in', ids)])
         return action
 
-    def message_get_reply_to(self, cr, uid, ids, context=None):
+    def message_get_reply_to(self, cr, uid, ids, default=None, context=None):
         """ Override to get the reply_to of the parent project. """
         applicants = self.browse(cr, SUPERUSER_ID, ids, context=context)
         job_ids = set([applicant.job_id.id for applicant in applicants if applicant.job_id])
-        aliases = self.pool['project.project'].message_get_reply_to(cr, uid, list(job_ids), context=context)
+        ctx = dict(context, thread_model='hr.job')
+        aliases = self.pool['hr.job'].message_get_reply_to(cr, uid, list(job_ids), default=default, context=ctx)
         return dict((applicant.id, aliases.get(applicant.job_id and applicant.job_id.id or 0, False)) for applicant in applicants)
 
     def message_get_suggested_recipients(self, cr, uid, ids, context=None):

--- a/addons/mail/mail_message.py
+++ b/addons/mail/mail_message.py
@@ -779,8 +779,12 @@ class mail_message(osv.Model):
             or take the email_from
         """
         model, res_id, email_from = values.get('model'), values.get('res_id'), values.get('email_from')
-        ctx = dict(context, thread_model=model)
-        return self.pool['mail.thread'].message_get_reply_to(cr, uid, [res_id], default=email_from, context=ctx)[res_id]
+        ctx = context
+        if model:
+            ctx = dict(context, thread_model=model)
+        else:
+            model = 'mail.thread'
+        return self.pool[model].message_get_reply_to(cr, uid, [res_id], default=email_from, context=ctx)[res_id]
 
     def _get_message_id(self, cr, uid, values, context=None):
         if values.get('no_auto_thread', False) is True:

--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -723,7 +723,7 @@ class mail_thread(osv.AbstractModel):
                 alias_ids = self.pool['mail.alias'].search(
                     cr, SUPERUSER_ID, [
                         ('alias_parent_model_id.model', '=', model_name),
-                        ('alias_parent_thread_id', 'in', ids),
+                        ('alias_parent_thread_id', 'in', ids + [0]),
                         ('alias_name', '!=', False)
                     ], context=context)
                 aliases.update(
@@ -731,7 +731,7 @@ class mail_thread(osv.AbstractModel):
                          for alias in self.pool['mail.alias'].browse(cr, SUPERUSER_ID, alias_ids, context=context)))
                 doc_names.update(
                     dict((ng_res[0], ng_res[1])
-                         for ng_res in self.pool[model_name].name_get(cr, SUPERUSER_ID, aliases.keys(), context=context)))
+                         for ng_res in self.pool[model_name].name_get(cr, SUPERUSER_ID, aliases.keys(), context=context) if ng_res[0]))
             # left ids: use catchall
             left_ids = set(ids).difference(set(aliases.keys()))
             if left_ids:

--- a/addons/project/project.py
+++ b/addons/project/project.py
@@ -1107,11 +1107,12 @@ class task(osv.osv):
             auto_follow_fields = ['user_id', 'reviewer_id']
         return super(task, self)._message_get_auto_subscribe_fields(cr, uid, updated_fields, auto_follow_fields, context=context)
 
-    def message_get_reply_to(self, cr, uid, ids, context=None):
+    def message_get_reply_to(self, cr, uid, ids, default=None, context=None):
         """ Override to get the reply_to of the parent project. """
         tasks = self.browse(cr, SUPERUSER_ID, ids, context=context)
         project_ids = set([task.project_id.id for task in tasks if task.project_id])
-        aliases = self.pool['project.project'].message_get_reply_to(cr, uid, list(project_ids), context=context)
+        ctx = dict(context, thread_model='project.project')
+        aliases = self.pool['project.project'].message_get_reply_to(cr, uid, list(project_ids), default=default, context=ctx)
         return dict((task.id, aliases.get(task.project_id and task.project_id.id or 0, False)) for task in tasks)
 
     def message_new(self, cr, uid, msg, custom_values=None, context=None):

--- a/addons/project_issue/project_issue.py
+++ b/addons/project_issue/project_issue.py
@@ -409,11 +409,12 @@ class project_issue(osv.Model):
     # Mail gateway
     # -------------------------------------------------------
 
-    def message_get_reply_to(self, cr, uid, ids, context=None):
+    def message_get_reply_to(self, cr, uid, ids, default=None, context=None):
         """ Override to get the reply_to of the parent project. """
         issues = self.browse(cr, SUPERUSER_ID, ids, context=context)
         project_ids = set([issue.project_id.id for issue in issues if issue.project_id])
-        aliases = self.pool['project.project'].message_get_reply_to(cr, uid, list(project_ids), context=context)
+        ctx = dict(context, thread_model='project.project')
+        aliases = self.pool['project.project'].message_get_reply_to(cr, uid, list(project_ids), default=default, context=ctx)
         return dict((issue.id, aliases.get(issue.project_id and issue.project_id.id or 0, False)) for issue in issues)
 
     def message_get_suggested_recipients(self, cr, uid, ids, context=None):

--- a/doc/cla/corporate/madvoid.md
+++ b/doc/cla/corporate/madvoid.md
@@ -1,0 +1,15 @@
+France, 2015-08-27
+
+Madvoid agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jean-Paul Bonnetouche jpb@madvoid.com https://github.com/madvoidhq
+
+List of contributors:
+
+Jean-Paul Bonnetouche jpb@madvoid.com https://github.com/goodtouch


### PR DESCRIPTION
Overriden versions of message_get_reply_to are never called, resulting
in always using the catchall email as reply-to for Tasks, Issues, Leads
and Applicants

Impacted versions:

 - 8.0

Steps to reproduce:

 1. Create a Partner and set his email address
 2. Create a Project and set the email name alias
 3. Create an Issue in the Project
 4. Assign the Partner to the Issue
 5. Send a message to the Partner with OpenChatter
 6. Check the reply-to header of the sent mail

Current behavior:

 - The reply-to is the global catchall email

Expected behavior:

 - The reply-to is the project email alias

(This behavior can also be reproduced with Tasks, Leads and Applicants.)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
