### PR TITLE
[FIX] website_form: Mark invalid checkboxes as such

### DIFF
--- a/addons/website_form/static/src/js/website_form.js
+++ b/addons/website_form/static/src/js/website_form.js
@@ -183,9 +183,9 @@ odoo.define('website_form.animation', function (require) {
                 });
 
                 // Update field color if invalid or erroneous
-                $field.removeClass('o_has_error').find('.form-control, .custom-select').removeClass('is-invalid');
+                $field.removeClass('o_has_error').find('.form-control, .custom-select, .form-check-input').removeClass('is-invalid');
                 if (invalid_inputs.length || error_fields[field_name]){
-                    $field.addClass('o_has_error').find('.form-control, .custom-select').addClass('is-invalid')
+                    $field.addClass('o_has_error').find('.form-control, .custom-select, .form-check-input').addClass('is-invalid')
                     if (_.isString(error_fields[field_name])){
                         $field.popover({content: error_fields[field_name], trigger: 'hover', container: 'body', placement: 'top'});
                         // update error message and show it.


### PR DESCRIPTION
This is the same as https://github.com/odoo/odoo/pull/28779, which has been rejected upstream because apparently it fixes only when a checkbox is properly formatted, but the enterprise form builder formats it wrongly... :roll_eyes: 

Description from that PR:

> Without this patch, a checkbox in a website form will never be marked as `.is-invalid`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa