### PR TITLE
[FIX]point_of_sale: Get Pricelist price based on producxt template

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1275,7 +1275,7 @@ exports.Product = Backbone.Model.extend({
         }
 
         var pricelist_items = _.filter(pricelist.items, function (item) {
-            return (! item.product_tmpl_id || item.product_tmpl_id[0] === self.product_tmpl_id) &&
+            return (! item.product_tmpl_id || item.product_tmpl_id[0] === self.product_tmpl_id[0]) &&
                    (! item.product_id || item.product_id[0] === self.id) &&
                    (! item.categ_id || _.contains(category_ids, item.categ_id[0])) &&
                    (! item.date_start || moment(item.date_start).isSameOrBefore(date)) &&


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When you set a pricelist for a product template get the template price for all variants
**Current behavior before PR:**
Pricelist price setted to a template is not working when you get the price of any variant
**Desired behavior after PR is merged:**
If you set a price for a template in the pricelist, ehn you open POS you will be able to seee that price in their variants.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
