### PR TITLE
[FIX] l10n_fr_certification breaks multi write on account.journal 

### DIFF
--- a/addons/l10n_fr_certification/models/account.py
+++ b/addons/l10n_fr_certification/models/account.py
@@ -143,9 +143,11 @@ class AccountJournal(models.Model):
 
     @api.multi
     def write(self, vals):
-        # restrict the operation in case we are trying to write a forbidden field
-        if self.company_id.country_id.code == 'FR' and vals.get('update_posted'):
-            raise UserError(ERR_MSG % (self._name, 'update_posted'))
+        # restrict operation in case we are trying to write a forbidden field
+        for rec in self:
+            if (rec.company_id.country_id.code == 'FR'
+                    and vals.get('update_posted')):
+                raise UserError(ERR_MSG % (self._name, 'update_posted'))
         return super(AccountJournal, self).write(vals)
 
     @api.model


### PR DESCRIPTION
backport of https://github.com/odoo/odoo/pull/20594

**Description of the issue/feature this PR addresses:**

when using `l10n_fr_certification` write w/ multiple records is broken account.journal

**Current behavior before PR:**
```
File \"/opt/odoo/src/addons/l10n_fr_certification/models/account.py\", line 147, in write
  if self.company_id.country_id.code == 'FR' and vals.get('update_posted'):
File \"/opt/odoo/src/odoo/fields.py\", line 864, in __get__
  record.ensure_one()
File \"/opt/odoo/src/odoo/models.py\", line 4822, in ensure_one
  raise ValueError(\"Expected singleton: %s\" % self)\nValueError: Expected singleton: account.journal(27, 28, 29, 30, 31)"}
```
**Desired behavior after PR is merged:**
make it work!


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
