### PR TITLE
invoice line tax fix

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -1468,6 +1468,7 @@ class account_invoice_line(models.Model):
                         continue
                     res.append(dict(mres))
                     res[-1]['price'] = 0.0
+                    res[-1]['quantity'] = 0.0  # should be 0.0 for correct 'entries analysis' reporting
                     res[-1]['account_analytic_id'] = False
                 elif not tax_code_id:
                     continue


### PR DESCRIPTION
The Odoo 'Entries analysis' (cf. Reporting -> Accounting -> Entries Analysis) gives wrong
results for the 'Product Quantity' measure for intracom acquisitions with tax config based on tax codes
(e.g. l10n_be, l10n_es)

In this case the intracom acquisition expense needs to be reported on 2 'base' tax codes.
the account.invoice.line,move_line_get method creates in such instances an extra
account_move_line and nullifies the 'price' and 'account_analytic_id' values but not
the quantity field.

The result is that the 'Entries Analysis' report shows twice the actual number of acquired products.

This is fixed by also putting the 'quantity' to zero in this method.

cf. also https://github.com/odoo/odoo/pull/21752

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
