### PR TITLE
[FIX] fix calculation of fixed taxes in PoS

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1334,8 +1334,8 @@ exports.Orderline = Backbone.Model.extend({
     },
     _compute_all: function(tax, base_amount, quantity) {
         if (tax.amount_type === 'fixed') {
-            var sign_base_amount = base_amount >= 0 ? 1 : -1;
-            return (Math.abs(tax.amount) * sign_base_amount) * quantity;
+            var sign_base_amount = Math.sign(base_amount) || 1;
+            return tax.amount * sign_base_amount * Math.abs(quantity);
         }
         if ((tax.amount_type === 'percent' && !tax.price_include) || (tax.amount_type === 'division' && tax.price_include)){
             return base_amount * tax.amount / 100;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When returning products with a fixed tax, the fixed tax is added with the wrong sign, due to a double negative sign. Hence, the prices of positive and negative amounts are not symmetrical.
The tax computation in PoS is different then in [account](https://github.com/odoo/odoo/blob/9.0/addons/account/models/account.py#L644), where it is done right.

This is a port of [this](https://github.com/odoo/odoo/pull/34548) PR in Odoo v11 to v9.

Current behavior before PR:

The prices of positive and negative amounts are not symmetrical.

Desired behavior after PR is merged:

The prices of positive and negative amounts are symmetrical.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
