### PR TITLE
[12.0][FIX] payment: Keep session serializable

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -31,7 +31,7 @@ class PaymentProcessing(http.Controller):
         if not transactions:
             return False
         tx_ids_list = set(request.session.get("__payment_tx_ids__", [])) | set(transactions.ids)
-        request.session["__payment_tx_ids__"] = tx_ids_list
+        request.session["__payment_tx_ids__"] = list(tx_ids_list)
         return True
 
     @staticmethod


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Keep the session object JSON serializable. e.g. when using an external session storage (like Redis)

Current behavior before PR:
Error like `TypeError: {4} is not JSON serializable` when trying to convert the session object into JSON

Desired behavior after PR is merged:
No error when serializing session object for external storage



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
