### PR TITLE
[10.0][FIX] expression: simplify sub-searches order (author @guewen)

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -725,13 +725,13 @@ class expression(object):
                         doms.insert(0, OR_OPERATOR)
                     doms += [AND_OPERATOR, ('parent_left', '<', rec.parent_right), ('parent_left', '>=', rec.parent_left)]
                 if prefix:
-                    return [(left, 'in', left_model.search(doms).ids)]
+                    return [(left, 'in', left_model.search(doms, order='id').ids)]
                 return doms
             else:
                 parent_name = parent or left_model._parent_name
                 child_ids = set(ids)
                 while ids:
-                    ids = left_model.search([(parent_name, 'in', ids)]).ids
+                    ids = left_model.search([(parent_name, 'in', ids)], order='id').ids
                     child_ids.update(ids)
                 return [(left, 'in', list(child_ids))]
 
@@ -746,7 +746,7 @@ class expression(object):
                         doms.insert(0, OR_OPERATOR)
                     doms += [AND_OPERATOR, ('parent_right', '>', rec.parent_left), ('parent_left', '<=',  rec.parent_left)]
                 if prefix:
-                    return [(left, 'in', left_model.search(doms).ids)]
+                    return [(left, 'in', left_model.search(doms, order='id').ids)]
                 return doms
             else:
                 parent_name = parent or left_model._parent_name
@@ -869,13 +869,13 @@ class expression(object):
                 raise NotImplementedError('auto_join attribute not supported on field %s' % field)
 
             elif len(path) > 1 and field.store and field.type == 'many2one':
-                right_ids = comodel.with_context(active_test=False).search([('.'.join(path[1:]), operator, right)]).ids
+                right_ids = comodel.with_context(active_test=False).search([('.'.join(path[1:]), operator, right)], order='id').ids
                 leaf.leaf = (path[0], 'in', right_ids)
                 push(leaf)
 
             # Making search easier when there is a left operand as one2many or many2many
             elif len(path) > 1 and field.store and field.type in ('many2many', 'one2many'):
-                right_ids = comodel.search([('.'.join(path[1:]), operator, right)]).ids
+                right_ids = comodel.search([('.'.join(path[1:]), operator, right)], order='id').ids
                 leaf.leaf = (path[0], 'in', right_ids)
                 push(leaf)
 
@@ -891,7 +891,7 @@ class expression(object):
                 else:
                     # Let the field generate a domain.
                     if len(path) > 1:
-                        right = comodel.search([('.'.join(path[1:]), operator, right)]).ids
+                        right = comodel.search([('.'.join(path[1:]), operator, right)], order='id').ids
                         operator = 'in'
                     domain = field.determine_domain(model, operator, right)
 
@@ -935,8 +935,7 @@ class expression(object):
                         else:
                             ids2 = [right]
                         if ids2 and is_integer_m2o and domain:
-                            ids2 = comodel.search([('id', 'in', ids2)] + domain).ids
-
+                            ids2 = comodel.search([('id', 'in', ids2)] + domain, order='id').ids
                     if not ids2:
                         if operator in ['like', 'ilike', 'in', '=']:
                             #no result found with given search criteria
@@ -969,7 +968,7 @@ class expression(object):
                         comodel_domain = [(field.inverse_name, '!=', False)]
                         if is_integer_m2o and domain:
                             comodel_domain += domain
-                        recs = comodel.search(comodel_domain).sudo().with_context(prefetch_fields=False)
+                        recs = comodel.search(comodel_domain, order='id').sudo().with_context(prefetch_fields=False)
                         ids1 = recs.mapped(field.inverse_name)
                         if not is_integer_m2o:
                             ids1 = ids1.ids
@@ -981,7 +980,7 @@ class expression(object):
                 if operator in HIERARCHY_FUNCS:
                     ids2 = to_ids(right, comodel)
                     dom = HIERARCHY_FUNCS[operator]('id', ids2, comodel)
-                    ids2 = comodel.search(dom).ids
+                    ids2 = comodel.search(dom, order='id').ids
                     if comodel == model:
                         push(create_substitution_leaf(leaf, ('id', 'in', ids2), model))
                     else:


### PR DESCRIPTION
Performance fix: when parsing domains using special operators
(`child_of`, ...), or with dotted field on the left value
(`['partner_id.name', ...]`), the ORM starts by a first call on
`search()` and builds a new domain so the final query has "IN (<ids
found by sub-search>)".

The sub-search issued on the comodel uses the default "order by".
The order of the ids is irrelevant here, we only need to know the ids.

A good example is when the sub-search happens on `product.product`,
which is ordered by `default_code, name, id`. The field `name` is
inherited and translated, so the ordering requires a JOIN on
`product_template` and a LEFT JOIN on `ir_translation`. Ordering by `id`
avoids these 2 JOINs.

Some discussion took place about modifying `_generate_order_by()` to
remove the `ORDER BY` clause when the `order` argument is False or ''.
Apart the fact that it would be a breaking change, @odony has shown that
sorting by `id` is so cheap that removing the `ORDER BY` might not
bring significant performance boost [0].

[0] https://github.com/odoo/odoo/pull/52368#issuecomment-646643773

opw-2270690

closes odoo/odoo#53614

X-original-commit: 4135d3e690a93ccb15b4e4d71640168f03556a8f
Signed-off-by: Raphael Collet (rco) <rco@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
