### PR TITLE
[FIX][10.0] context on reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -3,7 +3,7 @@
 <data>
 <template id="report_invoice_document">
     <t t-call="report.external_layout">
-        <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})" />
+        <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
         <div class="page">
             <div class="row">
                 <div name="invoice_address" class="col-xs-5 col-xs-offset-7">

--- a/addons/mrp_repair/report/mrp_repair_templates_repair_order.xml
+++ b/addons/mrp_repair/report/mrp_repair_templates_repair_order.xml
@@ -4,7 +4,7 @@
 <template id="report_mrprepairorder">
         <t t-foreach="docs" t-as="o">
             <t t-call="report.external_layout">
-                <t t-set="o" t-value="o.with_context({'lang': o.partner_id.lang})" />
+                <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
                 <div class="page">
                     <div class="oe_structure"/>
 

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 <template id="report_purchaseorder_document">
     <t t-call="report.external_layout">
-        <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})"/>
+        <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
         <div class="page">
             <div class="oe_structure"/>
             <div class="row">

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 <template id="report_purchasequotation_document">
     <t t-call="report.external_layout">
-        <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})"/>
+        <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)"/>
         <div class="page">
             <div class="oe_structure"/>
 

--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 <template id="report_saleorder_document">
     <t t-call="report.external_layout">
-        <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
+        <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)" />
         <div class="page">
             <div class="oe_structure"/>
             <div class="row">

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -4,7 +4,7 @@
     <template id="report_delivery_document">
         <t t-call="report.html_container">
             <t t-call="report.external_layout">
-                <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})" />
+                <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
                 <div class="page">
                     <div class="row" name="customer_address">
                         <div class="col-xs-4 pull-right">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
* The context on some reports is reseted inside it. It should be addressed kwargs
Idem as https://github.com/odoo/odoo/pull/31150

Current behavior before PR: 
* Fixes the reports

Desired behavior after PR is merged: 
* The original context is not deleted, only updated

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
