### PR TITLE
[10.0][Fix] Trigger constraint on hr.holidays when editing leave type

### DIFF
--- a/addons/hr_holidays/models/hr_holidays.py
+++ b/addons/hr_holidays/models/hr_holidays.py
@@ -248,7 +248,7 @@ class Holidays(models.Model):
             if nholidays:
                 raise ValidationError(_('You can not have 2 leaves that overlaps on same day!'))
 
-    @api.constrains('state', 'number_of_days_temp')
+    @api.constrains('state', 'number_of_days_temp', 'holiday_status_id')
     def _check_holidays(self):
         for holiday in self:
             if holiday.holiday_type != 'employee' or holiday.type != 'remove' or not holiday.employee_id or holiday.holiday_status_id.limit:


### PR DESCRIPTION
Upstream PR : https://github.com/odoo/odoo/pull/24320

Description of the issue/feature this PR addresses:
1. Open Leaves >  Configuration. Create a new leave type without checking "Allow to Override Limit ".
2. Open Leaves > My Leaves > Leaves request. Create a new Leaves request with the new leave type created above (there should be no remaining days).
3. When saving the following Validation Error appears : "The number of remaining leaves is not sufficient for this leave type.
Please verify also the leaves waiting for validation. "
4. Use a leave type with some remaining days (for example : "Legal Leaves 2018 (20 remaining out of 20)"), and you can now save the leaves request.

Current behavior before PR:
Without approving the leave request created above on point 4, edit it and change the leave type to the new one created on point 1 (without remaining days), and you're allowed to save it without having the Validation Error raised.

Desired behavior after PR is merged:
If a validation error is raised while creating holiday request with a leave type where it's not allowed to override the limit and there are no days remaining for the user, the same validation error should be raised when editing a holiday request and defining the same leave type.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
