### PR TITLE
[7.0][FIX] Do not pass built-in function when we're supposed to pass an id

### DIFF
--- a/addons/hr_timesheet/hr_timesheet.py
+++ b/addons/hr_timesheet/hr_timesheet.py
@@ -203,7 +203,7 @@ class hr_analytic_timesheet(osv.osv):
         ename = ''
         if emp_id:
             ename = emp_obj.browse(cr, uid, emp_id[0], context=context).name
-        res = self.on_change_unit_amount(cr, uid, id, vals.get('product_id'), vals.get('unit_amount'), False, False, vals.get('journal_id'), context)
+        res = self.on_change_unit_amount(cr, uid, [], vals.get('product_id'), vals.get('unit_amount'), False, False, vals.get('journal_id'), context)
         if res['value'].get('amount'):
             vals.update(amount=res['value']['amount'])
         if not vals.get('journal_id',False):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When we get in the onchange function from this call inside create, `id` is actually `<built-in function id>` as `id` is not declared in `create` function.

Current behavior before PR:
`<built-in function id>` is not interpreted as `False` by an `if` statement, whereas odoo sends usually an empty list when there's no id to pass, and empty list is interpreted as `False`.

Desired behavior after PR is merged:
Do not pass a built-in function as a parameter to a function which expects an id or a list of ids.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
