### PR TITLE
fix erppeek xmlrpclib.Fault() call with unicode message

### DIFF
--- a/doc/cla/individual/geekobi.md
+++ b/doc/cla/individual/geekobi.md
@@ -1,0 +1,11 @@
+France, 07/11/2017
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Herve GUERIN geekobi@openagora.fr https://github.com/geekobi

--- a/odoo/service/wsgi_server.py
+++ b/odoo/service/wsgi_server.py
@@ -67,13 +67,13 @@ def xmlrpc_handle_exception_int(e):
 
 def xmlrpc_handle_exception_string(e):
     if isinstance(e, odoo.exceptions.UserError):
-        fault = xmlrpclib.Fault('warning -- %s\n\n%s' % (e.name, e.value), '')
+        fault = xmlrpclib.Fault(RPC_FAULT_CODE_WARNING, u'%s\n\n%s' % (e.name, e.value))
     elif isinstance(e, odoo.exceptions.RedirectWarning):
-        fault = xmlrpclib.Fault('warning -- Warning\n\n' + str(e), '')
+        fault = xmlrpclib.Fault(RPC_FAULT_CODE_WARNING, u'Warning\n\n%s' % str(e))
     elif isinstance(e, odoo.exceptions.MissingError):
-        fault = xmlrpclib.Fault('warning -- MissingError\n\n' + str(e), '')
+        fault = xmlrpclib.Fault(RPC_FAULT_CODE_APPLICATION_ERROR, u'MissingError\n\n%s' % str(e))
     elif isinstance(e, odoo.exceptions.AccessError):
-        fault = xmlrpclib.Fault('warning -- AccessError\n\n' + str(e), '')
+        fault = xmlrpclib.Fault(RPC_FAULT_CODE_APPLICATION_ERROR, u'AccessError\n\n%s' % str(e))
     elif isinstance(e, odoo.exceptions.AccessDenied):
         fault = xmlrpclib.Fault('AccessDenied', str(e))
     elif isinstance(e, odoo.exceptions.DeferredException):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Unhide error from erppeek call when exception is except_orm, Warning or AccessError and message is unicode and not simple string :
When calling a odoo object methode through erppeek, if an error is raised with an unicode error message (for instance a french language message with some accents), if error is an instance of openerp.osv.orm.except_orm, openerp.exceptions.Warning or openerp.exceptions.AccessError, then wsgi_server.py:wmlrpc_handle_exception() calls xmlrpclib.Fault() with parameters faultCode and faultSring in reverse order, and as faultCode doesn't support unicode strings it raises an error. If the error message is a simple string, there is no error and as code is '', the permutation of code and string is not visible.
The issue impacts all versions from 7.0 to 11.0 at least (not checked others)

Current behavior before PR:
Raise an unicode string error when managing the error and loose the initial error message

Desired behavior after PR is merged:
Get the original error in the erppeek caller to help the caller to fix his error

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
