### PR TITLE
Delete "_translate=false" from the module report_intrastat, model 'report.intrastat.code'

### DIFF
--- a/addons/report_intrastat/i18n/report_intrastat.pot
+++ b/addons/report_intrastat/i18n/report_intrastat.pot
@@ -111,6 +111,7 @@ msgid "December"
 msgstr ""
 
 #. module: report_intrastat
+#: model:ir.model.fields,field_description:report_intrastat.field_report_intrastat_code_description
 #: model:ir.ui.view,arch_db:report_intrastat.report_intrastatinvoice_document
 msgid "Description"
 msgstr ""
@@ -161,6 +162,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:report_intrastat.action_report_intrastat_code_tree
 #: model:ir.model.fields,field_description:report_intrastat.field_product_product_intrastat_id
 #: model:ir.model.fields,field_description:report_intrastat.field_product_template_intrastat_id
+#: model:ir.model.fields,field_description:report_intrastat.field_report_intrastat_code_name
 #: model:ir.ui.menu,name:report_intrastat.menu_report_intrastat_code
 #: model:ir.ui.view,arch_db:report_intrastat.view_report_intrastat_code_form
 msgid "Intrastat Code"

--- a/addons/report_intrastat/models/report_intrastat.py
+++ b/addons/report_intrastat/models/report_intrastat.py
@@ -12,7 +12,6 @@ class res_country(models.Model):
 class ReportIntrastatCode(models.Model):
     _name = "report.intrastat.code"
     _description = "Intrastat code"
-    _translate = False
 
     name = fields.Char(string='Intrastat Code')
     description = fields.Char(string='Description')


### PR DESCRIPTION
Description of the issue/feature this PR addresses: module report_intrastat, reactivate the translations of the fields 'name' and 'description' defined in the model 'report.intrastat.code', deleting the "_translate=false" sentence and update the translations template report_intrastat.pot

Current behavior before PR: it does not translate correctly the description of the 2 fields

Desired behavior after PR is merged: it allows to translate correctly the description of the fields, after updating the python file and the translation files after exporting them via odoo and translating them with a translation tool

Thanks in advance,
Ugaitz

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
