### PR TITLE
[11.0][FIX] mrp,mrp_byproduct: warehouse routes not triggered on manufacture operations

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -370,6 +370,7 @@ class MrpProduction(models.Model):
             'location_dest_id': self.location_dest_id.id,
             'company_id': self.company_id.id,
             'production_id': self.id,
+            'warehouse_id': self.location_dest_id.get_warehouse().id,
             'origin': self.name,
             'group_id': self.procurement_group_id.id,
             'propagate': self.propagate,

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -435,7 +435,7 @@ class MrpProduction(models.Model):
             mto_route = False
         for move in self.move_raw_ids:
             product = move.product_id
-            routes = product.route_ids + product.route_from_categ_ids
+            routes = product.route_ids + product.route_from_categ_ids + move.warehouse_id.route_ids
             # TODO: optimize with read_group?
             pull = self.env['procurement.rule'].search([('route_id', 'in', [x.id for x in routes]), ('location_src_id', '=', move.location_id.id),
                                                         ('location_id', '=', move.location_dest_id.id)], limit=1)

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -161,6 +161,7 @@ class MrpUnbuild(models.Model):
                 'product_uom_qty': unbuild.product_qty,
                 'location_id': unbuild.location_id.id,
                 'location_dest_id': unbuild.product_id.property_stock_production.id,
+                'warehouse_id': unbuild.location_id.get_warehouse().id,
                 'origin': unbuild.name,
                 'consume_unbuild_id': unbuild.id,
             })
@@ -193,6 +194,7 @@ class MrpUnbuild(models.Model):
             'procure_method': 'make_to_stock',
             'location_dest_id': self.location_dest_id.id,
             'location_id': raw_move.location_dest_id.id,
+            'warehouse_id': self.location_dest_id.get_warehouse().id,
             'unbuild_id': self.id,
         })
 
@@ -207,6 +209,7 @@ class MrpUnbuild(models.Model):
             'procure_method': 'make_to_stock',
             'location_dest_id': self.location_dest_id.id,
             'location_id': self.product_id.property_stock_production.id,
+            'warehouse_id': self.location_dest_id.get_warehouse().id,
             'unbuild_id': self.id,
         })
 

--- a/addons/mrp_byproduct/models/mrp_production.py
+++ b/addons/mrp_byproduct/models/mrp_production.py
@@ -28,6 +28,7 @@ class MrpProduction(models.Model):
                 'location_dest_id': production.location_dest_id.id,
                 'operation_id': sub_product.operation_id.id,
                 'production_id': production.id,
+                'warehouse_id': production.location_dest_id.get_warehouse().id,
                 'origin': production.name,
                 'unit_factor': qty1 / (production.product_qty - production.qty_produced),
                 'subproduct_id': sub_product.id


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_ 
Finished product moves from a MO where created without warehouse_id. It implies that **push rule** based on warehouse where not trigger on those moves confirmation.
Also, the `_adjust_procure_method` is not taking into account the warehouse routes. It implies that **pull rule** based on warehouse where not triggered.
This PR adds warehouse_id on unbuild/production's finished/raw moves and adds the warehouse routes on the `_adjust_procure_method` pull method..

_Current behavior before PR:_
The warehouse push/pull routes are not triggered on manufacture operations.

_Desired behavior after PR is merged:_
Both push and pull warehouse routes are now taking into account on manufacture operations and triggered correctly.

Backport of https://github.com/OCA/OCB/commit/09ba95b2d06760d7486ebb587af2099cccb8955f

Backport of https://github.com/OCA/OCB/blob/719f087b1b5be5f1f276a0f87670830d073f6ef4/addons/mrp/models/mrp_production.py#L503 inspired on commit https://github.com/OCA/OCB/commit/1e160dffd375ef5bb5ceb7ec34ee172944719b03

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
