### PR TITLE
[9.0][FIX] update so line on analytical line when changing account_id

### DIFF
--- a/addons/sale_timesheet/models/sale_timesheet.py
+++ b/addons/sale_timesheet/models/sale_timesheet.py
@@ -63,7 +63,12 @@ class AccountAnalyticLine(models.Model):
                     'product_id': sol.product_id.id,
                 })
                 result = self._get_timesheet_cost(result)
-
+            else:
+                result.update({
+                    'so_line': False,
+                    'product_id': False,
+                })
+                result = self._get_timesheet_cost(result)
         result = super(AccountAnalyticLine, self)._get_sale_order_line(vals=result)
         return result
 

--- a/addons/sale_timesheet/models/sale_timesheet.py
+++ b/addons/sale_timesheet/models/sale_timesheet.py
@@ -46,6 +46,8 @@ class AccountAnalyticLine(models.Model):
         if self.is_timesheet:
             if result.get('so_line'):
                 sol = self.env['sale.order.line'].browse([result['so_line']])
+            elif result.get('account_id'):
+                sol = False
             else:
                 sol = self.so_line
             if not sol and self.account_id:


### PR DESCRIPTION
**before** 
On `account.analytical.line`
- when updating the `account_id` on an analytical line, `so_line` is not updated
- it leads to incorrect `qty_delivered` on linked sale order

**after**

- if `account_id` is in the change set, so_line is set to false
- then, qty_delivered is correctly computed 
   - on previously linked sale order
   - on newly linked sale_order

**Steps to reproduce:**

- create `sale.order` and click `confirm sale`
- click on created analytical account _SO001_ and tick 'tasks'. A new project _SO001_ is created.
- create a task _dev 1_ on the project and log 1 hour.

-> Sale order indicates `qty_delivered == 1`

Now, go back to logged line on the task _dev 1_ and change the account to any other.

-> Sale order still indicates `qty_delivered == 1` while it should indicate 0

**Use Case**

We invoice clients based on time spent on tasks. Sometime, we give free development hours to client. We then log our timesheets on the account "Client X - gift".

We don't want that time to be invoiced.

