### PR TITLE
[8.0] [FIX] Dont interfere with procurement exceptions in non-batch mode

### DIFF
--- a/addons/procurement/procurement.py
+++ b/addons/procurement/procurement.py
@@ -212,6 +212,9 @@ class procurement_order(osv.osv):
                             else:
                                 self.write(cr, uid, [procurement.id], {'state': 'exception'}, context=context)
                         except (openerp.exceptions.Warning, osv.except_osv):
+                            # only interfere in batch mode
+                            if not autocommit:
+                                raise
                             cr.rollback()
                             type, value, traceback = exc_info()
                             self.write(cr, uid, [procurement.id], {'state': 'exception'}, context=context)


### PR DESCRIPTION
In non-batch mode, eg. normal users clicking around in Odoo, dont try to save information about exceptions that are raised on the procurement order.

Otherwise, user may end up trying to write to a procurement order that was created in this transaction but its creation had just been [rollbacked here](https://github.com/OCA/OCB/blob/8.0/addons/procurement/procurement.py#L215), which then raises an exception of its own and obfuscates the real error message.

Description of the issue/feature this PR addresses:
Addresses #646

Current behavior before PR:
On confirm of a quotation that has some fault with it, eg [raises this exception](https://github.com/OCA/OCB/blob/8.0/addons/mrp/mrp.py#L344), shows 'MissingError' exception instead

Desired behavior after PR is merged:
Shows the original exception with its warning message so user can fix it and try to confirm the quotation again

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
