### PR TITLE
[FIX] if browse record is empty value assign failed

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -261,7 +261,6 @@ class ResPartner(models.Model):
     def _invoice_total(self):
         account_invoice_report = self.env['account.invoice.report']
         if not self.ids:
-            self.total_invoiced = 0.0
             return True
 
         user_currency_id = self.env.user.company_id.currency_id.id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If the function is called with an empy record set (self.ids empty), the assignation of value is broken
So just Return True
Current behavior before PR:
It failed on empty record set value assignation
Desired behavior after PR is merged:
It just return to true and continue the process


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
