### PR TITLE
[FIX] assign correct color to current user

### DIFF
--- a/addons/calendar/static/src/js/base_calendar.js
+++ b/addons/calendar/static/src/js/base_calendar.js
@@ -24,7 +24,7 @@ function reload_favorite_list(result) {
                     is_remove: false,
                 };
 
-                sidebar_items[0] = filter_item ;
+                sidebar_items[filter_value] = filter_item ;
                 filter_item = {
                         value: -1,
                         label: _lt("Everybody's calendars"),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the calendar, current user and "Everybody's calendar", although they have different colors, all of them appear with the same color. It is complicated the distinguish the meetings between them.

Current behavior before PR:
Current user and "Everybody's calendar" share the same color in the calendar.

Desired behavior after PR is merged:
Current user appear with his own color in the calendar.
