### PR TITLE
sale, sale_timesheet: unnecessary complex domain

### DIFF
--- a/addons/sale/sale_analytic.py
+++ b/addons/sale/sale_analytic.py
@@ -12,19 +12,7 @@ class SaleOrderLine(models.Model):
     def _compute_analytic(self, domain=None):
         lines = {}
         if not domain:
-            # To filter on analyic lines linked to an expense
-            expense_type_id = self.env.ref('account.data_account_type_expenses', raise_if_not_found=False)
-            expense_type_id = expense_type_id and expense_type_id.id
-            domain = [
-                ('so_line', 'in', self.ids),
-                '|',
-                    ('amount', '<', 0),
-                    '&',
-                        ('amount', '=', 0),
-                        '|',
-                            ('move_id', '=', False),
-                            ('move_id.account_id.user_type_id', '=', expense_type_id)
-            ]
+            domain = [('so_line', 'in', self.ids), ('amount', '<=', 0.0)]
 
         data = self.env['account.analytic.line'].read_group(
             domain,


### PR DESCRIPTION
Backport from: https://github.com/odoo/odoo/commit/21fbb9776a5fbd1838b189f1f7cf8c5d40663e14 authored by @nim-odoo 

Original description

> The use case was not supported anyway.
> This reverts a0fed3b845ce6720c3cba5dba4496a8e558c7376

Note: the subquery on 'move_id.account_id.user_type_id' is
pathologically slow as the DB grows, because it will generate a query
with IN (ids) where we have hundreds of thousands of ids for lines with
a 0 amount.

It won't be merged in odoo (https://github.com/odoo/odoo/pull/33429), but I think it's worth to have it in OCB.