### PR TITLE
[FIX] backport part of v 12 to fix On change specs wrong compute (fro…

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5538,6 +5538,11 @@ class BaseModel(object):
                         todo.append(name)
                         dirty.add(name)
 
+        # At the moment, the client does not support updates on a *2many field
+        # while this one is modified by the user.
+        if isinstance(field_name, basestring) and \
+                self._fields[field_name].type in ('one2many', 'many2many'):
+            dirty.discard(field_name)
         # determine subfields for field.convert_to_onchange() below
         Tree = lambda: defaultdict(Tree)
         subnames = Tree()


### PR DESCRIPTION
Back port part of models.py code from v 12 to fix On change specs compute bug from default view. This bug occurs when the form view contains a nested forms of three levels or more. For example sale.order + sale lines + sale lines options. For more detail, see : #26836

ping @lmignon, @bealdav, @pedrobaeza 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
