### PR TITLE
[IMP] website_portal_sale: Skip website view if possible

### DIFF
--- a/addons/website_portal_sale/models/sale_order.py
+++ b/addons/website_portal_sale/models/sale_order.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from openerp import api, models
+from openerp import api, exceptions, models
 
 
 class sale_order(models.Model):
@@ -9,14 +9,22 @@ class sale_order(models.Model):
 
     @api.multi
     def get_access_action(self):
-        """ Override method that generated the link to access the document. Instead
-        of the classic form view, redirect to the online quote if exists. """
+        """ Instead of the classic form view, redirect to the online quote for
+        portal users that have access to a confirmed order. """
+        # TDE note: read access on sale order to portal users granted to followed sale orders
         self.ensure_one()
-        if self.state in ['draft', 'cancel']:
+        if self.state == 'cancel' or (self.state == 'draft' and not self.env.context.get('mark_so_as_sent')):
             return super(sale_order, self).get_access_action()
-        return {
-            'type': 'ir.actions.act_url',
-            'url': '/my/orders/%s' % self.id,
-            'target': 'self',
-            'res_id': self.id,
-        }
+        if self.env.user.share or self.env.context.get('force_website'):
+            try:
+                self.check_access_rule('read')
+            except exceptions.AccessError:
+                pass
+            else:
+                return {
+                    'type': 'ir.actions.act_url',
+                    'url': '/my/orders/%s' % self.id,
+                    'target': 'self',
+                    'res_id': self.id,
+                }
+        return super(sale_order, self).get_access_action()


### PR DESCRIPTION
Partial backport of https://github.com/odoo/odoo/commit/a9bd9ab16087142e27076c63ef60a0467f0bcfad#diff-93ee27935d9854d63e4a6d46142c1c85

Current behavior before PR:

Without this, users get emails from sale orders that direct them to the website portal version, even when they have access to editing it.

Desired behavior after PR is merged:

Unauthenticated users get access to website portal SO. Authenticated ones access to backend directly.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa