### PR TITLE
[11.0][I18N] Change account balance field spanish translation

### DIFF
--- a/addons/account/i18n/es.po
+++ b/addons/account/i18n/es.po
@@ -2433,7 +2433,7 @@ msgstr "Deudor Malo"
 #: model:ir.ui.view,arch_db:account.report_payment_receipt
 #: model:ir.ui.view,arch_db:account.report_trialbalance
 msgid "Balance"
-msgstr "Balance"
+msgstr "Saldo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line_balance_cash_basis


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Spanish translation for account balance field (account.move.line)

Current behavior before PR:
Balance -> Balance

Desired behavior after PR is merged:
Balance -> Saldo



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
