### PR TITLE
Bump PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pyserial==3.1.1
 python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
-PyYAML==3.12
+PyYAML==3.13
 qrcode==5.3
 reportlab==3.3.0
 requests==2.11.1


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Version 3.13 supports Python 3.7.

This is a simple patch to fix some deployment version conflicts. It should be harmless, since the only thing that changed in this PyYAML version is adding Python 3.7 support.

Backport of https://github.com/odoo/odoo/pull/25937.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa