### PR TITLE
[8.0] fix stock search to2invoiced

### DIFF
--- a/addons/purchase/stock.py
+++ b/addons/purchase/stock.py
@@ -195,13 +195,21 @@ class stock_picking(osv.osv):
                 if move.purchase_line_id and move.purchase_line_id.order_id.invoice_method == 'picking':
                     if not move.move_orig_ids:
                         res[picking.id] = True
+                elif move.origin_returned_move_id and \
+                        move.location_dest_id.usage == 'internal':
+                    if not move.move_orig_ids:
+                        res[picking.id] = True
         return res
 
     def _get_picking_to_recompute(self, cr, uid, ids, context=None):
         picking_ids = set()
         for move in self.pool.get('stock.move').browse(cr, uid, ids, context=context):
-            if move.picking_id and move.purchase_line_id:
-                picking_ids.add(move.picking_id.id)
+            if move.picking_id:
+                if move.purchase_line_id or (
+                    move.origin_returned_move_id and
+                    move.location_dest_id.usage == 'internal'
+                ):
+                    picking_ids.add(move.picking_id.id)
         return list(picking_ids)
 
     _columns = {


### PR DESCRIPTION
Description of the issue/feature this PR addresses: when return a transfer (from a customer or to a supplier) this is not shown in picking to be invoiced in sale or purchase menu

Current behavior before PR: returned transfer are not shown in shipping to be invoiced

Desired behavior after PR is merged: returned transfer are shown in shipping to be invoiced


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
