### PR TITLE
[FIX] [no task] Fix call of model.read() in so that it can deal with the fact that mode.read() can return a [{}] or {}.

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -21,6 +21,7 @@
 
 from datetime import datetime, timedelta
 import time
+import types
 from openerp import SUPERUSER_ID
 from openerp.osv import fields, osv
 from openerp.tools.translate import _
@@ -1094,6 +1095,8 @@ class sale_order_line(osv.osv):
     def create(self, cr, uid, values, context=None):
         if values.get('order_id') and values.get('product_id') and  any(f not in values for f in ['name', 'price_unit', 'product_uom_qty', 'product_uom']):
             order = self.pool['sale.order'].read(cr, uid, values['order_id'], ['pricelist_id', 'partner_id', 'date_order', 'fiscal_position'], context=context)
+            if isinstance(order, types.ListType):
+                order = order[0]
             defaults = self.product_id_change(cr, uid, [], order['pricelist_id'][0], values['product_id'],
                 qty=float(values.get('product_uom_qty', False)),
                 uom=values.get('product_uom', False),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There are two versions of `model.read` one is decorated with v7 and the other with v8. The code inside the `create` here expects a dictionary to be returned from the call to read. Which is what would happen if the v7 would be called. But it turns out that is not always the case because there might be code that overrides `read` and decorates it with `model` 

In order to reproduce, install the `server-tools/base_mixin_restrict_field_access` module and run the following script:

```
#!/usr/bin/env python                                        
from xmlrpclib import ServerProxy                            
                                                             
server = ServerProxy('http://localhost:8069/xmlrpc/2/object')
                                                             
result = server.execute_kw(                                  
        '$YOUR_DB_NAME',                                       
        1,                                                  
        '$ADMIN_PASS',                                        
        'sale.order.line',                                   
        'create', [{                                         
                'order_id': $VAL,                          
                'product_id': $VAL,                          
                'price_unit': $VAL,                            
                'product_uom_qty': 1,                        
                'name': $VAL,               
                'discount': $VAL,                              
}])                                                          

```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
