### PR TITLE
[FIX] product: variant num w/o prefetch pollution (backport)

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -233,8 +233,9 @@ class ProductTemplate(models.Model):
     @api.one
     @api.depends('product_variant_ids.product_tmpl_id')
     def _compute_product_variant_count(self):
-        self.product_variant_count = len(self.product_variant_ids)
-
+        # do not pollute variants to be prefetched when counting variants
+        self.product_variant_count = len(self.with_prefetch().product_variant_ids)
+        
     @api.depends('product_variant_ids', 'product_variant_ids.default_code')
     def _compute_default_code(self):
         unique_variants = self.filtered(lambda template: len(template.product_variant_ids) == 1)


### PR DESCRIPTION
This is a backport from https://github.com/odoo/odoo/commit/05a00fa9d4f001cef6d31a5b8d20a847de4f455b

When getting:

- product_variant_count,
- sales_count,

of a product.product, we would pollute the records to be prefetched by
all the variants when counting the number of variants.

Thus if this happened before sales_count, we would possibly compute the
sales_count for up to 1000 records when it could have been needed for
just one.

By using `.with_prefetch()`, a recordset will have its own records to be
prefetched list and will not pollute the original one.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
