### PR TITLE
[11.0] mail: ignore alien domain alias

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1033,9 +1033,11 @@ class MailThread(models.AbstractModel):
         MailMessage = self.env['mail.message']
         Alias, dest_aliases = self.env['mail.alias'], self.env['mail.alias']
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
+        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         fallback_model = model
 
         # get email.message.Message variables for future processing
+        local_hostname = socket.gethostname()
         message_id = message.get('Message-Id')
 
         # compute references to find if message is a reply to an existing thread
@@ -1051,6 +1053,7 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
@@ -1064,6 +1067,7 @@ class MailThread(models.AbstractModel):
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(rcpt_tos)
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         # 0. Verify whether this is a bounced email and use it to collect bounce data and update notifications for customers

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1034,6 +1034,8 @@ class MailThread(models.AbstractModel):
         Alias, dest_aliases = self.env['mail.alias'], self.env['mail.alias']
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        # activate strict alias domain check for stable, will be falsy by default to be backward compatible
+        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -1053,7 +1055,7 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
@@ -1067,7 +1069,7 @@ class MailThread(models.AbstractModel):
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(rcpt_tos)
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         # 0. Verify whether this is a bounced email and use it to collect bounce data and update notifications for customers

--- a/addons/mail/tests/test_mail_gateway.py
+++ b/addons/mail/tests/test_mail_gateway.py
@@ -863,6 +863,8 @@ class TestMailgateway(TestMail):
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_process_bounce_domain_confusion(self):
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
+
         """Incoming email: bounce not conflicting with alien domains """
         alien_bounce_partner = self.env['res.partner'].create({
             'name': "Alien bounce address",
@@ -993,6 +995,8 @@ class TestMailgateway(TestMail):
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_alias_domain_confusion_external(self):
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
+
         """ Incoming email: write to external address similar to alias: raise as not valid alias """
         with self.assertRaises(ValueError):
             new_groups = self.format_and_process(
@@ -1002,6 +1006,18 @@ class TestMailgateway(TestMail):
                 to='groups@another.domain.com',
                 msg_id='<whatever.JavaMail.diff1@agrolait.com>'
             )
+
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', '')
+
+        """ Incoming email: write to external address similar to alias: raise as not valid alias """
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            subject='Test Subject',
+            email_from='valid.other@gmail.com',
+            to='groups@another.domain.com',
+            msg_id='<whatever.JavaMail.diff2@agrolait.com>'
+        )
+        self.assertEqual(len(new_groups), 1, 'message_process: a new mail.test should have been created')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_alias_domain_confusion_no_domain(self):

--- a/addons/mail/tests/test_mail_gateway.py
+++ b/addons/mail/tests/test_mail_gateway.py
@@ -862,6 +862,27 @@ class TestMailgateway(TestMail):
         self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_process_bounce_domain_confusion(self):
+        """Incoming email: bounce not conflicting with alien domains """
+        alien_bounce_partner = self.env['res.partner'].create({
+            'name': "Alien bounce address",
+            'email': '%s+%s-%s-%s@%s' % (
+                self.bounce_alias, self.fake_email.id,
+                self.fake_email.model, self.fake_email.res_id,
+                'another.domain.com'
+            ),
+        })
+        # Test: group created, bounce-similar email is treated as a normal address
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+            to=alien_bounce_partner.email + ', groups@example.com',
+        )
+        self.assertEqual(new_groups.message_ids[0].author_id, self.partner_1, 'message_process: recognized email -> author_id')
+        self.assertIn('Valid Lelitre <valid.lelitre@agrolait.com>', new_groups.message_ids[0].email_from, 'message_process: recognized email -> email_from')
+        self.assertEqual(new_groups.message_ids.partner_ids, alien_bounce_partner, 'message_process: alien bounce-like address should be subscribed as a normal partner')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_bounce_other_recipients(self):
         """Incoming email: bounce processing: bounce should be computed even if not first recipient """
         new_groups = self.format_and_process(
@@ -971,8 +992,20 @@ class TestMailgateway(TestMail):
         #                  'message_process: after reply, group should have 2 followers (0 channels)')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_alias_domain_confusion_external(self):
+        """ Incoming email: write to external address similar to alias: raise as not valid alias """
+        with self.assertRaises(ValueError):
+            new_groups = self.format_and_process(
+                MAIL_TEMPLATE,
+                subject='Test Subject',
+                email_from='valid.other@gmail.com',
+                to='groups@another.domain.com',
+                msg_id='<whatever.JavaMail.diff1@agrolait.com>'
+            )
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_alias_domain_confusion_no_domain(self):
-        """ Incoming email: write to alias even if no domain set: considered as valid alias """
+        """ Incoming email: write to external address similar to alias without alias domain: considered as valid alias """
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', '')
 
         new_groups = self.format_and_process(
@@ -1001,8 +1034,22 @@ class TestMailgateway(TestMail):
         self.assertEqual(new_rec._name, self.alias_2.alias_model_id.model)
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_alias_forward_domain_confusion_external(self):
+        """ Incoming email: write to alias of another model: external address not taken into account """
+        new_rec = self.format_and_process(
+            MAIL_TEMPLATE,
+            subject='Test Subject',
+            email_from='valid.other@gmail.com',
+            to='%s@%s, %s@%s' % (self.alias.alias_name, self.catchall_domain, self.alias_2.alias_name, 'another.domain.com'),
+            msg_id='<whatever.JavaMail.diff1@agrolait.com>'
+        )
+        # Test: one channel (alias 2) created
+        self.assertEqual(len(new_rec), 1, 'message_process: a new mail.test should have been created')
+        self.assertEqual(new_rec._name, self.alias.alias_model_id.model)
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_alias_forward_domain_confusion_no_domain(self):
-        """ Incoming email: write to alias of another model: forward to new alias even if no catchall domain """
+        """ Incoming email: write to alias of another model: forward to new alias if no catchall domain """
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', '')
 
         new_rec = self.format_and_process(

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -18,10 +18,12 @@ class MailThread(models.AbstractModel):
     def message_route(self, message, message_dict, model=None, thread_id=None, custom_values=None):
         """ Override to udpate mass mailing statistics based on bounce emails """
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
+        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         email_to = decode_message_header(message, 'To')
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         if bounce_alias and any(email.startswith(bounce_alias) for email in email_to_localparts):

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -19,11 +19,13 @@ class MailThread(models.AbstractModel):
         """ Override to udpate mass mailing statistics based on bounce emails """
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        # activate strict alias domain check for stable, will be falsy by default to be backward compatible
+        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
         email_to = decode_message_header(message, 'To')
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         if bounce_alias and any(email.startswith(bounce_alias) for email in email_to_localparts):


### PR DESCRIPTION
Well, this is a long story, let me see if I can summarize it:

1. **The problem:** Odoo has a long standing problem when routing incoming mail: it ignores the domain part. Imagine you have 2 inboxes: `catchall@example.com` and `info@anotherdomain.com`; your main domain is `example.com`; you configured `info` as an alias for a sales team; an email enters into `info@anotherdomain.com`. Result :arrow_right: It is considered an email for the sales team, even when the email was sent to `info@anotherdomain.com` instead of `info@example.com`.
1. **The solution**: It was included upstream in https://github.com/odoo/odoo/commit/e40f3ccad627af5f74be4fe9f73c201447cb6eb1, including tests and a pretty good description of the problem. Now only emails from the `mail.catchall.domain` were considered for aliases.
1. **The new problem:** There was some people using that bug as a feature: https://github.com/odoo/odoo/pull/38459#issuecomment-555598458
1. **The new solution**: https://github.com/odoo/odoo/pull/41042 reverted partially the original solution (only the part that affected the new problem, because it solved some more things), so we went back to the start.
1. **The new new problem:** See point 1.

Odoo claims to be solving this for master, but that isn't still proven, and we still need a solution; the problem is quite nasty, but we don't want to damage people relying on this bug.

It turns out that in https://github.com/odoo/odoo/pull/41042#issuecomment-559482321 @tde-banana-odoo got a pretty good solution: enable the new (fixed) behavior only in databases where a new ICP `mail.catchall.domain.strict` was set to `True`. That solution can still be seen in the PR history; namely it's commit https://github.com/odoo/odoo/commit/8d5dd14e125f5167ea110c6426a0b18c98e57dba. That solution was discarded in favor of fully reverting the original patch.

**So, what am I doing here?**

Basically:

1. Revert the reversion (https://github.com/odoo/odoo/pull/41042).
1. Apply the 1st approach from https://github.com/odoo/odoo/pull/41042: if you want this fixed in your DB, add the ICP.

@OCA will have to maintain this feature until @odoo fixes it in v14 (if they fulfill their promise).

@Tecnativa TT22715