### PR TITLE
[FIX] Localized payment dates in invoice reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -200,7 +200,7 @@
                 <t t-foreach="payments_vals" t-as="payment_vals">
                     <tr>
                         <td>
-                            <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="payment_vals['date']" t-options="{&quot;widget&quot;: &quot;date&quot;}"/></i>
+                            <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="payment_vals['date']" t-options='{"widget": "date"}'/></i>
                         </td>
                         <td class="text-right">
                             <span t-esc="payment_vals['amount']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -200,7 +200,7 @@
                 <t t-foreach="payments_vals" t-as="payment_vals">
                     <tr>
                         <td>
-                            <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="payment_vals['date']"/></i>
+                            <i class="oe_form_field text-right oe_payment_label">Paid on <t t-esc="payment_vals['date']" t-options="{&quot;widget&quot;: &quot;date&quot;}"/></i>
                         </td>
                         <td class="text-right">
                             <span t-esc="payment_vals['amount']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>


### PR DESCRIPTION
Odoo PR #34324 
Fix the Odoo issue #34317 by making the payment date to be localized thanks to date widget

Description of the issue/feature this PR addresses:
Fix the issue #34317 by making the payment date to be localized thanks to date widget

Current behavior before PR:
Payment dates not localized in invoice reports

Desired behavior after PR is merged:
Payment dates localized as per Odoo settings in invoice reports




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
