### PR TITLE
[8.0][FIX] Stock move operation link without quant

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1304,7 +1304,9 @@ class stock_picking(osv.osv):
                 #Check moves with same product
                 qty_to_assign = uom_obj._compute_qty_obj(cr, uid, ops.product_uom_id, ops.product_qty, ops.product_id.uom_id, context=context)
                 precision_rounding = ops.product_id.uom_id.rounding
-                for move_dict in prod2move_ids.get(ops.product_id.id, []):
+                prod2moves = prod2move_ids.get(ops.product_id.id, [])
+                prod2moves_copy = [{'move': m['move'], 'remaining_qty': m['remaining_qty']} for m in prod2moves]
+                for move_dict in prod2moves_copy:
                     move = move_dict['move']
                     for quant in move.reserved_quant_ids:
                         if float_compare(qty_to_assign, 0, precision_rounding=precision_rounding) != 1:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
* Creation of stock move operation links without associated quant.

Current behavior before PR:
* Create a link without associated quant

Desired behavior after PR is merged:
* Create a link with its associated quant

Steps to reproduce:
1. Create an outgoing stock picking.
2. Add more than one stock move for the same product.
3. Transfer the picking with its operations without associated package.

Because we are iterating through an editable dictionary which we edit, we don't iterate through all items:
```python
def _recompute_remaining_qty(self, cr, uid, picking, context=None):
    def _create_link_for_index(operation_id, index, product_id, qty_to_assign, quant_id=False):
        ...
            prod2move_ids[product_id].pop(index)
        ...
...
            for move_dict in prod2move_ids.get(ops.product_id.id, []):
            ...
                        qty_on_link = _create_link_for_quant(ops.id, quant, max_qty_on_link)
            ...
...
```




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
