### PR TITLE
calendar, event: do not send emails to canceled attendees

### DIFF
--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -257,7 +257,7 @@ class event_event(models.Model):
         return res
 
     @api.one
-    def mail_attendees(self, template_id, force_send=False, filter_func=lambda self: True):
+    def mail_attendees(self, template_id, force_send=False, filter_func=lambda self: self.state != 'cancel'):
         for attendee in self.registration_ids.filtered(filter_func):
             self.env['mail.template'].browse(template_id).send_mail(attendee.id, force_send=force_send)
 


### PR DESCRIPTION
Backport https://github.com/odoo/odoo/commit/de62e33618211fd754ad6e372ac93805cce58770
for OCB 9.0.

Fixed in v10 and v11 upstream, doing backport from https://github.com/odoo/odoo/pull/22882 here.

Current behavior before PR: mails were sent to cancelled attendees by default

Desired behavior after PR is merged: mails sent only to non-cancelled attendees

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa