### PR TITLE
[IMP][11.0][BACKPORT] point_of_sale: add ticket reference in payment

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -886,10 +886,13 @@ class PosOrder(models.Model):
 
     def _prepare_bank_statement_line_payment_values(self, data):
         """Create a new payment for the order"""
+        payment_name = '%s - %s' % (self.name, self.pos_reference)
+        if data.get('payment_name'):
+            payment_name += ': ' + data['payment_name']
         args = {
             'amount': data['amount'],
             'date': data.get('payment_date', fields.Date.context_today(self)),
-            'name': self.name + ': ' + (data.get('payment_name', '') or ''),
+            'name': payment_name,
             'partner_id': self.env["res.partner"]._find_accounting_partner(self.partner_id).id or False,
         }
 


### PR DESCRIPTION
Backported from `master` https://github.com/odoo/odoo/commit/2fab076e84ef72fa3482af227e432e6f3885e9a1

Description of the issue/feature this PR addresses:

In the point of sale, when a statement line is saved for an order, only the pos order name is used as reference (field `name`). The problem is that the customer doesn't have that reference in his ticket, but the one stored in the `pos_reference` field. Besides, the statement name is also used in the journal items label when the session entries are posted.

Current behavior before PR:

When pos order payment is processed, the statement line is formated like this (besides, a colon is left at the end of the string even if no payment name is given):
```
Main/0000:
```

Desired behavior after PR is merged:

We'd get the full info correctly formated:
```
Main/0000 - Order 00000-000-0000
```

cc @Tecnativa