### PR TITLE
[FIX] pos_restaurant: make config items inheritable 

### DIFF
--- a/addons/pos_restaurant/views/pos_config_views.xml
+++ b/addons/pos_restaurant/views/pos_config_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <button id="btn_use_pos_restaurant" position="replace"/>
             <div id="iface_invoicing" position="before">
-                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="iface_printbill" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="iface_printbill"/>
                     </div>
@@ -20,7 +20,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="iface_splitbill" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="iface_splitbill"/>
                     </div>
@@ -32,7 +32,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xs-12 col-md-6 o_setting_box" title="This product is used as reference on customer receipts." attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="iface_tipproduct" title="This product is used as reference on customer receipts." attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="iface_tipproduct"/>
                     </div>
@@ -52,7 +52,7 @@
                 </div>
             </div>
             <div id="barcode_scanner" position="after">
-                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="is_order_printer" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="is_order_printer"/>
                     </div>
@@ -75,7 +75,7 @@
                 </div>
             </div>
             <div id="category_reference" position="before">
-                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="is_table_management" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="is_table_management"/>
                     </div>
@@ -96,7 +96,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
+                <div class="col-xs-12 col-md-6 o_setting_box" id="iface_orderline_notes" attrs="{'invisible': [('module_pos_restaurant', '=', False)]}">
                     <div class="o_setting_left_pane">
                         <field name="iface_orderline_notes"/>
                     </div>

--- a/doc/cla/individual/primes2h.md
+++ b/doc/cla/individual/primes2h.md
@@ -1,0 +1,11 @@
+Italy, 2018-02-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sergio Zanchetta primes2h@gmail.com https://github.com/primes2h


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- point_of_sale config items have each an id attribute to be easily intercepted by other modules based on it. (eg. pos_restaurant)
- pos_restaurant extend point_of_sale config items without setting an id for new items added.
- So, for a new module depending upon pos_restaurant, it's not possible to intercept pos_restaurant config_items.

Current behavior before PR:

- pos_restaurant config items can't be intercepted to extend functionality.

Desired behavior after PR is merged:

- pos_restaurant config items are interceptable, so you can add features.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
