### PR TITLE
[TST] Xvfb not available in Travis by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "2.7.13"
 
 addons:
+  postgresql: "9.4"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
@@ -24,10 +25,6 @@ env:
   - INCLUDE="applications"
   - INCLUDE="no_applications" TESTS="1"
   - INCLUDE="localization"
-
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 
 install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools


### PR DESCRIPTION
```
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during 
```
https://travis-ci.org/OCA/OCB/jobs/648811437