### PR TITLE
[FIX] use domain when loading new partner in Point of Sale

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -443,9 +443,11 @@ function openerp_pos_models(instance, module){ //module is instance.point_of_sal
             var self = this;
             var def  = new $.Deferred();
             var fields = _.find(this.models,function(model){ return model.model === 'res.partner'; }).fields;
+            var domain = _.find(this.models, function(model){ return model.model === 'res.partner'; }).domain.slice(0);
+            domain.push(['write_date','>',this.db.get_partner_write_date()]);
             new instance.web.Model('res.partner')
                 .query(fields)
-                .filter([['write_date','>',this.db.get_partner_write_date()]])
+                .filter(domain)
                 .all({'timeout':3000, 'shadow': true})
                 .then(function(partners){
                     if (self.db.add_partners(partners)) {   // check if the partners we got were real updates


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

the domain for the res.partner model is used when PoS is loaded. but an other call is done to load new partners, since the last load of the PoS. this call doesn't reuse domain.

Current behavior before PR:

All partners are loaded.

Desired behavior after PR is merged:

Only desired partners are loaded.


CC : 
- @NL66278 (for  pos_restricted_customer_list) and #168 reviewiers (@rafaelbn, @hparfr) 
- @StefanRijnhart 

regards.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
