### PR TITLE
[13.0] [FIX] Test Form should update all fields on save.

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1675,9 +1675,9 @@ class Form(object):
                 r.write(values)
         else:
             r = self._model.create(values)
-            self._values.update(
-                record_to_values(self._view['fields'], r)
-            )
+        self._values.update(
+            record_to_values(self._view['fields'], r)
+        )
         self._changed.clear()
         self._model.flush()
         self._model.invalidate_cache()


### PR DESCRIPTION
When a record is updated from a form, other fields can be changed as part of an _inverse method.

See description in upstream PR: https://github.com/odoo/odoo/pull/45355