### PR TITLE
[FIX] Avoid AccessError in multicompany mode

### DIFF
--- a/addons/mail/mail_thread.py
+++ b/addons/mail/mail_thread.py
@@ -182,7 +182,7 @@ class mail_thread(osv.AbstractModel):
 
     def read_followers_data(self, cr, uid, follower_ids, context=None):
         result = []
-        for follower in self.pool.get('res.partner').browse(cr, uid, follower_ids, context=context):
+        for follower in self.pool.get('res.partner').browse(cr, SUPERUSER_ID, follower_ids, context=context):
             is_editable = self.pool['res.users'].has_group(cr, uid, 'base.group_no_one')
             is_uid = uid in map(lambda x: x.id, follower.user_ids)
             data = (follower.id,


### PR DESCRIPTION
Steps to reproduce:

1. The database is in multicompany mode.
1. Install `mail_tracking_mailgun`, or any other module that adds a computed, non-stored field to the partner form.
2. Admin user has company 1 enabled.
3. Admin user creates partner 1. He appears in that record's `message_ids`, and is a follower.
4. Admin user enables company 2.
5. Admin user creates partner 2.
6. Demo user has company 1 enabled.
7. Demo user tries to access partner 1 form.

In this case, Demo user would get AccessError.

This happens because the computed field will try to write to the `res.users` field too, since both are equivalent. When trying to do so, logically, an `AccessError` is raised. However, it's not actually writing a value that is going to be used, it's just trying to invalidate the cache; the field will be written when it's actually used the 1st time, and not found in the cache.

To avoid such problem, the patch simply invalidates cache for all records that have a `SpecialValue` (a.k.a. failed). If further calls will actually need that field from that record, it will be fetched and the correct `AccessError` exception will be raised if the user has no access, but it makes no sense to raise that just to update some obscure prefetching cache.

Now that the user can access the partner form, another problem raises: he cannot see the names of the record followers if any of them belongs to a different company. That's a UX problem because he could be messaging, unaware that he's polluting other company receivers. To fix that, the followers list is obtained as super user. Further management of that list (getting the image, subscribing anyone, etc.) still follows standard rules system.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa