### PR TITLE
[FIX] web: Remove limitation on date before 1900

### DIFF
--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -432,12 +432,10 @@ function parseDate(value, field, options) {
         if (date.year() === 0) {
             date.year(moment.utc().year());
         }
-        if (date.year() >= 1900) {
-            date.toJSON = function () {
-                return this.clone().locale('en').format('YYYY-MM-DD');
-            };
-            return date;
-        }
+        date.toJSON = function () {
+            return this.clone().locale('en').format('YYYY-MM-DD');
+        };
+        return date;
     }
     throw new Error(_.str.sprintf(core._t("'%s' is not a correct date"), value));
 }
@@ -479,12 +477,10 @@ function parseDateTime(value, field, options) {
         if (datetime.year() === 0) {
             datetime.year(moment.utc().year());
         }
-        if (datetime.year() >= 1900) {
-            datetime.toJSON = function () {
-                return this.clone().locale('en').format('YYYY-MM-DD HH:mm:ss');
-            };
-            return datetime;
-        }
+        datetime.toJSON = function () {
+            return this.clone().locale('en').format('YYYY-MM-DD HH:mm:ss');
+        };
+        return datetime;
     }
     throw new Error(_.str.sprintf(core._t("'%s' is not a correct datetime"), value));
 }

--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -29,7 +29,7 @@ var DateWidget = Widget.extend({
         this.options = _.extend({
             locale: moment.locale(),
             format : this.type_of_date === 'datetime' ? time.getLangDatetimeFormat() : time.getLangDateFormat(),
-            minDate: moment({ y: 1900 }),
+            minDate: moment({ y: 1000 }),
             maxDate: moment({ y: 9999, M: 11, d: 31 }),
             useCurrent: false,
             icons: {

--- a/addons/web/static/tests/fields/field_utils_tests.js
+++ b/addons/web/static/tests/fields/field_utils_tests.js
@@ -300,7 +300,7 @@ QUnit.test('parse percentage', function(assert) {
 });
 
 QUnit.test('parse datetime', function (assert) {
-    assert.expect(5);
+    assert.expect(4);
 
     var originalParameters = _.clone(core._t.database.parameters);
     var originalLocale = moment.locale();
@@ -328,7 +328,6 @@ QUnit.test('parse datetime', function (assert) {
     moment.locale('englishForTest');
     _.extend(core._t.database.parameters, {date_format: '%m/%d/%Y', time_format: '%H:%M:%S'});
     assert.throws(function () {fieldUtils.parse.datetime("13/01/2019 12:00:00", {}, {})}, /is not a correct/, "Wrongly formated dates should be invalids");
-    assert.throws(function () {fieldUtils.parse.datetime("1899-01-01 12:00:00", {}, {})}, /is not a correct/, "Dates before 1900 should be invalids");
 
     dateStr = '01/13/2019 10:05:45';
     date1 = fieldUtils.parse.datetime(dateStr);


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Odoo issues [#42875](https://github.com/odoo/odoo/issues/42875) and [#41788](https://github.com/odoo/odoo/issues/41788) (Odoo fails to display a record with date < 1900-01-01)

Current behavior before PR: JS exception when trying to select a record with a date before 1900 and impossible to select via date picker a date before 1900

Desired behavior after PR is merged: records correctly displayed and date picker can be used to select any date starting with 01/01/1000 (if you would select a date before, you would still have a JS issue that date is not understood)

PR also pushed to Odoo on 9th Jan 2020 ([PR#43055](https://github.com/odoo/odoo/pull/43055))


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
