### PR TITLE
[8.0] 2 importants fixes for accounting

### DIFF
--- a/addons/account/account_move_line.py
+++ b/addons/account/account_move_line.py
@@ -686,7 +686,7 @@ class account_move_line(osv.osv):
         (_check_no_view, 'You cannot create journal items on an account of type view or consolidation.', ['account_id']),
         (_check_no_closed, 'You cannot create journal items on closed account.', ['account_id']),
         (_check_company_id, 'Account and Period must belong to the same company.', ['company_id']),
-        (_check_date, 'The date of your Journal Entry is not in the defined period! You should change the date or remove this constraint from the journal.', ['date']),
+        (_check_date, 'The date of your Journal Entry is not in the defined period! You should change the date or remove this constraint from the journal.', ['date', 'period_id']),
         (_check_currency, 'The selected account of your Journal Entry forces to provide a secondary currency. You should remove the secondary currency on the account or select a multi-currency view on the journal.', ['currency_id']),
         (_check_currency_and_amount, "You cannot create journal items with a secondary currency without recording both 'currency' and 'amount currency' field.", ['currency_id','amount_currency']),
         (_check_currency_amount, 'The amount expressed in the secondary currency must be positive when account is debited and negative when account is credited.', ['amount_currency']),


### PR DESCRIPTION
The first fix "block cancel of an account move in a closed fiscal year" was to odoo/odoo in May 2015, but was brillantly ignored by the editor https://github.com/odoo/odoo/pull/6711

For the second fix "really take into account 'allow_date' on journal", I only discovered it very recently... when fixing the consequences of this openupgrade bug https://github.com/OCA/OpenUpgrade/issues/1407 for my customers recently migrated from v8 and to v10 and figuring out that they had more problems than only the openupgrade bug. I must say I was very upset to discover this second bug only now... after using Odoo v8 for accounting during so much time :-(

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
