### PR TITLE
[10.0]Oauth better decoding of Oauth provider response

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -18,6 +18,7 @@ from odoo import registry as registry_get
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome as Home
 from odoo.addons.web.controllers.main import db_monodb, ensure_db, set_cookie_and_redirect, login_and_redirect
 
+import urllib
 
 _logger = logging.getLogger(__name__)
 
@@ -129,7 +130,10 @@ class OAuthController(http.Controller):
     @http.route('/auth_oauth/signin', type='http', auth='none')
     @fragment_to_query_string
     def signin(self, **kw):
-        state = json.loads(kw['state'])
+        tmp_state = urllib.unquote(kw['state'])
+        while urllib.unquote(tmp_state) != tmp_state:
+            tmp_state = urllib.unquote(tmp_state)
+        state = json.loads(tmp_state)
         dbname = state['d']
         provider = state['p']
         context = state.get('c', {})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
* When using other provider than those natively defined like ApereoCas https://apereo.github.io/cas/5.2.x/installation/OAuth-OpenId-Authentication.html, 

Current behavior before PR:
* Response kw['state'] is presented in a non decoded json :
``` unicode: %7B%22p%22%3A 4%2C %22r%22%3A %22http%253A%252F%252Flocalhost%253A8069%252Fweb%22%2C %22d%22%3A %22mag_prod10_2018_01_12%22%7D ```

Desired behavior after PR is merged:

* Interpret the kw['state'] correctly

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
