### PR TITLE
10.0 sale fix multi company access error

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -981,7 +981,7 @@ class SaleOrderLine(models.Model):
                 product_currency = pricelist_item.base_pricelist_id.currency_id
             currency_id = pricelist_item.pricelist_id.currency_id
 
-        product_currency = product_currency or(product.company_id and product.company_id.currency_id) or self.env.user.company_id.currency_id
+        product_currency = product_currency or(product.company_id and product.company_id.sudo().currency_id) or self.env.user.company_id.currency_id
         if not currency_id:
             currency_id = product_currency
             cur_factor = 1.0


### PR DESCRIPTION
Impacted version: 10.0 and higher

Description of the issue/feature this PR addresses:

Access error in multi company product sharing situation

Steps to reproduce:

Enable multicompany, enable 'share products'
Have a product of company A
Log in as user with active company B
Create a new quotation
Select 'Public pricelist' (or any other pricelist) as the active pricelist on the sale order
Add the product of company A to sale order line

Current behavior before PR:

Access error on `res.company` object through `product.company_id.currency_id` on [this line](https://github.com/OCA/OCB/blob/10.0/addons/sale/models/sale.py#L984)

Desired behavior after PR is merged:

No access error


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
