### PR TITLE
[8.0][FIX] In multicompany environments, if a partner does not belong…

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -309,8 +309,7 @@ class account_invoice(models.Model):
         readonly=True, states={'draft': [('readonly', False)]})
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity',
         compute='_get_commercial_partner_id',
-        search='_search_commercial_partner_id',
-        store=False, readonly=True,
+        store=True, readonly=True,
         help="The commercial entity that will be used on Journal Entries for this invoice")
 
     def _get_commercial_partner_id(self):
@@ -319,9 +318,6 @@ class account_invoice(models.Model):
             while not current_partner.is_company and current_partner.parent_id:
                 current_partner = current_partner.parent_id
             self.commercial_partner_id = current_partner
-
-    def _search_commercial_partner_id(self, operator, value):
-        return [('commercial_partner_id', operator, value)]
 
     _sql_constraints = [
         ('number_uniq', 'unique(number, company_id, journal_id, type)',

--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -308,8 +308,20 @@ class account_invoice(models.Model):
     fiscal_position = fields.Many2one('account.fiscal.position', string='Fiscal Position',
         readonly=True, states={'draft': [('readonly', False)]})
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity',
-        related='partner_id.commercial_partner_id', store=True, readonly=True,
+        compute='_get_commercial_partner_id',
+        search='_search_commercial_partner_id',
+        store=False, readonly=True,
         help="The commercial entity that will be used on Journal Entries for this invoice")
+
+    def _get_commercial_partner_id(self):
+        for partner in self.partner_id:
+            current_partner = partner
+            while not current_partner.is_company and current_partner.parent_id:
+                current_partner = current_partner.parent_id
+            self.commercial_partner_id = current_partner
+
+    def _search_commercial_partner_id(self, operator, value):
+        return [('commercial_partner_id', operator, value)]
 
     _sql_constraints = [
         ('number_uniq', 'unique(number, company_id, journal_id, type)',


### PR DESCRIPTION
… to a company, the stored computed field commercial_partner_id block modification of is_company field

Description of the issue/feature this PR addresses: condition:
1. is multicompany enabled
2. create partner without "company_id"
When changed "is_company" field in res.partner, the onchange cause the recomputation of stored field commercial_partner_id. As this is related in account.invoice, and account.invoice is linked to one company only, the update fails.

Current behavior before PR: update of field is_company in partner impossible 

Desired behavior after PR is merged: is_company field in partner is updatable


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
