### PR TITLE
[FIX] mail: make domain validation tests pass

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1141,7 +1141,7 @@ class MailThread(models.AbstractModel):
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         # activate strict alias domain check for stable, will be falsy by default to be backward compatible
-        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
+        alias_domain_check = tools.str2bool(self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict", "False"))
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -1275,7 +1275,7 @@ class MailThread(models.AbstractModel):
             message_dict.pop('parent_id', None)
 
             # check it does not directly contact catchall
-            if catchall_alias and any(email.startswith(catchall_alias) for email in email_to_localparts):
+            if catchall_alias and all(email_localpart == catchall_alias for email_localpart in email_to_localparts):
                 _logger.info('Routing mail from %s to %s with Message-Id %s: direct write to catchall, bounce', email_from, email_to, message_id)
                 body = self.env.ref('mail.mail_bounce_catchall').render({
                     'message': message,

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -631,6 +631,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
     def test_message_process_crash_alien_domain_same_alias(self):
         """Incoming email to the same address in an alien domain must raise."""
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
         with self.assertRaises(ValueError):
             self.format_and_process(
                 MAIL_TEMPLATE,


### PR DESCRIPTION
After merging https://github.com/OCA/OCB/pull/914, some tests failed to add the new `mail.catchall.domain.strict=True` ICP to enable the new alien domain discrimination behavior. Thus, they were failing as explained in https://github.com/OCA/OCB/pull/914#issuecomment-599753767.

Patch summary:

1. Consider `mail.catchall.domain.strict="False"` properly as `False`.
2. Consider a new email with `To: catchall@example.com, valid-alias@example.com` as a valid new email.
3. Add `mail.catchall.domain.strict=True` to strict domain tests.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa TT22715
Closes https://github.com/OCA/OCB/pull/916

Co-authored-by: Miquel Raïch <MiquelRForgeFlow@users.noreply.github.com>
