### PR TITLE
[MERGE] config: support hashed master passwords

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -623,7 +623,7 @@ class Database(http.Controller):
 
     def _render_template(self, **d):
         d.setdefault('manage',True)
-        d['insecure'] = odoo.tools.config['admin_passwd'] == 'admin'
+        d['insecure'] = odoo.tools.config.verify_admin_password('admin')
         d['list_db'] = odoo.tools.config['list_db']
         d['langs'] = odoo.service.db.exp_list_lang()
         d['countries'] = odoo.service.db.exp_list_countries()

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -32,7 +32,7 @@ class DatabaseExists(Warning):
 #----------------------------------------------------------
 
 def check_super(passwd):
-    if passwd and passwd == odoo.tools.config['admin_passwd']:
+    if passwd and odoo.tools.config.verify_admin_password(passwd):
         return True
     raise odoo.exceptions.AccessDenied()
 
@@ -296,7 +296,7 @@ def exp_rename(old_name, new_name):
     return True
 
 def exp_change_admin_password(new_password):
-    odoo.tools.config['admin_passwd'] = new_password
+    odoo.tools.config.set_admin_password(new_password)
     odoo.tools.config.save()
     return True
 


### PR DESCRIPTION
- Add support for hashed master passwords (super-admin password) using a
  strong scheme (PBKDF2_SHA512).

- Replace the password with a hash in memory (tools.config map), after
  verifying it

- Automatically replace the plaintext master password with a hash when
  saving it after a password change

- Preserve support for setting/using plaintext passwords when necessary
  (e.g. as a temporary deployment thing)

Description of the issue/feature this PR addresses:
Backports encrypted master password to 10.0

Current behaviour before PR:
Master password was in plaintext

Desired behaviour after PR is merged:
Master password encrypted

