### PR TITLE
12.0 mail ignore aliases for other domains

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1140,6 +1140,8 @@ class MailThread(models.AbstractModel):
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.alias")
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        # activate strict alias domain check for stable, will be falsy by default to be backward compatible
+        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -1158,7 +1160,7 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
@@ -1172,7 +1174,7 @@ class MailThread(models.AbstractModel):
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(rcpt_tos)
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         # 0. Verify whether this is a bounced email and use it to collect bounce data and update notifications for customers

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1139,6 +1139,7 @@ class MailThread(models.AbstractModel):
         Alias, dest_aliases = self.env['mail.alias'], self.env['mail.alias']
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.alias")
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
+        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -1157,6 +1158,7 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
@@ -1170,6 +1172,7 @@ class MailThread(models.AbstractModel):
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(rcpt_tos)
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         # 0. Verify whether this is a bounced email and use it to collect bounce data and update notifications for customers
@@ -1229,23 +1232,27 @@ class MailThread(models.AbstractModel):
         msg_references = [ref for ref in tools.mail_header_msgid_re.findall(thread_references) if 'reply_to' not in ref]
         mail_messages = MailMessage.sudo().search([('message_id', 'in', msg_references)], limit=1, order='id desc, message_id')
         is_a_reply = bool(mail_messages)
+        alias_domain = [('alias_name', 'in', rcpt_tos_localparts)]
 
         # 1.1 Handle forward to an alias with a different model: do not consider it as a reply
