### PR TITLE
[7.0] On module update or init always update module list

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -316,9 +316,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         # STEP 2: Mark other modules to be loaded/updated
         if update_module:
             modobj = pool.get('ir.module.module')
-            if ('base' in tools.config['init']) or ('base' in tools.config['update']):
-                _logger.info('updating modules list')
-                modobj.update_list(cr, SUPERUSER_ID)
+            _logger.info('updating modules list')
+            modobj.update_list(cr, SUPERUSER_ID)
 
             _check_module_names(cr, itertools.chain(tools.config['init'].keys(), tools.config['update'].keys()))
 


### PR DESCRIPTION
On V 7.0 we want like V 8.0 https://github.com/OCA/OCB/pull/354/commits/f6db474ba3924f47a97631523f0669eb9991c4e5
Always update the modules list




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
