### PR TITLE
9.0 purchase treeview with model discrimination

### DIFF
--- a/addons/purchase/purchase_view.xml
+++ b/addons/purchase/purchase_view.xml
@@ -547,7 +547,16 @@
 
         <record model="ir.actions.act_window" id="action_purchase_line_product_tree">
             <field name="context">{}</field>
-            <field name="domain">[('product_id.product_tmpl_id','in',active_ids)]</field>
+            <field name="domain">[('product_id.product_tmpl_id', 'in', active_ids)]</field>
+            <field name="name">Purchases</field>
+            <field name="res_model">purchase.order.line</field>
+            <field name="view_id" ref="purchase_order_line_tree"/>
+        </record>
+
+
+        <record model="ir.actions.act_window" id="action_purchase_line_product_product_tree">
+            <field name="context">{}</field>
+            <field name="domain">[('product_id', 'in', active_ids)]</field>
             <field name="name">Purchases</field>
             <field name="res_model">purchase.order.line</field>
             <field name="view_id" ref="purchase_order_line_tree"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When calling action action_purchase_line_product_tree from a product.product form  does not work. need model discrimination

Current behavior before PR:
Action not working when called with active model product.product

Desired behavior after PR is merged:
We can call the newly defined action  action_purchase_line_product_product_tree  witth active model product.product and have returned the correct results.  the purchase order_line_tree will be called correctly




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
