### PR TITLE
[FIX] Protected fields break partner merge

### DIFF
--- a/addons/crm/base_partner_merge.py
+++ b/addons/crm/base_partner_merge.py
@@ -276,6 +276,9 @@ class MergePartnerAutomatic(osv.TransientModel):
         values = dict()
         for column, field in columns.iteritems():
             if field._type not in ('many2many', 'one2many') and not isinstance(field, fields.function):
+                if field.groups and not self.pool['res.users'].has_group(cr, uid, field.groups):
+                    continue
+
                 for item in itertools.chain(src_partners, [dst_partner]):
                     if item[column]:
                         values[column] = write_serializer(column, item[column])

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 import test_new_lead_notification
+import test_partner_merge

--- a/addons/crm/tests/test_partner_merge.py
+++ b/addons/crm/tests/test_partner_merge.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+from openerp.tests.common import TransactionCase
+
+
+class TestPartnerMerge(TransactionCase):
+    def setUp(self):
+        super(TestPartnerMerge, self).setUp()
+        self.partner1 = self.env.ref('base.res_partner_6')
+        self.partner2 = self.env.ref('base.res_partner_6').copy()
+        self.user = self.env.ref('base.user_demo')
+
+    def _do_merge(self):
+        # Switch to old API due to guessing mismatch
+        wizard_obj = self.registry['base.partner.merge.automatic.wizard']
+        wizard_obj._merge(
+            self.env.cr, self.user.id, [self.partner1.id, self.partner2.id],
+            self.partner2, context=self.env.context)
+
+    def test_partner_merge(self):
+        self._do_merge()
+
+    def test_partner_merge_protected_field(self):
+        """ Protecting a field with a specific group does not break merging """
+        column = self.env['res.partner']._columns['birthdate']
+        groups_orig = getattr(column, 'groups', None)
+        column.groups = 'base.group_system'
+        try:
+            self._do_merge()
+        finally:
+            column.groups = groups_orig


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
Merging partners when there are columns that are protected by a groups attribute (e.g. signup_token, after the backport of https://github.com/OCA/OCB/pull/777) is broken.

_Current behavior before PR:_
Traceback 
odoo/openerp/models.py", line 3248, in _prefetch_field
2019-03-25 18:04:06,179 27470 ERROR odoo openerp.addons.crm.tests.test_partner_merge: assert field.name in fnames

_Desired behavior after PR is merged:_
Partners can be merged successfully

This issue does not occur in the new API implementation of this method in later versions of Odoo. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
