### PR TITLE
[FIX] Allow attributes on embedded Many2ManyListView widget

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -5021,7 +5021,6 @@ instance.web.form.Many2ManyListView = instance.web.ListView.extend(/** @lends in
             });
         }
      },
-    is_action_enabled: function () { return true; },
 });
 instance.web.form.Many2ManyList = instance.web.form.AddAnItemList.extend({
     _add_row_class: 'oe_form_field_many2many_list_row_add',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

For some reason the `is_action_enabled` was overridden and always was returning true. The prohibited a super call and the user could not set attributes on the widget (eg. `create="false"`)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
