### PR TITLE
[7.0] [backport] [FIX] http: avoid corruption with domain name

### DIFF
--- a/addons/document_webdav/dav_fs.py
+++ b/addons/document_webdav/dav_fs.py
@@ -396,6 +396,7 @@ class openerp_dav_handler(dav_interface):
         u = urlparse.urlsplit(uri)
         h = u.hostname
         d = h.split('.')[0]
+        d, h = re.escape(d), re.escape(h)
         r = openerp.tools.config['dbfilter'].replace('%h', h).replace('%d',d)
         dbs = [i for i in self._all_db_list() if re.match(r, i)]
         return dbs

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -90,6 +90,7 @@ def db_list(req, force=False):
     dbs = proxy.list(force)
     h = req.httprequest.environ['HTTP_HOST'].split(':')[0]
     d = h.split('.')[0]
+    d, h = re.escape(d), re.escape(h)
     r = openerp.tools.config['dbfilter'].replace('%h', h).replace('%d', d)
     dbs = [i for i in dbs if re.match(r, i)]
     return dbs


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/commit/afde870da4d2af0d9b40f907261d1ea5d48864d2