### PR TITLE
Pass context variable to account.move create

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -1062,11 +1062,10 @@ class account_move_line(osv.osv):
             writeoff_move_id = move_obj.create(cr, uid, {
                 'period_id': writeoff_period_id,
                 'journal_id': writeoff_journal_id,
-                'date':date,
+                'date': date,
                 'state': 'draft',
                 'line_id': writeoff_lines,
-                'ref': "write-off small amounts"
-            })
+            }, context=context)
 
             writeoff_line_ids = self.search(cr, uid, [('move_id', '=', writeoff_move_id), ('account_id', '=', account_id)])
             if account_id == writeoff_acc_id:

--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -1064,7 +1064,8 @@ class account_move_line(osv.osv):
                 'journal_id': writeoff_journal_id,
                 'date':date,
                 'state': 'draft',
-                'line_id': writeoff_lines
+                'line_id': writeoff_lines,
+                'ref': "write-off small amounts"
             })
 
             writeoff_line_ids = self.search(cr, uid, [('move_id', '=', writeoff_move_id), ('account_id', '=', account_id)])


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Context variable is not passed when calling the create function during automatic writeoff.

Current behavior before PR: No context variable is passed.

Desired behavior after PR is merged: Context variable is passed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
