### PR TITLE
base: Do not force creating localhost SMTP server

### DIFF
--- a/openerp/addons/base/base_data.xml
+++ b/openerp/addons/base/base_data.xml
@@ -74,7 +74,7 @@ Administrator</span>]]></field>
             <field name="company_id" ref="main_company"/>
         </record>
 
-        <record id="ir_mail_server_localhost0" model="ir.mail_server">
+        <record id="ir_mail_server_localhost0" model="ir.mail_server" forcecreate="0">
             <field name="name">localhost</field>
             <field name="smtp_host">localhost</field>
             <field eval="25" name="smtp_port"/>


### PR DESCRIPTION
Assuming there's a SMTP server always in `localhost:10` is itself something weird, but at least Odoo shouldn't recreate the record if it was removed for any reason.

This is a backport from https://github.com/odoo/odoo/pull/23285


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa