### PR TITLE
[REF] .travis.yml: Using new template from MQT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,45 @@
-cache: pip
+language: python
+sudo: false
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+python:
+  - "2.7.13"
 
 addons:
   apt:
-    sources:
-      - pov-wkhtmltopdf
     packages:
       - expect-dev  # provides unbuffer utility
       - poppler-utils # document index
       - antiword # document index
-      - python-ldap # auth_ldap
-      - wkhtmltopdf # report_webkit
-
-language: python
-sudo: false
-
-python:
-  - "2.7"
 
 env:
   global:
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0" WEBSITE_REPO="1" TESTS="0"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0" WEBSITE_REPO="1"
+  - WKHTMLTOPDF_VERSION="0.12.4"
+  - EXCLUDE="hw_escpos,hw_scanner"
   matrix:
-  - INCLUDE=applications
-  - INCLUDE=no_applications TESTS="1"
-  - INCLUDE=localization
-
-virtualenv:
-  system_site_packages: true
+  - INCLUDE="applications"
+  - INCLUDE="no_applications" TESTS="1"
+  - INCLUDE="localization"
 
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - ln -s ${HOME}/build/${ODOO_REPO} ${HOME}/${ODOO_REPO#*/}-${VERSION}
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
+  - rm -rf ${HOME}/${ODOO_REPO#*/}-${VERSION}; ln -s ${TRAVIS_BUILD_DIR} ${HOME}/${ODOO_REPO#*/}-${VERSION}
   - pip install gengo
-  - export EXCLUDE=hw_scanner,hw_escpos
   - cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .
 
 script:
   - if [ $INCLUDE = 'applications' ]; then
+        sed -i "s/self.url_open(url)/self.url_open(url, timeout=100)/g" ${TRAVIS_BUILD_DIR}/addons/website/tests/test_crawl.py;
         export INCLUDE=$(getaddons.py -m --only-applications ${HOME}/build/${ODOO_REPO}/openerp/addons ${HOME}/build/${ODOO_REPO}/addons);
     elif [ $INCLUDE = 'no_applications' ]; then
         export INCLUDE=$(getaddons.py -m --exclude-applications --exclude-localization ${HOME}/build/${ODOO_REPO}/openerp/addons ${HOME}/build/${ODOO_REPO}/addons);


### PR DESCRIPTION
 * Exclude from global env instead of 'export'
 * Remove python-* apt packages to install them from pip with cache
 * Use python higher version
 * Fix pip cache
 * Install wkhtmltopdf from MQT instead of unpatched native version
 * Patch test_crawl in order to increase timeout
   * Fix https://github.com/OCA/OCB/issues/667
   * More details https://github.com/OCA/OCB/pull/744