### PR TITLE
[11.0][FIX] iap: Don't be auto-installed if you are not going to use any IAP module

### DIFF
--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -19,7 +19,7 @@ This module provides standard tools (account model, context manager and helpers)
     'qweb': [
         'static/src/xml/iap_templates.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     # needed because dependencies can't be changed in a stable version
     # TODO in master: add web_settings_dashboard to depends and remove this
     'post_init_hook': '_install_web_settings_dashboard',


### PR DESCRIPTION
It will be installed when you have one module that requires it.

cc @Tecnativa