### PR TITLE
[10.0][IMP] Update hr_payroll payslip report structure

### DIFF
--- a/addons/hr_payroll/tests/test_payslip_flow.py
+++ b/addons/hr_payroll/tests/test_payslip_flow.py
@@ -72,7 +72,7 @@ class TestPayslipFlow(TestPayslipBase):
         })
 
         # I print the payslip report
-        data, format = render_report(self.env.cr, self.env.uid, richard_payslip.ids, 'hr_payroll.report_payslip', {}, {})
+        data, format = render_report(self.env.cr, self.env.uid, richard_payslip.ids, 'hr_payroll.report_payslip_main', {}, {})
         if config.get('test_report_directory'):
             file(os.path.join(config['test_report_directory'], 'hr_payroll-payslip.'+ format), 'wb+').write(data)
 

--- a/addons/hr_payroll/views/hr_payroll_report.xml
+++ b/addons/hr_payroll/views/hr_payroll_report.xml
@@ -14,8 +14,8 @@
             model="hr.payslip" 
             string="Payslip"
             report_type="qweb-pdf"
-            name="hr_payroll.report_payslip" 
-            file="hr_payroll.report_payslip"
+            name="hr_payroll.report_payslip_main" 
+            file="hr_payroll.report_payslip_main"
         />
         <report
             id="payslip_details_report"

--- a/addons/hr_payroll/views/report_payslip_templates.xml
+++ b/addons/hr_payroll/views/report_payslip_templates.xml
@@ -1,75 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<template id="report_payslip">
-    <t t-call="report.html_container">
-        <t t-foreach="docs" t-as="o">
-            <t t-call="report.external_layout">
-                <div class="page">
-                    <h2>Pay Slip</h2>
-                    <p t-field="o.name"/>
-
-                    <table class="table table-condensed table-bordered">
-                        <tr>
-                            <td><strong>Name</strong></td>
-                            <td><span t-field="o.employee_id"/></td>
-                            <td><strong>Designation</strong></td>
-                            <td><span t-field="o.employee_id.job_id"/></td>
-                        </tr>
-                        <tr>
-                            <td><strong>Address</strong></td>
-                            <td colspan="3">
-                                <div t-field="o.employee_id.address_home_id"
-                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone", "fax"], "no_marker": True, "phone_icons": True}'/>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><strong>Email</strong></td>
-                            <td><span t-field="o.employee_id.work_email"/></td>
-                            <td><strong>Identification No</strong></td>
-                            <td><span t-field="o.employee_id.identification_id"/></td>
-                        </tr>
-                        <tr>
-                            <td><strong>Reference</strong></td>
-                            <td><span t-field="o.number"/></td>
-                            <td><strong>Bank Account</strong></td>
-                            <td><span t-field="o.employee_id.bank_account_id"/></td>
-                        </tr>
-                        <tr>
-                            <td><strong>Date From</strong></td>
-                            <td><span t-field="o.date_from"/></td>
-                            <td><strong>Date To</strong></td>
-                            <td><span t-field="o.date_to"/></td>
-                        </tr>
-                    </table>
-
-                    <table class="table table-condensed">
-                        <thead>
-                            <tr>
-                                <th>Code</th>
-                                <th>Name</th>
-                                <th>Quantity/rate</th>
-                                <th>Amount</th>
-                                <th>Total</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                                <tr t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="line">
-                                <td><span t-field="line.code"/></td>
-                                <td><span t-field="line.name"/></td>
-                                <td><span t-field="line.quantity"/></td>
-                                <td><span t-esc="line.amount"
-                                          t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
-                                <td><span t-esc="line.total"
-                                          t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
-
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <p class="text-right"><strong>Authorized signature</strong></p>
-                </div>
+    <template id="report_payslip_main">
+        <t t-call="report.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="hr_payroll.report_payslip" />
             </t>
         </t>
-    </t>
-</template>
+    </template>
+
+    <template id="report_payslip">
+        <t t-call="report.external_layout">
+            <div class="page">
+                <h2>Pay Slip</h2>
+                <p t-field="o.name"/>
+
+                <table class="table table-condensed table-bordered">
+                    <tr>
+                        <td><strong>Name</strong></td>
+                        <td><span t-field="o.employee_id"/></td>
+                        <td><strong>Designation</strong></td>
+                        <td><span t-field="o.employee_id.job_id"/></td>
+                    </tr>
+                    <tr>
+                        <td><strong>Address</strong></td>
+                        <td colspan="3">
+                            <div t-field="o.employee_id.address_home_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone", "fax"], "no_marker": True, "phone_icons": True}'/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><strong>Email</strong></td>
+                        <td><span t-field="o.employee_id.work_email"/></td>
+                        <td><strong>Identification No</strong></td>
+                        <td><span t-field="o.employee_id.identification_id"/></td>
+                    </tr>
+                    <tr>
+                        <td><strong>Reference</strong></td>
+                        <td><span t-field="o.number"/></td>
+                        <td><strong>Bank Account</strong></td>
+                        <td><span t-field="o.employee_id.bank_account_id"/></td>
+                    </tr>
+                    <tr>
+                        <td><strong>Date From</strong></td>
+                        <td><span t-field="o.date_from"/></td>
+                        <td><strong>Date To</strong></td>
+                        <td><span t-field="o.date_to"/></td>
+                    </tr>
+                </table>
+
+                <table class="table table-condensed">
+                    <thead>
+                        <tr>
+                            <th>Code</th>
+                            <th>Name</th>
+                            <th>Quantity/rate</th>
+                            <th>Amount</th>
+                            <th>Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                            <tr t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)" t-as="line">
+                            <td><span t-field="line.code"/></td>
+                            <td><span t-field="line.name"/></td>
+                            <td><span t-field="line.quantity"/></td>
+                            <td><span t-esc="line.amount"
+                                      t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
+                            <td><span t-esc="line.total"
+                                      t-esc-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/></td>
+
+                        </tr>
+                    </tbody>
+                </table>
+
+                <p class="text-right"><strong>Authorized signature</strong></p>
+            </div>
+        </t>
+    </template>
 </odoo>
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, the structure of the payslip report does not allow for an override of the language used in the said report. For example, if you want to issue the payslip in the employee language, you can't unless rewriting the whole report in your own module.

Current behavior before PR:
Payslip report is printed in the user language, without any possibilities to override it.

Desired behavior after PR is merged:
Payslip report can be inherited to change its language.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
