### PR TITLE
[11.0][IMP] purchase: Avoid purchase account invoice lines with zero quantities

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -82,9 +82,11 @@ class AccountInvoice(models.Model):
         new_lines = self.env['account.invoice.line']
         for line in self.purchase_id.order_line - self.invoice_line_ids.mapped('purchase_line_id'):
             data = self._prepare_invoice_line_from_po_line(line)
-            new_line = new_lines.new(data)
-            new_line._set_additional_fields(self)
-            new_lines += new_line
+            if data.get('quantity', 0.0) or self.type == 'in_refund':
+                # Only create lines with units
+                new_line = new_lines.new(data)
+                new_line._set_additional_fields(self)
+                new_lines += new_line
 
         self.invoice_line_ids += new_lines
         self.payment_term_id = self.purchase_id.payment_term_id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fix inheritance _prepare_invoice_line_from_po_line method

Current behavior before PR:

Desired behavior after PR is merged:

--
cc @jbeficent 
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
