### PR TITLE
[FIX] website_sale_comparison: Fix category order

### DIFF
--- a/addons/website_sale_comparison/models/website_sale_comparison.py
+++ b/addons/website_sale_comparison/models/website_sale_comparison.py
@@ -26,6 +26,6 @@ class ProductTemplate(models.Model):
 
     def get_variant_groups(self):
         res = OrderedDict()
-        for var in self.attribute_line_ids.sorted(lambda x: x.attribute_id.sequence):
+        for var in self.attribute_line_ids.sorted(lambda x: (x.attribute_id.category_id.sequence, x.attribute_id.sequence)):
             res.setdefault(var.attribute_id.category_id.name or _('Uncategorized'), []).append(var)
         return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On product description in the website, the categories of product attributes are arbitrary ordered, not respecting the sequences configured.

Current behavior before PR:
Categories order does not respect sequence order

Desired behavior after PR is merged:
Categories are ordered respecting their sequence.
Product attributes will be ordered firstly by category sequence, then by attribute sequence



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
