### PR TITLE
speedup holidays actions

### DIFF
--- a/doc/cla/corporate/odooexperts.md
+++ b/doc/cla/corporate/odooexperts.md
@@ -13,4 +13,4 @@ Erwin van der Ploeg erwin@bas-solutions.nl https://github.com/erwin-bas-solution
 List of contributors:
 
 Erwin van der Ploeg erwin@odooexperts.nl https://github.com/ploegvde
-Yenthe Van Ginneken yenthe@odooexperts.nl https://github.com/Yenthe666
+Yenthe Van Ginneken yenthe@odooexperts.nl https://github.com/Yenthe666 (up to 2019-09-25)


### PR DESCRIPTION
upstream PR: https://github.com/odoo/odoo/pull/28226

when mass cancelling holidays, performance can be improved
by using vectorized operations rather than loops on records.
This is especially important when some computed fields depend
on the state of holidays (in custom addons)
