### PR TITLE
[FIX] account: In statements reconcile show only move lines after fiscalyear_lock_date

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -567,6 +567,11 @@ class AccountBankStatementLine(models.Model):
         # Blue lines = payment on bank account not assigned to a statement yet
         reconciliation_aml_accounts = [self.journal_id.default_credit_account_id.id, self.journal_id.default_debit_account_id.id]
         domain_reconciliation = ['&', ('statement_id', '=', False), ('account_id', 'in', reconciliation_aml_accounts)]
+        fiscalyear_lock_date = self.env.user.company_id.fiscalyear_lock_date
+        if fiscalyear_lock_date:
+            domain_reconciliation.append(('date_maturity', '>', fiscalyear_lock_date))
+            # Remove when expression.OR works fine
+            domain_reconciliation.insert(0, '&')
 
         # Black lines = unreconciled & (not linked to a payment or open balance created by statement
         domain_matching = [('reconciled', '=', False)]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
After #678 if we have old moves from an import a lot of blue lines are showed.
With this code only moves after fiscalyear_lock_date are showed.

Current behavior before PR:
After #678 if we have old moves from an import a lot of blue lines are showed.

Desired behavior after PR is merged:
Show only moves after fiscalyear_lock_date

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
