### PR TITLE
[IMP] web: Improve calendar items usability with handpicked colors

### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -8,22 +8,35 @@
     @include o-webclient-padding($top: $o-horizontal-padding/2, $bottom: $o-horizontal-padding/2);
     display: flex;
 
+    // 24 hand-picked distinguishable colors and their best contrasts for calendar items, based on luminance
+    $calendar-colors-bg:    #0000ff #ff0000 #00ff00 #00002b #ff1ab8 #ffd300 #005700 #8383ff #9e4f46 #72f6ff #00ffc1 #008395 #00007b #95d34f #f69edb #d311ff #7b1a69 #f61160 #ffc183 #72607b #232308 #8ca77b #f68308 #837200;
+    $calendar-colors-text:  #fdfdfd #fdfdfd #0d0d0d #fdfdfd #fdfdfd #0d0d0d #fdfdfd #0d0d0d #fdfdfd #0d0d0d #0d0d0d #fdfdfd #fdfdfd #0d0d0d #0d0d0d #fdfdfd #fdfdfd #fdfdfd #0d0d0d #fdfdfd #fdfdfd #0d0d0d #0d0d0d #fdfdfd;
+
     @for $index from 1 through $o-nb-calendar-colors {
-        .o_calendar_color_#{$index} {
-            color: #0D0D0D;
-            background-color: adjust-hue(rgb(255, 192, 192), (360/($o-nb-calendar-colors+1) * $index) * 1deg);
-            border-color:  adjust-hue(rgb(255, 192, 192), (360/($o-nb-calendar-colors+1) * $index) * 1deg);
+        $color-bg: nth($calendar-colors-bg, $index);
+        $color-text: nth($calendar-colors-text, $index);
+        $color-text-hover: lighten($color-text, 30%);
+
+        @if $color-text == #fdfdfd {
+            $color-text-hover: darken($color-text, 15%);
+        }
+
+        a.o_calendar_color_#{$index} {
+            color: $color-text;
+            background-color: $color-bg;
+            border-color: mix($color-bg, $color-text, 85%);
             opacity: 0.7;
             &.o_event_hightlight {
                 font-weight: bold;
                 opacity: 0.9;
             }
             &:hover {
-                color: #666 !important;
+                color: $color-text-hover;
             }
         }
+
         .o_underline_color_#{$index} {
-            border-bottom: 4px solid adjust-hue(rgba(255, 192, 192, 0.7), (360/($o-nb-calendar-colors+1) * $index) * 1deg);
+            border-bottom: 4px solid $color-bg;
         }
     }
 


### PR DESCRIPTION


Quoting from https://github.com/odoo/odoo/pull/32912:

> Previous implementation autogenerates colors and applies them in a random order, but most of them are hardly distinguishable.
> 
> Now, with handpicked background and text colors, it's all easier to read, distinguish and use.
> 
> The selection is based on luminance, which is the way the human eye percieves contrasts among colors, which is not always the mathematical brightness. You can read http://compass-style.org/reference/compass/utilities/color/brightness/ for more details.
> 
> However, we cannot use algorithms because compass cannot be used with libsass: https://github.com/sass/libsass/issues/82. So, the results have been executed locally and hardcoded here.
> 
> 
> Desired behavior after PR is merged:
> 
> ![Captura de pantalla de 2019-04-24 11-56-05](https://user-images.githubusercontent.com/973709/56655283-3b6c8b00-668a-11e9-9241-2009c6d8a500.png)

I'm moving that PR to OCB. @odoo fixed it upstream in master as you can read in https://github.com/odoo/odoo/pull/34985#issuecomment-520331788, but v12 is still broken.

A real backport would be a little crazy because the calendar view has been much refactored in master. However, since this is a simple Scss-only patch that is already developed, I think it's still a good fit for OCB.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa