### PR TITLE
Add hook to extend the way different PDFs are merged together

### DIFF
--- a/odoo/addons/base/ir/ir_actions_report.py
+++ b/odoo/addons/base/ir/ir_actions_report.py
@@ -546,6 +546,13 @@ class IrActionsReport(models.Model):
                 streams.append(io.BytesIO(content))
 
         # Build the final pdf.
+        result = self._merge_pdfs(streams)
+
+        # We have to close the streams after PdfFileWriter's call to write()
+        close_streams(streams)
+        return result
+
+    def _merge_pdfs(self, streams):
         writer = PdfFileWriter()
         for stream in streams:
             reader = PdfFileReader(stream)
@@ -553,11 +560,7 @@ class IrActionsReport(models.Model):
         result_stream = io.BytesIO()
         streams.append(result_stream)
         writer.write(result_stream)
-        result = result_stream.getvalue()
-
-        # We have to close the streams after PdfFileWriter's call to write()
-        close_streams(streams)
-        return result
+        return result_stream.getvalue()
 
     @api.multi
     def render_qweb_pdf(self, res_ids=None, data=None):


### PR DESCRIPTION
Upstream : https://github.com/odoo/odoo/pull/27161

Description of the issue/feature this PR addresses:
When getting multiple PDFs from Odoo, these PDFs are merged in memory and we'd like an hook allowing to extend this function to merge PDFs on disk. Context : https://github.com/OCA/reporting-engine/issues/241

Current behavior before PR:
No change to current behavior, it's only adding an hook to extend a function.

Desired behavior after PR is merged:
No change to current behavior, it's only adding an hook to extend a function.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
