### PR TITLE
[FIX] [10.0] Remove not working invalidate_session_cache.

### DIFF
--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -21,5 +21,4 @@ def check_session(session, env):
     expected = self._compute_session_token(session.sid)
     if expected and odoo.tools.misc.consteq(expected, session.session_token):
         return True
-    self._invalidate_session_cache()
     return False


### PR DESCRIPTION
Upstream PR is here: https://github.com/odoo/odoo/pull/30811

The function _invalidate_session_cache in the res.users model can not work,
because it leads to an error on the line
'self._compute_session_token.clear_cache(self)'.

_compute_session_token is a function, and therefore has no clear_cache
attribute.

As the function can not have worked ever, and seems not to have been missed,
although it exists unchanged in 11.0, 12.0 and master, I decided not to
correct the function (where I would have to guess what it was supposed to do),
but remove it all together.

Relevant lines from traceback:
```
583:2019-02-04 09:54:06,620 14437 ERROR odownbweb10 odoo.addons.password_security.tests.test_res_users:    File /home/openeyedev/var/projects/woonweb_10021/odoo/parts/odoo/odoo/addons/base/res/res_users.py, line 697, in write
585:2019-02-04 09:54:06,620 14437 ERROR odownbweb10 odoo.addons.password_security.tests.test_res_users:    File /home/openeyedev/var/projects/woonweb_10021/odoo/parts/odoo/odoo/addons/base/res/res_users.py, line 382, in write
587:2019-02-04 09:54:06,620 14437 ERROR odownbweb10 odoo.addons.password_security.tests.test_res_users:    File /home/openeyedev/var/projects/woonweb_10021/odoo/parts/odoo/odoo/addons/base/res/res_users.py, line 547, in _invalidate_session_cache
589:2019-02-04 09:54:06,620 14437 ERROR odownbweb10 odoo.addons.password_security.tests.test_res_users:  AttributeError: 'function' object has no attribute 'clear_cache'
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
