### PR TITLE
[10.0] At sale order confirmation, run all procurements at once (performance)

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -496,7 +496,7 @@ class StockMove(models.Model):
                 to_assign[key] |= move
 
         # create procurements for make to order moves
-        procurements = self.env['procurement.order']
+        procurements = self.env['procurement.order'].with_context(procurement_autorun_defer=True)
         for move in move_create_proc:
             procurements |= procurements.create(move._prepare_procurement_from_move())
         if procurements:


### PR DESCRIPTION
See https://github.com/odoo/odoo/issues/18714

For SO with lot of lines, the performance gain is important.

The change (context) prevents the call to create method to run the procurement. The procurement are anyway run all at once just after there are all created.