### PR TITLE
[FIX] Field 'to_refund_so' to default to True

### DIFF
--- a/addons/sale_stock/__init__.py
+++ b/addons/sale_stock/__init__.py
@@ -3,3 +3,4 @@
 
 from . import models
 from . import report
+from . import wizards

--- a/addons/sale_stock/wizards/__init__.py
+++ b/addons/sale_stock/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import stock_picking_return

--- a/addons/sale_stock/wizards/stock_picking_return.py
+++ b/addons/sale_stock/wizards/stock_picking_return.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    @api.model
+    def _prepare_stock_return_picking_line_vals_from_move(self, move):
+        result = super(ReturnPicking, self)._prepare_stock_return_picking_line_vals_from_move(move)
+        result['to_refund_so'] = True
+        return result

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -75,7 +75,7 @@ class ReturnPicking(models.TransientModel):
             lambda quant: not quant.reservation_id or quant.reservation_id.origin_returned_move_id != move)
         )
         quantity = move.product_id.uom_id._compute_quantity(quantity, move.product_uom)
-        return {'product_id': move.product_id.id, 'quantity': quantity, 'move_id': move.id, 'to_refund_so': True}
+        return {'product_id': move.product_id.id, 'quantity': quantity, 'move_id': move.id}
 
     @api.multi
     def _create_returns(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Odoo 10.0 has this checkbox 'To Refund' in the return picking wizard:

![image](https://user-images.githubusercontent.com/1466356/68023541-b355e680-fca7-11e9-8e05-afb3709184ae.png)

When creating a return picking it is better to have this checkbox ('to_refund_so') set to True by default, otherwise the `qty_delivered` on sale order lines will not be updated and show a wrong value. Users will often forget to check this.

This was [raised](https://www.odoo.com/forum/help-1/question/v12-solved-set-default-to-true-for-field-to-refund-on-delivery-returns-144315) before, [proposed](https://github.com/odoo/odoo/pull/32495/files) to Odoo and [merged](https://github.com/odoo/odoo/commit/d9b0b09bd2a9a359ff04d28fd1a6f5c06f89f378) in version 13.0.

Odoo wont address this in 10.0 and it's difficult to make this into an OCA stock addon module, but there are still 10.0 instances that will run into this, hence this backport.

Current behavior before PR:

`to_refund_so` defaults to False, making qty_delivered on sale order lines *not* be updated after a return picking is transferred.

Desired behavior after PR is merged:

`to_refund_so` defaults to True, making qty_delivered on sale order lines *be* updated after a return picking is transferred.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
