### PR TITLE
Implement new vat check Netherlands

### DIFF
--- a/addons/base_vat/base_vat.py
+++ b/addons/base_vat/base_vat.py
@@ -379,6 +379,8 @@ class res_partner(osv.osv):
         except ImportError:
             return True
 
+        # This string rewrite is needed up untill Odoo 10.0
+        vat = "NL" + vat
         vat = clean(vat, ' -.').upper().strip()
 
         if not (len(vat) == 14):

--- a/addons/base_vat/base_vat.py
+++ b/addons/base_vat/base_vat.py
@@ -232,6 +232,10 @@ class res_partner(osv.osv):
                                     r"(?P<ano>[0-9]{2})(?P<mes>[01][0-9])(?P<dia>[0-3][0-9])" \
                                     r"[ \-_]?" \
                                     r"(?P<code>[A-Za-z0-9&\xd1\xf1]{3})$")
+
+    # Netherlands VAT verification
+    __check_vat_nl_re = re.compile("(?:NL)?[0-9A-Z+*]{10}[0-9]{2}")
+
     def check_vat_mx(self, vat):
         ''' Mexican VAT verification
 
@@ -356,6 +360,58 @@ class res_partner(osv.osv):
                 c2 += int(vat[f])
             c2 = c2 % 10
             return int(vat[9]) == c1 and int(vat[10]) == c2
+
+        return False
+
+    def check_vat_nl(self, vat):
+        """
+        Temporary Netherlands VAT validation to support the new format introduced in January 2020,
+        until upstream is fixed.
+
+        Algorithm detail: http://kleineondernemer.nl/index.php/nieuw-btw-identificatienummer-vanaf-1-januari-2020-voor-eenmanszaken
+
+        TODO: remove when fixed upstream
+        """
+
+        try:
+            from stdnum.util import clean
+            from stdnum.nl.bsn import checksum
+        except ImportError:
+            return True
+
+        vat = clean(vat, ' -.').upper().strip()
+
+        if not (len(vat) == 14):
+            return False
+
+        # Check the format
+        match = self.__check_vat_nl_re.match(vat)
+        if not match:
+            return False
+
+        # Match letters to integers
+        char_to_int = {k: str(ord(k) - 55) for k in string.ascii_uppercase}
+        char_to_int['+'] = '36'
+        char_to_int['*'] = '37'
+
+        # Remove the prefix
+        vat = vat[2:]
+
+        # 2 possible checks:
+        # - For natural persons
+        # - For non-natural persons and combinations of natural persons (company)
+
+        # Natural person => mod97 full checksum
+        check_val_natural = '2321'
+        for x in vat:
+            check_val_natural += x if x.isdigit() else char_to_int[x]
+        if int(check_val_natural) % 97 == 1:
+            return True
+
+        # Company => weighted(9->2) mod11 on bsn
+        vat = vat[:-3]
+        if vat.isdigit() and checksum(vat) == 0:
+            return True
 
         return False
 

--- a/addons/base_vat/tests/__init__.py
+++ b/addons/base_vat/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_vat_number

--- a/addons/base_vat/tests/test_vat_number.py
+++ b/addons/base_vat/tests/test_vat_number.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (C) 2020 Essent <http://www.essent.be>
+# @author Robin Conjour <r.conjour@essent.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import SavepointCase
+
+class TestVatNumber(SavepointCase):
+    """ Test vat validator """
+
+    def setUp(self):
+        super(TestVatNumber, self).setUp()
+        self.partner_id = self.env['res.partner'].create(
+            {'name': 'Test', 'ref': '__aswr_test'})
+
+    def test_00_nl_vat(self):
+        """
+        Check NL vat number validation
+        """
+
+        valid_vat = '000099998B57'
+        invalid_vat = '020099998B01'
+
+        self.assertTrue(self.partner_id.simple_vat_check('nl', valid_vat))
+        self.assertFalse(self.partner_id.simple_vat_check('nl', invalid_vat))
+


### PR DESCRIPTION
Due to legal changes, some businesses in The Netherlands got a new vat number, these changes are backported from Odoo 12 and modified.