### PR TITLE
#893 [FIX] Scheduler creates assigned picking

### DIFF
--- a/addons/stock/models/procurement.py
+++ b/addons/stock/models/procurement.py
@@ -241,12 +241,12 @@ class ProcurementOrder(models.Model):
         we run functions as SUPERUSER to avoid intercompanies and access rights issues. '''
         super(ProcurementOrder, self).run_scheduler(use_new_cursor=use_new_cursor, company_id=company_id)
         try:
+            # Minimum stock rules
+            self.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id)
+
             if use_new_cursor:
                 cr = registry(self._cr.dbname).cursor()
                 self = self.with_env(self.env(cr=cr))  # TDE FIXME
-
-            # Minimum stock rules
-            self.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id)
 
             # Search all confirmed stock_moves and try to assign them
             confirmed_moves = self.env['stock.move'].search([('state', '=', 'confirmed'), ('product_uom_qty', '!=', 0.0)], limit=None, order='priority desc, date_expected asc')


### PR DESCRIPTION
Description of the issue/feature this PR addresses: See #893 

There are three times where we create a new cursor during the `run_scheduler()` method :
- On super()
- On the method itself (line 244)
- On the `_procure_orderpoint_confirm` method

So, when the system look for all confirmed moves, the cursor used is not the same as the one which have create the stock move from the orderpoint.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
