### PR TITLE
[ADD] [8.0] support selectable=False to hide fields from Advanced Search

### DIFF
--- a/openerp/fields.py
+++ b/openerp/fields.py
@@ -324,6 +324,7 @@ class Field(object):
         'groups': None,                 # csv list of group xml ids
         'change_default': False,        # whether the field may trigger a "user-onchange"
         'deprecated': None,             # whether the field is deprecated
+        'selectable': True,             # whether the field is selectable in advanced search
 
         'inverse_fields': (),           # collection of inverse fields (objects)
         'computed_fields': (),          # fields computed with the same method as self
@@ -676,6 +677,7 @@ class Field(object):
     _description_groups = property(attrgetter('groups'))
     _description_change_default = property(attrgetter('change_default'))
     _description_deprecated = property(attrgetter('deprecated'))
+    _description_selectable = property(attrgetter('selectable'))
 
     @property
     def _description_searchable(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In practice it often happens that a model has several cloned fields, eg. technical fields, for example for Name and you end up seeing Name, Name, Name... etc in the Advanced Search. This is not user-friendly for users.

Putting "selectable=False" as an attribute on a field was originally designed in Odoo to be able to solve this problem and manually stop a field from appearing in Advanced Search (eg. a technical field). But this feature has never worked. This PR makes it work.

This was reported as a [bug](https://github.com/odoo/odoo/issues/892) already in Odoo 7.0, and still there in Odoo 11.0, witnessed by [this PR](https://github.com/odoo/odoo/pull/23021). Odoo refuses to accept the PR, claiming that the automatically generated "searchable" field is enough to solve the issue. But that offers much too less control. A workaround is to overload `fields_get` and selectively add "searchable=False" to fields there, but that leads to much less maintainable code. 

**Current behavior before PR:**

There is no elegant way to stop fields from appearing in Advanced Search.

**Desired behavior after PR is merged:**

Putting "selectable=False" as an attribute on fields will stop fields from appearing in Advanced Search.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