-        if is_a_reply and reply_model and reply_thread_id:
-            alias_count = Alias.search_count([
+        if reply_model and reply_thread_id:
+            other_aliases = Alias.search([
+                '&',
                 ('alias_name', '!=', False),
                 ('alias_name', 'in', email_to_localparts),
-                ("alias_model_id.model", "!=", reply_model),
             ])
-            is_a_reply = alias_count == 0
+            for other_alias in other_aliases:
+                if other_alias.alias_model_id.model == reply_model:
+                    is_a_reply = bool(mail_messages)
+                    alias_domain.append(("alias_model_id.model", "=", reply_model))
+                    break
+                if other_alias.alias_model_id.model != reply_model:
+                    is_a_reply = False
 
         if is_a_reply:
             model, thread_id = mail_messages.model, mail_messages.res_id
             if not reply_private:  # TDE note: not sure why private mode as no alias search, copying existing behavior
-                dest_aliases = Alias.search([
-                    ('alias_name', 'in', rcpt_tos_localparts),
-                    ('alias_model_id.model', '=', model),
-                ], limit=1)
+                dest_aliases = Alias.search(alias_domain, limit=1)
 
             route = self.message_route_verify(
                 message, message_dict,
@@ -1266,7 +1273,7 @@ class MailThread(models.AbstractModel):
             message_dict.pop('parent_id', None)
 
             # check it does not directly contact catchall
-            if catchall_alias and all(email_localpart == catchall_alias for email_localpart in email_to_localparts):
+            if catchall_alias and any(email.startswith(catchall_alias) for email in email_to_localparts):
                 _logger.info('Routing mail from %s to %s with Message-Id %s: direct write to catchall, bounce', email_from, email_to, message_id)
                 body = self.env.ref('mail.mail_bounce_catchall').render({
                     'message': message,
@@ -1274,7 +1281,7 @@ class MailThread(models.AbstractModel):
                 self._routing_create_bounce_email(email_from, body, message, reply_to=self.env.user.company_id.email)
                 return []
 
-            dest_aliases = Alias.search([('alias_name', 'in', rcpt_tos_localparts)])
+            dest_aliases = Alias.search(alias_domain)
             if dest_aliases:
                 routes = []
                 for alias in dest_aliases:

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -21,11 +21,13 @@ class MailThread(models.AbstractModel):
         """ Override to udpate mass mailing statistics based on bounce emails """
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        # activate strict alias domain check for stable, will be falsy by default to be backward compatible
+        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
         email_to = decode_message_header(message, 'To')
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
 
         if bounce_alias and any(email.startswith(bounce_alias) for email in email_to_localparts):

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -20,10 +20,12 @@ class MailThread(models.AbstractModel):
     def message_route(self, message, message_dict, model=None, thread_id=None, custom_values=None):
         """ Override to udpate mass mailing statistics based on bounce emails """
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
+        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         email_to = decode_message_header(message, 'To')
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
 
         if bounce_alias and any(email.startswith(bounce_alias) for email in email_to_localparts):

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -13,6 +13,7 @@ class MailTestSimple(models.Model):
 
     name = fields.Char()
     email_from = fields.Char()
+    message_bounce = fields.Integer(default=0)
 
 
 class MailTestStandard(models.Model):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -190,6 +190,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         """Incoming bounce is properly processed."""
         self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
 
         # Test: No group created, incoming bounce is counted
         self.assertEqual(self.test_record.message_bounce, 0, 'The bounced thread should have no bounced messages by default')
@@ -212,6 +213,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         """Incoming bounce-like mails are not confused when in alien domains."""
         self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
         # A partner with an address that seems like our bounce address
         alien_bounce_partner = self.env["res.partner"].create({
             "name": "Alien bounce address",

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -185,11 +185,57 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record.message_ids), 1)
 
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_received_bounce(self):
+        """Incoming bounce is properly processed."""
+        self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+
+        # Test: No group created, incoming bounce is counted
+        self.assertEqual(self.test_record.message_bounce, 0, 'The bounced thread should have no bounced messages by default')
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+            to='valid.other@gmail.com, oops+{msg_id}-{model}-{res_id}@example.com'.format(
+                msg_id=self.fake_email.id,
+                model=self.fake_email.model,
+                res_id=self.fake_email.res_id,
+            ),
+            subject='Your email bounced, be more careful next time plea se',
+        )
+        self.assertFalse(new_groups)
+        self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
+        self.assertEqual(self.test_record.message_bounce, 1, 'The bounced thread should have 1 bounced message')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_received_bounce_no_domain_confusion(self):
+        """Incoming bounce-like mails are not confused when in alien domains."""
+        self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        # A partner with an address that seems like our bounce address
+        alien_bounce_partner = self.env["res.partner"].create({
+            "name": "Alien bounce address",
+            "email": 'oops+{msg_id}-{model}-{res_id}@alien.com'.format(
+                msg_id=self.fake_email.id,
+                model=self.fake_email.model,
+                res_id=self.fake_email.res_id,
+            ),
+        })
+        # Test: group created, bounce-similar email is treated as a normal address
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+            to=alien_bounce_partner.email + ', groups@example.com',
+        )
+        self.assertEqual(new_groups.message_ids[0].author_id, self.partner_1, 'message_process: recognized email -> author_id')
+        self.assertIn('Valid Lelitre <valid.lelitre@agrolait.com>', new_groups.message_ids[0].email_from, 'message_process: recognized email -> email_from')
+        self.assertEqual(new_groups.message_ids.partner_ids, alien_bounce_partner, 'message_process: alien bounce-like address should be subscribed as a normal partner')
+
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
     def test_message_process_alias_partners_bounce(self):
         """ Incoming email from an unknown partner on a Partners only alias -> bounce + test bounce email """
         self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'bounce.test')
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'test.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
         self.alias.write({'alias_contact': 'partners'})
 
         # Test: no group created, email bounced
@@ -200,7 +246,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         # Test bounce email
         self.assertEqual(self._mails[0].get('subject'), 'Re: Should Bounce')
         self.assertEqual(self._mails[0].get('email_to')[0], 'whatever-2a840@postmaster.twitter.com')
-        self.assertEqual(self._mails[0].get('email_from'), 'MAILER-DAEMON <bounce.test@test.com>')
+        self.assertEqual(self._mails[0].get('email_from'), 'MAILER-DAEMON <bounce.test@example.com>')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
     def test_message_process_alias_followers_bounce(self):
@@ -578,6 +624,17 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
                           MAIL_TEMPLATE,
                           to='noone@example.com', subject='spam', extra='',
                           msg_id='<1198923581.41972151344608186760.JavaMail.new5@agrolait.com>')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_crash_alien_domain_same_alias(self):
+        """Incoming email to the same address in an alien domain must raise."""
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        with self.assertRaises(ValueError):
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+                to='groups@alien.com, other@gmail.com',
+            )
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_fallback(self):


### PR DESCRIPTION
This is the same as https://github.com/OCA/OCB/pull/913, but for v12. However, the patch is different because in v12, the incoming mail gateway was modified to accept only replies in the catchall address, and mail tests were extracted to a specific addon (test_mail), so the cherry-pick is modified.

Odoo rejected it in https://github.com/odoo/odoo/pull/38484 and here comes OCB to the rescue.

Just like in https://github.com/OCA/OCB/pull/913, it will have no effect unless you set an ICP `mail.catchall.domain.strict=True`.

@Tecnativa TT22715