### PR TITLE
[FIX] base: impossible to change contact name format

### DIFF
--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -575,6 +575,9 @@ class Partner(models.Model, FormatAddress):
                 'target': 'new',
                 'flags': {'form': {'action_buttons': True}}}
 
+    def _get_contact_name(self, partner, name):
+        return "%s, %s" % (partner.commercial_company_name or partner.parent_id.name, name)
+
     @api.multi
     def name_get(self):
         res = []
@@ -585,7 +588,7 @@ class Partner(models.Model, FormatAddress):
                 if not name and partner.type in ['invoice', 'delivery', 'other']:
                     name = dict(self.fields_get(['type'])['type']['selection'])[partner.type]
                 if not partner.is_company:
-                    name = "%s, %s" % (partner.commercial_company_name or partner.parent_id.name, name)
+                    name = self._get_contact_name(partner, name)
             if self._context.get('show_address_only'):
                 name = partner._display_address(without_company=True)
             if self._context.get('show_address'):


### PR DESCRIPTION
Idem as https://github.com/odoo/odoo/pull/38100 for 10.0

- Create a sales order for a company with a contact name.
- Click the Preview button.
- The company and contact names appear on the same line, only separated by a
comma.

Before this commit:

it's not possible to easily override this behavior.

After this commit:

it's possible to override `Partner._get_contact_name` to change the format of
contact name.

Beware that this method is used in `_get_name` which is called from various
places. A check on the context may be necessary.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
