### PR TITLE
12.0 add pos order account mapping based on fiscal position

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -2212,7 +2212,7 @@ var set_fiscal_position_button = ActionButtonWidget.extend({
 
         var selection_list = no_fiscal_position.concat(fiscal_positions);
         self.gui.show_popup('selection',{
-            title: _t('Select tax'),
+            title: _t('Select Fiscal Position'),
             list: selection_list,
             confirm: function (fiscal_position) {
                 var order = self.pos.get_order();

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -173,14 +173,14 @@
                     </div>
                     <h2>Taxes</h2>
                     <div class="row mt16 o_settings_container">
-                        <div class="col-12 col-lg-6 o_setting_box" title="Choose a specific tax regime at the order depending on the kind of customer (tax exempt, onsite vs. takeaway, etc.).">
+                        <div class="col-12 col-lg-6 o_setting_box" title="Choose a specific fiscal position at the order depending on the kind of customer (tax exempt, onsite vs. takeaway, etc.).">
                             <div class="o_setting_left_pane">
                                 <field name="tax_regime_selection"/>
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="tax_regime_selection" string="Fiscal Position per Order"/>
                                 <div class="text-muted">
-                                    Choose among several tax regimes when processing an order
+                                    Choose among fiscal positions when processing an order
                                 </div>
                                 <div class="content-group" attrs="{'invisible': [('tax_regime_selection', '=', False)]}">
                                     <div class="mt16">


### PR DESCRIPTION
Taken from: https://github.com/odoo/odoo/pull/29433/commits/7e5dcb554a4c57b3bc457b73c01250f7b7a0898d

accounts mapping of fiscal positions should work on the PoS as it works
in Sales

Description of the issue/feature this PR addresses:

Setup a fiscal position with account mapping for income account and
receivable account
Make a pos_order with the fiscal position

Current behavior before PR:

When pos is closed, account mapping is not done and the
account_move does not take the mapped income account nor
receivable account

Desired behavior after PR is merged:

The account_move should take the mapped income account
and receivable account

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
