### PR TITLE
[FIX] English translations can be empty and still OK

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -3325,9 +3325,7 @@ class BaseModel(object):
                         res_trans = ir_translation._get_ids(
                             '%s,%s' % (self._name, f), 'model', context['lang'], ids)
                         for vals in result:
-                            if res_trans.get(vals['id']) is False:
-                                res_trans.pop(vals['id'])
-                            vals[f] = res_trans.get(vals['id'], vals[f])
+                            vals[f] = res_trans.get(vals['id'], False) or vals[f]
 
             # apply the symbol_get functions of the fields we just read
             for field in fields_pre:


### PR DESCRIPTION
If you database included some English translations, those get the translated value empty by design, given *the original purpose of empty translations was to mean the field is not yet translated*.

https://github.com/OCA/OCB/pull/710 introduced a breaking change where an empty translation *now means that you really want the field contents to disappear* in the target language.

We have to skip en_US from that POV.

Honestly I think we should completely rollback that PR. If you want an empty translation, you just have to write `" "` into it, that's enough. I guess nobody noticed this logical breakage, but I guess it's gonna produce many failures for many people that will start seeing empty things where there was English text before...

In any case I started by fixing my specific problem, but I can switch to undoing that commit if we agree on that.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa