### PR TITLE
[FIX] 9.0 stock: _complete_name failing

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -4232,10 +4232,11 @@ class stock_package(osv.osv):
         """
         res = {}
         for m in self.browse(cr, uid, ids, context=context):
-            res[m.id] = m.name
+            res[m.id] = m.name or ''
             parent = m.parent_id
             while parent:
-                res[m.id] = parent.name + ' / ' + res[m.id]
+                parent_name = parent.name or ''
+                res[m.id] = u"%s / %s" %(parent_name, res[m.id])
                 parent = parent.parent_id
         return res
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when package name is False this will throw an error
on the concatenation of bool and unicode

Current behaviour before PR:
Error on trying to read the record with parent set and name = False

Desired behaviour after PR is merged:
No exception thrown )
