### PR TITLE
[FIX] project, project_issue, project_timesheet: correct wrong invisi…

### DIFF
--- a/addons/project/project_view.xml
+++ b/addons/project/project_view.xml
@@ -100,7 +100,7 @@
                         </div>
                     </div>
                     <div class="oe_right oe_button_box" name="buttons" groups="base.group_user">
-                         <button class="oe_inline oe_stat_button" type="action" attrs="{'invisible':[('use_tasks','=', 0)]}"
+                         <button class="oe_inline oe_stat_button" type="action" attrs="{'invisible':[('use_tasks','=', False)]}"
                             name="%(act_project_project_2_project_task_all)d" icon="fa-tasks">
                             <field string="Tasks" name="task_count" widget="statinfo"/>
                         </button>

--- a/addons/project_issue/project_issue_view.xml
+++ b/addons/project_issue/project_issue_view.xml
@@ -303,7 +303,7 @@
                     <label for="use_issues"/>
                 </xpath>
                 <xpath expr='//div[@name="buttons"]' position='inside'>
-                    <button class="oe_inline oe_stat_button" type="action" attrs="{'invisible':[('use_issues','=', 0)]}"
+                    <button class="oe_inline oe_stat_button" type="action" attrs="{'invisible':[('use_issues','=', False)]}"
                         name="%(act_project_project_2_project_issue_all)d" icon="fa-bug">
                         <field string="Issues" name="issue_count" widget="statinfo"/>
                     </button>

--- a/addons/project_timesheet/project_timesheet_view.xml
+++ b/addons/project_timesheet/project_timesheet_view.xml
@@ -30,7 +30,7 @@
                     <label for="use_timesheets"/>
                 </xpath>
                 <xpath expr='//div[@name="buttons"]' position="inside">
-                    <button class="oe_inline oe_stat_button" name="open_timesheets" type="object" attrs="{'invisible':[('use_timesheets','=', 0)]}"
+                    <button class="oe_inline oe_stat_button" name="open_timesheets" type="object" attrs="{'invisible':[('use_timesheets','=', False)]}"
                         icon="fa-calendar" string="Timesheets"/>
                 </xpath>
             </field>


### PR DESCRIPTION
…ble conditions
Minimal issue, but takes more time to read it than solve it.

Impacted versions: 8.0

Steps to reproduce: Create a project, uncheck the "Use timesheets" checkbox, the button to timesheets does not dissapear

Current behavior: does not dissapear

Expected behavior: The button should go invisible

Solution:
https://github.com/OCA/OCB/blob/70e35cb40c578e0a4c0879495e932da6fd2a9829/addons/project_timesheet/project_timesheet_view.xml#L33
Replace the invisible condition for:
attrs="{'invisible':[('use_timesheets','=', False)]}"

-----------------------------------
Other versions:

- 9.0: the button does not even have an invisible condition: https://github.com/OCA/OCB/blob/7f70d151a659c1e2979283cb5225a7b9351e5736/addons/project_timesheet/project_timesheet_view.xml#L11

- 10.0: Works perfectly: https://github.com/OCA/OCB/blob/151a7c97b0c330959d9dd2c3a05b5e96fe926e0e/addons/hr_timesheet/project_timesheet_view.xml#L46

