### PR TITLE
[FIX] base,base_address_city: double parent_id in view

### DIFF
--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -31,7 +31,6 @@ class Partner(models.Model):
         replacement_xml = """
             <div>
                 <field name="country_enforce_cities" invisible="1"/>
-                <field name="parent_id" invisible="1"/>
                 <field name='city' placeholder="%(placeholder)s" class="o_address_city"
                     attrs="{
                         'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)],

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -407,6 +407,7 @@
                 <form string="Private Address Form">
                     <sheet>
                         <field name="type" invisible="1"/>
+                        <field name="parent_id" invisible="1"/>
                         <label for="name" class="oe_editonly"/>
                         <field name="name" required="0"/>
                         <group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Issue [#34405](https://github.com/odoo/odoo/issues/34405), reverts and fix [#34498](https://github.com/odoo/odoo/issues/34498) : enforce parent_id domain and placeholder on partner form view when base_address_city is installed

Current behavior before PR: with implementation of [#34498](https://github.com/odoo/odoo/issues/34498), parent_id field is present twice in partner form view with different attributes / options, and therefore no domain / placeholder is enforced on parent_id field (you can therefore select parent among all possible partners, not only among company type ones and placeholder disappeared).

Desired behavior after PR is merged: Bring back correct domain / placeholder / options on parent_id field on partner form views

PR pushed to Odoo in parallel on 9th Jan 2020 ([#43068](https://github.com/odoo/odoo/pull/43068))



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
