### PR TITLE
Improve commitment_date calculation to take into account picking policy,

### DIFF
--- a/addons/sale_order_dates/sale_order_dates.py
+++ b/addons/sale_order_dates/sale_order_dates.py
@@ -21,7 +21,10 @@ class sale_order_dates(osv.osv):
             for pick in order.picking_ids:
                 dates_list.append(pick.date)
             if dates_list:
-                res[order.id] = min(dates_list)
+                if self.picking_policy == 'one'
+                   res[order.id] = max(dates_list)
+                else:
+                   res[order.id] = min(dates_list)
             else:
                 res[order.id] = False
         return res


### PR DESCRIPTION
if products should be delivered together take the max date, if they are
delivered separately take the min date.

Description of the issue/feature this PR addresses:

Current behavior before PR:
the commitment date was allways the minimum date on the SO


Desired behavior after PR is merged:
Now the commitment date checks if picking policy is "one" (IOW all products together) and chooses the maximum date to determine the commitment_date.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
