### PR TITLE
[IMP] base: allow to set a timeout in SMTP servers

### DIFF
--- a/openerp/addons/base/ir/ir_mail_server_view.xml
+++ b/openerp/addons/base/ir/ir_mail_server_view.xml
@@ -15,6 +15,7 @@
                         <field name="smtp_host"/>
                         <field name="smtp_port"/>
                         <field name="smtp_debug" groups="base.group_no_one"/>
+                        <field name="smtp_timeout"/>
                      </group>
                      <group string="Security and Authentication" colspan="4">
                         <field name="smtp_encryption" on_change="on_change_encryption(smtp_encryption)"/>

--- a/openerp/tools/config.py
+++ b/openerp/tools/config.py
@@ -236,6 +236,8 @@ class configmanager(object):
                          help='specify the SMTP username for sending email')
         group.add_option('--smtp-password', dest='smtp_password', my_default=False,
                          help='specify the SMTP password for sending email')
+        group.add_option('--smtp-timeout', dest='smtp_timeout', type="float",
+                         help='if greater than zero, the timeout in seconds for SMTP connections')
         parser.add_option_group(group)
 
         group = optparse.OptionGroup(parser, "Database related options")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Allow to set a timeout in SMTP servers.

Current behavior before PR:

If SMTP server isn't available the email delivery hangs indefinitely.

Desired behavior after PR is merged:

If SMTP server isn't available the email delivery fails after the timeout.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
