### PR TITLE
[FIX] website: user navbar check for `main_object`

### DIFF
--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -59,7 +59,7 @@
                 </ul>
 
                 <ul class="o_menu_systray hidden-xs" groups="website.group_website_publisher">
-                    <li t-if="'website_published' in main_object.fields_get()" t-attf-class="js_publish_management #{main_object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="main_object.id" t-att-data-object="main_object._name" t-att-data-controller="publish_controller">
+                    <li t-if="main_object and 'website_published' in main_object.fields_get()" t-attf-class="js_publish_management #{main_object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="main_object.id" t-att-data-object="main_object._name" t-att-data-controller="publish_controller">
                         <a>
                             <label class="o_switch js_publish_btn" for="id" >
                                 <input type="checkbox" t-att-checked="main_object.website_published" id="id"/>
@@ -85,7 +85,7 @@
                     <li t-if="not translatable" id="edit-page-menu">
                         <a data-action="edit" href="#"><span class="fa fa-pencil"/>Edit</a>
                     </li>
-                    <li t-if="'website_published' in main_object.fields_get() and main_object._name != 'website.page'">
+                    <li t-if="main_object and 'website_published' in main_object.fields_get() and main_object._name != 'website.page'">
                         <a class="btn btn-primary btn-xs dropdown-toggle css_edit_dynamic" data-toggle="dropdown">
                             <span class="caret"></span>
                             <span class="sr-only">Toggle Dropdown</span>


### PR DESCRIPTION
**Current behavior before PR:**

User navbar rendering broken if `main_object` is None.

**Desired behavior after PR is merged:**

Make it fault tolerant and check if that object is really there.

**Upstream PR:** https://github.com/odoo/odoo/pull/22384 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
