### PR TITLE
[FIX] mail: Render mail in the template language

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -461,10 +461,11 @@ class MailTemplate(models.Model):
         # templates: res_id -> template; template -> res_ids
         templates_to_res_ids = {}
         for res_id, template in res_ids_to_templates.items():
-            templates_to_res_ids.setdefault(template, []).append(res_id)
+            templates_to_res_ids.setdefault((template, template.env.context.get('lang')), []).append(res_id)
 
         results = dict()
         for template, template_res_ids in templates_to_res_ids.items():
+            template = template[0]
             Template = self.env['mail.template']
             # generate fields value for all res_ids linked to the current template
             if template.lang:

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -442,8 +442,8 @@ class MailComposer(models.TransientModel):
             multi_mode = False
             res_ids = [res_ids]
 
-        subjects = self.render_template(self.subject, self.model, res_ids)
-        bodies = self.render_template(self.body, self.model, res_ids, post_process=True)
+        subjects = self.render_template(self.subject, self.model, res_ids) if not self.template_id else False
+        bodies = self.render_template(self.body, self.model, res_ids, post_process=True) if not self.template_id else False
         emails_from = self.render_template(self.email_from, self.model, res_ids)
         replies_to = self.render_template(self.reply_to, self.model, res_ids)
         default_recipients = {}
@@ -453,8 +453,8 @@ class MailComposer(models.TransientModel):
         results = dict.fromkeys(res_ids, False)
         for res_id in res_ids:
             results[res_id] = {
-                'subject': subjects[res_id],
-                'body': bodies[res_id],
+                'subject': subjects[res_id] if subjects else False,
+                'body': bodies[res_id] if subjects else False,
                 'email_from': emails_from[res_id],
                 'reply_to': replies_to[res_id],
             }
@@ -464,7 +464,7 @@ class MailComposer(models.TransientModel):
         if self.template_id:
             template_values = self.generate_email_for_composer(
                 self.template_id.id, res_ids,
-                fields=['email_to', 'partner_to', 'email_cc', 'attachment_ids', 'mail_server_id'])
+                fields=['subject', 'body_html', 'email_to', 'partner_to', 'email_cc', 'attachment_ids', 'mail_server_id'])
         else:
             template_values = {}
 
@@ -474,6 +474,8 @@ class MailComposer(models.TransientModel):
                 results[res_id].pop('partner_ids')
                 results[res_id].pop('email_to')
                 results[res_id].pop('email_cc')
+                results[res_id].pop('subject')
+                results[res_id].pop('body')
                 # remove attachments from template values as they should not be rendered
                 template_values[res_id].pop('attachment_ids', None)
             else:


### PR DESCRIPTION
On an optimization done for not rendering each time the template, the possibility of sending the template in the proper language when multiple recipients was lost.

This is being refactoring in master, but for this version, Odoo won't merge a change in the behavior (said in an OPW ticket), although it's the correct one as in previous versions.

Courtesy of @nim-odoo from https://gist.github.com/nim-odoo/8a9749037370343f05c7e6681324f576

@Tecnativa