### PR TITLE
[Add] Allow to uninstall module(s) from command line

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -418,6 +418,20 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
 
         cr.commit()
 
+        # Mark the modules to uninstall if any given in command line with --uninstall
+        if tools.config.get('uninstall'):
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            modulenames = tools.config.pop('uninstall').split(',')
+            irmodule = env['ir.module.module']
+            uninstall_ids = irmodule.search([('name', 'in', modulenames), ('state', '=', 'installed')])
+            uninstall_ids += uninstall_ids.downstream_dependencies()
+            if uninstall_ids:
+                update_module = True
+                cr.execute("update ir_module_module set state=%s where id in %s and state=%s", ('to remove', (tuple(uninstall_ids.ids)), 'installed'))
+                _logger.info('Uninstalling modules (including all dependencies installed) %s', uninstall_ids.mapped('name'))
+            else:
+                _logger.info('Module(s) not installed %s', modulenames)
+
         # STEP 5: Uninstall modules to remove
         if update_module:
             # Remove records referenced from ir_model_data for modules to be

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -107,6 +107,8 @@ class configmanager(object):
         group.add_option("-i", "--init", dest="init", help="install one or more modules (comma-separated list, use \"all\" for all modules), requires -d")
         group.add_option("-u", "--update", dest="update",
                           help="update one or more modules (comma-separated list, use \"all\" for all modules). Requires -d.")
+        group.add_option("--uninstall", dest="uninstall",
+                          help="uninstall one or more modules including their DEPENDENCIES (comma-separated list), requires -d")
         group.add_option("--without-demo", dest="without_demo",
                           help="disable loading demo data for modules to be installed (comma-separated, use \"all\" for all modules). Requires -d and -i. Default is %default",
                           my_default=False)
@@ -405,7 +407,7 @@ class configmanager(object):
                 'db_maxconn', 'import_partial', 'addons_path',
                 'syslog', 'without_demo',
                 'dbfilter', 'log_level', 'log_db',
-                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface'
+                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface', 'uninstall',
         ]
 
         for arg in keys:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: **Allow to uninstall module from command line**  :sparkles:

PR From: https://github.com/odoo/odoo/pull/12373
OCB Test & Demo: https://www.youtube.com/watch?v=u0AVZ2aR2B4

Current behavior before PR: Sometimes you are not able to get to UI due to some crash and you become helpless, you can not uninstall the culprit module. **One module can break the whole system and you have no way of uninstalling the module that caused the problems.** For Example, The error "can not parse from bool" which may occur after the upgrade of a module.

Often you dont get UI because of some crash and you are not able to get your system to healthy state.

Usage: **./odoo.py -d db_name --uninstall module_name(s)**
(Comma separated list of module_name(s))

This might also be helpful during migration.

Desired behavior after PR is merged: Ability to uninstall module from command line.
## One use case: https://youtu.be/7jtmDM0wfFQ
## Let's have one more reason to use OCB :+1: 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
