### PR TITLE
[FIX] mass_mailing: remove inactive lists from mass mailing

### DIFF
--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -244,6 +244,12 @@ msgid "Archived"
 msgstr ""
 
 #. module: mass_mailing
+#: code:addons/mass_mailing/models/mass_mailing.py:54
+#, python-format
+msgid "At least one of the mailing list you are trying to archive is used in an ongoing mailing campaign."
+msgstr ""
+
+#. module: mass_mailing
 #: model:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
 msgid "Attach a file"
 msgstr ""


### PR DESCRIPTION
Backport from #46622

Issue

	- Install Mass Mailing
	- Create 2 mailing list (x & y) with differents
	  contacts
	- Create a mass mailing with x & y, send it

	Ok, sent to everyome

	- Archive mailing list y
	- Duplicate the last mass mailing, send it

	Not ok, sent to y contacts too

	When a list is archived, I can't manually
	remove it from the mass mailing (it disappears)

Cause

	When archiving a list, it still remains in
	contact_list_ids

Solution

	Prevent archiving a mailing list if any mass mailing
	using it exist with state != 'done'

	Re-evaluate the domain field at copy

OPW-2202111

closes odoo/odoo#46622

Signed-off-by: Nicolas Martinelli (nim) <nim@odoo.com>


cc @Tecnativa TT22469