### PR TITLE
[12.0][FIX] mail ignore aliases and fix test_mail tests

### DIFF
--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -13,7 +13,6 @@ class MailTestSimple(models.Model):
 
     name = fields.Char()
     email_from = fields.Char()
-    message_bounce = fields.Integer(default=0)
 
 
 class MailTestStandard(models.Model):


### PR DESCRIPTION
This PR should fix the fucking problem with some tests of `test_mail`.

This basically reverts https://github.com/OCA/OCB/pull/914 plus https://github.com/odoo/odoo/commit/0580ee5f983b95f6775e479278d17feef00ae8c9.

Odoo merged first https://github.com/odoo/odoo/commit/40ae36b7f8c412cd96dc9592d8d1fb90de1e52d2 and then merged https://github.com/odoo/odoo/commit/0580ee5f983b95f6775e479278d17feef00ae8c9. If you don't like https://github.com/odoo/odoo/commit/0580ee5f983b95f6775e479278d17feef00ae8c9, then you should revert it instead of doing a patch ambiguous like https://github.com/OCA/OCB/pull/914 that makes some tests fail.

Well, not sure of what I am saying, not an expert of this, but that's what my logic says. Otherwise, proof I am wrong 😜



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr