### PR TITLE
[8.0][FIX]warning: empty request.env.user object

### DIFF
--- a/addons/warning/warning.py
+++ b/addons/warning/warning.py
@@ -28,7 +28,7 @@ WARNING_MESSAGE = [
                    ('block','Blocking Message')
                    ]
 
-WARNING_HELP = _('Selecting the "Warning" option will notify user with the message, Selecting "Blocking Message" will throw an exception with the message and block the flow. The Message has to be written in the next field.')
+WARNING_HELP = 'Selecting the "Warning" option will notify user with the message, Selecting "Blocking Message" will throw an exception with the message and block the flow. The Message has to be written in the next field.'
 
 class res_partner(osv.osv):
     _inherit = 'res.partner'


### PR DESCRIPTION
This fixes issue #806.

Description of the issue/feature this PR addresses:
Install warning and website.
Print active user on a page (`<t t-esc="request.env.user"/>`).
Restart odoo and load the page.

Current behavior before PR: The request.env.user object will be empty the first 1 - 3 (possibly more) page loads.

Desired behavior after PR is merged: The request.env.user object should always be set.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
