### PR TITLE
[FIX] web: controllers main (datas vs data)

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1492,6 +1492,10 @@ class Reports(http.Controller):
             if 'ids' in action['datas']:
                 report_ids = action['datas'].pop('ids')
             report_data.update(action['datas'])
+        elif 'data' in action:
+            if 'ids' in action['data']:
+                report_ids = action['data'].pop('ids')
+            report_data.update(action['data'])
 
         report_id = report_srv.report(
             request.session.db, request.session.uid, request.session.password,


### PR DESCRIPTION
Long ago, the process of creation of reports used the `datas` parameter. Now uses `data` instead, but the change was not done complete. This PR fixes a forgotten step.

Upstream PR: https://github.com/odoo/odoo/pull/24964
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr