### PR TITLE
[FIX] requirements: Don't complain on missing library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ mock==2.0.0
 num2words==0.5.4
 ofxparse==0.16
 passlib==1.6.5
+phonenumbers
 Pillow==4.0.0
 psutil==4.3.1; sys_platform != 'win32'
 psycopg2==2.7.3.1; sys_platform != 'win32'


### PR DESCRIPTION
A wizard from module `sms` try to import this library and complains with a warning if not found. This makes runbot to turn brown, which for Travis status means red, causing false alarms by that.

As most of the 11.0 repositories uses OCB for building runbot instances, this will greenify the PRs without adding the library repository per repository.

I have proposed it directly to OCB without PR to Odoo because Odoo is going to reject it, or they will already added to the file.