### PR TITLE
[FIX] web: Unselect global checkbox when unselecting single row

### DIFF
--- a/addons/web/static/src/js/views/form_common.js
+++ b/addons/web/static/src/js/views/form_common.js
@@ -936,8 +936,8 @@ var SelectCreateListView = ListView.extend({
         this.popup.on_selected([this.dataset.ids[index]]);
         this.popup.close();
     },
-    do_select: function(ids, records) {
-        this._super(ids, records);
+    do_select: function(ids) {
+        this._super.apply(this, arguments);
         this.popup.on_click_element(ids);
     }
 });


### PR DESCRIPTION
Before this commit, when unselecting a row in a domain selector dialog, the global checkbox didn't uncheck automatically:

![peek 13-11-2018 08-59](https://user-images.githubusercontent.com/973709/48402035-7ef9bb00-e722-11e8-9a09-0d04e7e85b8b.gif)



Now, it works fine just like any other list view:

![peek 13-11-2018 08-58](https://user-images.githubusercontent.com/973709/48402041-84ef9c00-e722-11e8-938b-d7a4fc52315a.gif)


The problem is that the child method was discarding [the important `deselected` argument that the parent method needed][1].

[1]: https://github.com/OCA/OCB/blob/9c78e73706ff46e9a058dc9d90dc209e9a49bca2/addons/web/static/src/js/views/list_view.js#L671


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa