### PR TITLE
[FIX] website_portal_sale: Frontend only for portal users

### DIFF
--- a/addons/website_portal_sale/models/sale_order.py
+++ b/addons/website_portal_sale/models/sale_order.py
@@ -12,7 +12,7 @@ class sale_order(models.Model):
         """ Override method that generated the link to access the document. Instead
         of the classic form view, redirect to the online quote if exists. """
         self.ensure_one()
-        if self.state in ['draft', 'cancel']:
+        if self.state in ['draft', 'cancel'] or not self.env.user.share:
             return super(sale_order, self).get_access_action()
         return {
             'type': 'ir.actions.act_url',


### PR DESCRIPTION
Before this commit, in v9, when a normal backend user received an email coming from a `sale.order`, it had a "View Sales Order" button that redirected him to the SO frontend page instead of the backend, which is mostly useless for such users.

That's why [in v10+, normal users get to backend directly if possible][1].

This commit is the minimal modification needed to backport such behavior and make those "View Sales Order" mail links useful again.

[1]: https://github.com/odoo/odoo/blob/e6ff16cbba3802ca17c7bc110d91674580edd38b/addons/website_portal_sale/models/sale_order.py#L19-L23


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa