### PR TITLE
[10.0] Restrict deletion of equipment if requests exists

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -277,7 +277,8 @@ class MaintenanceRequest(models.Model):
                                help="Date requested for the maintenance to happen")
     owner_user_id = fields.Many2one('res.users', string='Created by', default=lambda s: s.env.uid)
     category_id = fields.Many2one('maintenance.equipment.category', related='equipment_id.category_id', string='Category', store=True, readonly=True)
-    equipment_id = fields.Many2one('maintenance.equipment', string='Equipment', index=True)
+    equipment_id = fields.Many2one('maintenance.equipment', string='Equipment',
+                                   ondelete='restrict', index=True)
     technician_user_id = fields.Many2one('res.users', string='Owner', track_visibility='onchange', oldname='user_id')
     stage_id = fields.Many2one('maintenance.stage', string='Stage', track_visibility='onchange',
                                group_expand='_read_group_stage_ids', default=_default_stage)


### PR DESCRIPTION
Cf : https://github.com/odoo/odoo/pull/18794

Description of the issue/feature this PR addresses:
Any equipment can be deleted without taking care of the existing requests for this equipment.

Current behavior before PR:
Deleting an equipment removes the equipment from the existing requests linked to this equipment, but we have no clue on what happened looking at the existing requests.

Desired behavior after PR is merged:
Deleting an equipment will throw an error if requests are existing for this equipment.
To remove an equipment, the user should first remove the equipment from its requests.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
