### PR TITLE
[FIX] Return the result of super in the method put_in_pack 

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -130,7 +130,7 @@ class StockPicking(models.Model):
         current_package_carrier_type = self.carrier_id.delivery_type if self.carrier_id.delivery_type not in ['base_on_rule', 'fixed'] else 'none'
         count_packaging = self.env['product.packaging'].search_count([('package_carrier_type', '=', current_package_carrier_type)])
         if not count_packaging:
-            return False
+            return package
         # By default, sum the weights of all package operations contained in this package
         pack_operation_ids = self.env['stock.pack.operation'].search([('result_package_id', '=', package.id)])
         package_weight = sum([x.qty_done * x.product_id.weight for x in pack_operation_ids])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Return the result of super in the method put_in_pack (module delivery). Otherwise the method can return False even if the package was created

Current behavior before PR:
The inherited method "def put_in_pack" (stock.picking) in the module delivery call super to retrieve the created package. However if this doesn't find a carrier, it will return False.

Desired behavior after PR is merged:
This method should return the result of super