### PR TITLE
[FIX] Backport of get_working_hours fix

### DIFF
--- a/addons/resource/resource.py
+++ b/addons/resource/resource.py
@@ -377,9 +377,9 @@ class resource_calendar(osv.osv):
                           resource_id=None, default_interval=None, context=None):
         hours = 0.0
         for day in rrule.rrule(rrule.DAILY, dtstart=start_dt,
-                               until=(end_dt + datetime.timedelta(days=1)).replace(hour=0, minute=0, second=0),
+                               until=end_dt.replace(hour=23, minute=59, second=59, microsecond=999999),
                                byweekday=self.get_weekdays(cr, uid, id, context=context)):
-            day_start_dt = day.replace(hour=0, minute=0, second=0)
+            day_start_dt = day.replace(hour=0, minute=0, second=0, microsecond=0)
             if start_dt and day.date() == start_dt.date():
                 day_start_dt = start_dt
             day_end_dt = day.replace(hour=23, minute=59, second=59)


### PR DESCRIPTION
Backport of [10.0 and 11.0 fix](https://github.com/odoo/odoo/commit/506ac455376d605bc360764ae958835b3da195e9)