### PR TITLE
[10.0][IMP] purchase: Avoid purchase account invoice lines with zero quantities

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -36,7 +36,8 @@ class AccountInvoice(models.Model):
         else:
             qty = line.qty_received - line.qty_invoiced
         if float_compare(qty, 0.0, precision_rounding=line.product_uom.rounding) <= 0:
-            qty = 0.0
+            # If received quantities or quantities is zero is better not create invoice lines
+            return {}
         taxes = line.taxes_id
         invoice_line_tax_ids = line.order_id.fiscal_position_id.map_tax(taxes)
         invoice_line = self.env['account.invoice.line']
@@ -70,9 +71,11 @@ class AccountInvoice(models.Model):
         new_lines = self.env['account.invoice.line']
         for line in self.purchase_id.order_line - self.invoice_line_ids.mapped('purchase_line_id'):
             data = self._prepare_invoice_line_from_po_line(line)
-            new_line = new_lines.new(data)
-            new_line._set_additional_fields(self)
-            new_lines += new_line
+            if data:
+                # Only create lines with units
+                new_line = new_lines.new(data)
+                new_line._set_additional_fields(self)
+                new_lines += new_line
 
         self.invoice_line_ids += new_lines
         self.purchase_id = False


### PR DESCRIPTION
**When I create an purchase invoice from a purchase order, the lines with zero delivery quantities are transfered to invoice**

Impacted versions:
 - 10.0
 - 9.0 Fixed here: 
 https://github.com/OCA/OCB/pull/580
 https://github.com/OCA/OCB/pull/597

Steps to reproduce:

 1. create a new purchase order
 2. add 2 lines with product 'Stockable product1', quantity 10, unit price 100.0 and the other one with a diferent stockable product
 3. validate the purchase order
 4. Do a partial picking (Only receipt 5 unit from the first line)
 5. Create a purchase invoice and select the purchase order

Current behavior:

 - Create invoice lines from picking lines with delivery quantities distinct to zero.

Expected behavior:

 - Only create invoice lines with delivery quantities distinct to zero

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @Tecnativa
