### PR TITLE
[FIX] show falsy translations

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3325,7 +3325,9 @@ class BaseModel(object):
                         res_trans = ir_translation._get_ids(
                             '%s,%s' % (self._name, f), 'model', context['lang'], ids)
                         for vals in result:
-                            vals[f] = res_trans.get(vals['id'], False) or vals[f]
+                            if res_trans.get(vals['id']) is False:
+                                res_trans.pop(vals['id'])
+                            vals[f] = res_trans.get(vals['id'], vals[f])
 
             # apply the symbol_get functions of the fields we just read
             for field in fields_pre:


### PR DESCRIPTION
without this, if you change a string to the empty string in some language, it will show you the English version.

No upstream PR because 8 is out of maintenance and translations are handled totally differently in newer versions