### PR TITLE
[8.0][IMP] stock move write in block

### DIFF
--- a/addons/stock_account/stock.py
+++ b/addons/stock_account/stock.py
@@ -351,7 +351,8 @@ class stock_picking(osv.osv):
                     invoice_line_vals['invoice_line_tax_id'] = extra_move_tax[0, move.product_id]
 
             move_obj._create_invoice_line_from_vals(cr, uid, move, invoice_line_vals, context=context)
-            move_obj.write(cr, uid, move.id, {'invoice_state': 'invoiced'}, context=context)
+        move_ids = [move.id for move in moves]
+        move_obj.write(cr, uid, move_ids, {'invoice_state': 'invoiced'}, context=context)
 
         invoice_obj.button_compute(cr, uid, invoices.values(), context=context, set_total=(inv_type in ('in_invoice', 'in_refund')))
         return invoices.values()


### PR DESCRIPTION
Description of the issue/feature this PR addresses: write is slow as it is called record by record

Current behavior before PR: write is slow as it is called record by record

Desired behavior after PR is merged: write is faster as it is called one time on all records




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
