### PR TITLE
[8.0][FIX] stock: do not write date_done if it is only splitted

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -991,7 +991,7 @@ class stock_picking(osv.osv):
             move_obj = self.pool.get("stock.move")
             move_obj.write(cr, uid, backorder_move_ids, {'picking_id': backorder_id}, context=context)
 
-            if not picking.date_done:
+            if not picking.date_done and not context.get('do_only_split'):
                 self.write(cr, uid, [picking.id], {'date_done': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)}, context=context)
             self.action_confirm(cr, uid, [backorder_id], context=context)
             return backorder_id


### PR DESCRIPTION
When a picking is splitted it adds date_done to the origin picking, although it has not been finished. With this PR it does not write it when you are executing the split.

odoo PR : https://github.com/odoo/odoo/pull/20131

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
