### PR TITLE
[IMP] web format value number

### DIFF
--- a/addons/web/static/src/js/formats.js
+++ b/addons/web/static/src/js/formats.js
@@ -238,6 +238,9 @@ instance.web.parse_value = function (value, descriptor, value_if_empty) {
                 throw new Error(_.str.sprintf(_t("'%s' is not a correct integer"), value));
             return tmp;
         case 'float':
+            var tmp = Number(value);
+            if (!isNaN(tmp))
+                return tmp;
             var tmp2 = value;
             do {
                 tmp = tmp2;


### PR DESCRIPTION
Description of the issue/feature this PR addresses: if float separator is not dot, float number can't be expressed in English format

Current behavior before PR: float numbers with dot separator are evaluated as they don't exist

Desired behavior after PR is merged: float numbers with dot separator are evaluated correctly


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
