### PR TITLE
[9.0][FIX] move gengo install to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - rm -rf ${HOME}/${ODOO_REPO#*/}-${VERSION}; ln -s ${HOME}/build/${ODOO_REPO} ${HOME}/${ODOO_REPO#*/}-${VERSION}
+  - pip install gengo
   - export EXCLUDE=hw_scanner,hw_escpos,theme_bootswatch
   - cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,3 @@ vatnumber==1.2
 vobject==0.6.6
 wsgiref==0.1.2
 xlwt==0.7.5
-gengo


### PR DESCRIPTION
It's less intrusive to put the gengo install in the travis file that in the requirements, right?

@StefanRijnhart 