### PR TITLE
[8.0] [FIX] Add httponly flag to the session_id

### DIFF
--- a/addons/web/static/src/js/openerpframework.js
+++ b/addons/web/static/src/js/openerpframework.js
@@ -1081,11 +1081,8 @@ openerp.Session = openerp.Class.extend(openerp.PropertiesMixin, {
             }).always(function() {
                 self.avoid_recursion = false;
             });
-        } else {
-            // normal use case, just use the cookie
-            self.session_id = openerp.get_cookie("session_id");
-            return $.when();
         }
+        return $.when();
     },
     /**
      * Executes an RPC call, registering the provided callbacks.

--- a/openerp/http.py
+++ b/openerp/http.py
@@ -1399,7 +1399,8 @@ class Root(object):
         #   (the one using the cookie). That is a special feature of the Session Javascript class.
         # - It could allow session fixation attacks.
         if not explicit_session and hasattr(response, 'set_cookie'):
-            response.set_cookie('session_id', httprequest.session.sid, max_age=90 * 24 * 60 * 60)
+            response.set_cookie('session_id', httprequest.session.sid,
+                                max_age=90 * 24 * 60 * 60, httponly=True)
 
         return response
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Odoo's session_id cookie can be retrieved with javascript, this facilitates potential XSS extraction of session_ids and therefor session hijacking.

Current behavior before PR: Odoo's session_id cookie does not carry the HttpOnly flag. 

Desired behavior after PR is merged: Odoo's session_Id cookie carries the HttpOnly flag.

Based on commit in odoo main branch 11.0: https://github.com/odoo/odoo/commit/f4d541e51abd7fcb3cd17d3e023b3132b9293d2a

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
