### PR TITLE
Fix requirements for python3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ ofxparse==0.16
 passlib==1.6.5
 Pillow==4.0.0
 psutil==4.3.1; sys_platform != 'win32'
-psycopg2==2.7.3.1; sys_platform != 'win32'
+psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.3; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.2.3
 pyldap==2.4.28; sys_platform != 'win32'
 pyparsing==2.1.10


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Odoo 12.0 wont work under python 3.8 if psycopg2==2.7.7 is used.

Current behavior before PR:

Cant install psycopg2 with the current version if use python 3.8

Desired behavior after PR is merged:

After merge the fix, psycopg2 will be installed without error in python 3.8


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
