### PR TITLE
[11.0][FIX] sale: Allow to invoice multiple sale returns

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -18,11 +18,12 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
     @api.model
     def _get_advance_payment_method(self):
-        if self._count() == 1:
-            sale_obj = self.env['sale.order']
-            order = sale_obj.browse(self._context.get('active_ids'))[0]
-            if all([line.product_id.invoice_policy == 'order' for line in order.order_line]) or order.invoice_count:
-                return 'all'
+        if self._count() != 1:
+            return 'all'
+        sale_obj = self.env['sale.order']
+        order = sale_obj.browse(self._context.get('active_ids'))[0]
+        if all([line.product_id.invoice_policy == 'order' for line in order.order_line]) or order.invoice_count:
+            return 'all'
         return 'delivered'
 
     @api.model


### PR DESCRIPTION
- [ ] Consider into OCB if https://github.com/odoo/odoo/pull/39336 is rejected

When two or more orders have returns after been invoice and a user
wants to make a single credit note for them all, the default values in
the sale lot invoincing wizard makes it impossible as they're hidden for
the user. So we default to 'all' if more than one orders are selected.
Otherwise the behavior remains the same.

cc @Tecnativa Tecnativa-Task #18619

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
