### PR TITLE
[9.0][IMP] requirements: Up version to allow install zeep from l10n-s…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pytz==2014.10
 pyusb==1.0.0b2
 qrcode==5.1
 reportlab==3.1.44
-requests==2.6.0
+requests==2.7.0
 six==1.9.0
 suds-jurko==0.6
 vatnumber==1.2


### PR DESCRIPTION
Package zeep is only compatible with version of requests >= 2.7.0


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
