### PR TITLE
[9.0][FIX] purchase: Enviroment multicompany payment transaction sudo sale order confirmation

### DIFF
--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -914,7 +914,11 @@ class ProcurementOrder(models.Model):
         cache = {}
         res = []
         for procurement in self:
-            suppliers = procurement.product_id.seller_ids.filtered(lambda r: not r.product_id or r.product_id == procurement.product_id)
+            # Check company when a so is confirmed with sudo by
+            # payment transacction
+            suppliers = procurement.product_id.seller_ids.filtered(lambda r: (
+                (not r.company_id or r.company_id == procurement.company_id) and
+                not r.product_id or r.product_id == procurement.product_id))
             if not suppliers:
                 procurement.message_post(body=_('No vendor associated to product %s. Please set one to fix this procurement.') % (procurement.product_id.name))
                 continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when payment transacction confirm with sudo a sale order mto or dropship in multicompany environment, the supplier filter does not take into account the procurement company.

Current behavior before PR:
The purchase order has a purchase with an wrong supplier

Desired behavior after PR is merged:
The purchase order has a purchase with an succesfull supplier

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa