### PR TITLE
[9.0][FIX] Fix move line update check

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1200,7 +1200,8 @@ class AccountMoveLine(models.Model):
             err_msg = _('Move name (id): %s (%s)') % (line.move_id.name, str(line.move_id.id))
             if line.move_id.state != 'draft':
                 raise UserError(_('You cannot do this modification on a posted journal entry, you can just change some non legal fields. You must revert the journal entry to cancel it.\n%s.') % err_msg)
-            if line.reconciled and not (line.debit == 0 and line.credit == 0):
+            digits_rounding_precision = line.company_id.currency_id.rounding
+            if line.reconciled and not (float_is_zero(line.debit, precision_rounding=digits_rounding_precision) and float_is_zero(line.credit, precision_rounding=digits_rounding_precision)):
                 raise UserError(_('You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.\n%s.') % err_msg)
             if line.move_id.id not in move_ids:
                 move_ids.add(line.move_id.id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When we have an account.move containing account.move.line where debit and credit equals 0, we normally can unlink these records even if, according to the code, the line is considered reconciled as the residual amount is also equals to 0. Currently, the comparison is made with a strict equal (==), comparing a float with an integer. But, most of the time, float are stored with full precision in DB (e.g. : 0.0000000000000006661338147750939), so the test return false and, thus not allowing us to unlink a record we should normally be allowed to.

Current behavior before PR:
Cannot unlink account.move with account.move.line where debit and credit equals 0 with the following error : "You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first."

Desired behavior after PR is merged:
Can unlink account.move with account.move.line where debit and credit equals 0 without errors.