### PR TITLE
[FIX] portal: should depend on auth_signup

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -15,7 +15,7 @@ portal.
 This module contains most code coming from odoo v10 website_portal. Purpose
 of this module is to allow the display of a customer portal without having
 a dependency towards website edition and customization capabilities.""",
-    'depends': ['http_routing', 'mail'],
+    'depends': ['http_routing', 'mail', 'auth_signup'],
     'data': [
         'data/portal_data.xml',
         'views/assets.xml',


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/commit/54049c14b3c3dc46992461a69b1d68fe9e665b14

portal uses methods defined in auth_signup
without depending on it (probably counting on the autoinstall)

So before this commit, you could uninstall auth_signup
but every flow involving portal - making share urls - crashed

This commit adds the dependency

OPW 2064883

closes odoo/odoo#36477

Signed-off-by: Christophe Simonis <chs@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
