### PR TITLE
Fix zoom for wkhtmltopdf >= 1.12.5

### DIFF
--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -68,7 +68,7 @@ else:
             wkhtmltopdf_state = 'upgrade'
         else:
             wkhtmltopdf_state = 'ok'
-        if LooseVersion(version) >= LooseVersion('0.12.2'):
+        if LooseVersion(version) >= LooseVersion('0.12.2') and LooseVersion(version) < LooseVersion('0.12.5'):
             wkhtmltopdf_dpi_zoom_ratio = True
 
         if config['workers'] == 1:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We had set 300 dpi for our paper formats and we had with wkhtmltopdf 1.12.4.
Now we have upgraded to wkhtmltopdf 1.12.5 and all the pdf content becomes very tiny in the page.
Since 1.12.5 wkhtmltopdf supports the dpi value and the zoom hack is not needed anymore.

Current behavior before PR:
When dpi set to > 96 dpi in paper format, everything is shrinked when use wkhtmltopdf 1.12.5

Desired behavior after PR is merged:
Standard behavior, no shrinkage.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
