### PR TITLE
[FIX] account: Payments without payment_id related aren't showed in …

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -566,7 +566,7 @@ class AccountBankStatementLine(models.Model):
         """
         # Blue lines = payment on bank account not assigned to a statement yet
         reconciliation_aml_accounts = [self.journal_id.default_credit_account_id.id, self.journal_id.default_debit_account_id.id]
-        domain_reconciliation = ['&', '&', ('statement_id', '=', False), ('account_id', 'in', reconciliation_aml_accounts), ('payment_id','<>', False)]
+        domain_reconciliation = ['&', ('statement_id', '=', False), ('account_id', 'in', reconciliation_aml_accounts)]
 
         # Black lines = unreconciled & (not linked to a payment or open balance created by statement
         domain_matching = [('reconciled', '=', False)]
@@ -786,7 +786,7 @@ class AccountBankStatementLine(models.Model):
             # company in currency A, statement in currency B and transaction in currency A
             # counterpart line must have currency B and amount is computed using the rate between A and B
             amount_currency = amount/st_line_currency_rate
-        
+
         # last case is company in currency A, statement in currency A and transaction in currency A
         # and in this case counterpart line does not need any second currency nor amount_currency
 


### PR DESCRIPTION
…statement

Description of the issue/feature this PR addresses:
This commit https://github.com/odoo/odoo/commit/9188d0193465e7aca5c7c9a43ee2b16ba00cbae6 was partially reverted in https://github.com/odoo/odoo/commit/fa02b798377da3a1c14fddbacfc81b626d862283 

OPW opened and rejected by Odoo

Current behavior before PR:
If you create an account move to send or receipt money (manually move, payment order, payment return, ...) this move don't show in statement reconcille (blue lines).

Desired behavior after PR is merged:
Show moves without payment related

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa