### PR TITLE
[IMP] osv.fields: Link all ids in one query for many2many 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "2.7.13"
 
 addons:
+  postgresql: "9.5"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/openerp/osv/fields.py
+++ b/openerp/osv/fields.py
@@ -1057,16 +1057,17 @@ class many2many(_column):
                     """.format(rel=rel, id1=id1, id2=id2)
                     cr.execute(query)
                     links = set(links) - set(cr.fetchall() or [])
-                query = """
-                    INSERT INTO {rel} ({id1}, {id2})
-                    VALUES {values}
-                """.format(
-                   rel=rel, id1=id1, id2=id2,
-                   values=", ".join(["%s"] * len(links)),
-                )
-                if cr._cnx.server_version >= 95000:
-                    query += " ON CONFLICT DO NOTHING"
-                cr.execute(query, tuple(links))
+                if links
+                    query = """
+                        INSERT INTO {rel} ({id1}, {id2})
+                        VALUES {values}
+                    """.format(
+                       rel=rel, id1=id1, id2=id2,
+                       values=", ".join(["%s"] * len(links)),
+                    )
+                    if cr._cnx.server_version >= 95000:
+                        query += " ON CONFLICT DO NOTHING"
+                    cr.execute(query, tuple(links))
 
         def unlink_all():
             # remove all records for which user has access rights

--- a/openerp/osv/fields.py
+++ b/openerp/osv/fields.py
@@ -1051,14 +1051,21 @@ class many2many(_column):
         def link(ids):
             if ids:
                 links = [(id, r) for r in ids]
+                if cr._cnx.server_version < 95000:
+                    query = """
+                        SELECT {id1}, {id2} FROM {rel}
+                    """.format(rel=rel, id1=id1, id2=id2))
+                    cr.execute(query)
+                    links = set(links) - set(cr.fetchall() or [])
                 query = """
                     INSERT INTO {rel} ({id1}, {id2})
                     VALUES {values}
-                    ON CONFLICT DO NOTHING
                 """.format(
                    rel=rel, id1=id1, id2=id2,
                    values=", ".join(["%s"] * len(links)),
                 )
+                if cr._cnx.server_version >= 95000:
+                    query += " ON CONFLICT DO NOTHING"
                 cr.execute(query, tuple(links))
 
         def unlink_all():

--- a/openerp/osv/fields.py
+++ b/openerp/osv/fields.py
@@ -1054,7 +1054,7 @@ class many2many(_column):
                 if cr._cnx.server_version < 95000:
                     query = """
                         SELECT {id1}, {id2} FROM {rel}
-                    """.format(rel=rel, id1=id1, id2=id2))
+                    """.format(rel=rel, id1=id1, id2=id2)
                     cr.execute(query)
                     links = set(links) - set(cr.fetchall() or [])
                 query = """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Without this change, a -u all on a database with more than 13000 users takes more than 10 hours
With this change: 1h30

**Requires postgresl >= 9.5**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

supersedes #818 