### PR TITLE
[13.0][FIX] Fix test Form class: handle fields not in record.

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2162,6 +2162,8 @@ class M2MProxy(X2MProxy, collections.Sequence):
 def record_to_values(fields, record):
     r = {}
     for f, descr in fields.items():
+        if f not in record:
+            continue
         v = record[f]
         if descr['type'] == 'many2one':
             assert v._name == descr['relation']


### PR DESCRIPTION
For some forms, for instance for res.users, the form view has fields inserted that are not actually
part of the model. Testing with those fields using the Form class will fail.

Description of the issue/feature this PR addresses:
Testing a form with artificial fields (like the user form with sel_groups_* and in_group_* fields), will
result in an exception, and therefore travis failures.

Current behaviour before PR:
Exceptions and travis failures despite correct code.

Desired behaviour after PR is merged:
Testing works properly.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
