### PR TITLE
[10.0]lxml <3.7.1 installation failed on CentOS 7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gevent==1.1.2
 greenlet==0.4.10
 jcconv==0.2.3
 Jinja2==2.10.1
-lxml==3.5.0
+lxml==3.7.1
 Mako==1.0.4
 MarkupSafe==0.23
 mock==2.0.0


### PR DESCRIPTION
the 3.5.0 version in the requirements.txt failed to be installed.
Yet working with 3.7.1 works fine with the same CentOs environment.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
