### PR TITLE
[10.0][FIX] membership: associate member tree view

### DIFF
--- a/addons/membership/views/partner_views.xml
+++ b/addons/membership/views/partner_views.xml
@@ -9,7 +9,7 @@
                 <tree string="Members">
                     <field name="name"/>
                     <field name="membership_state"/>
-                    <field name="associate_member" attrs="{'invisible':[('membership_state', '!=', 'none')]}"/>
+                    <field name="associate_member"/>
                     <field name="membership_start"/>
                     <field name="membership_stop"/>
                     <field name="user_id" invisible="1"/>


### PR DESCRIPTION
Merged in `master`: https://github.com/odoo/odoo/commit/f236b095cb2374511d1973c05b42e8ecb66a27d5

But not considered in `10.0`: https://github.com/odoo/odoo/pull/21571

Description of the issue/feature this PR addresses:

- Whatever the state of the association is the `associate_member` is
relevant in order to follow where the membership status of the partner
comes from.

Current behavior before PR:

- If the state of the `associate_member` is different from none, the field won't be visible on the tree view hiding relevant info to the user.

Desired behavior after PR is merged:

- The `associate_member` is always shown.

cc @Tecnativa
