### PR TITLE
[FIX] mrp_time_counter widget format

### DIFF
--- a/addons/mrp/static/src/js/mrp.js
+++ b/addons/mrp/static/src/js/mrp.js
@@ -237,7 +237,13 @@ var TimeCounter = AbstractField.extend({
         } else {
             clearTimeout(this.timer);
         }
-        this.$el.html($('<span>' + moment.utc(this.duration).format("HH:mm:ss") + '</span>'));
+        var hours = Math.trunc(moment.duration(this.duration).asHours());
+        var hoursString = hours >= 100 && hours || (('0' + hours).slice(-2));
+        this.$el.html($('<span>'
+            + hoursString
+            + ':'
+            + moment.utc(this.duration).format("mm:ss")
+            + '</span>'));
     },
 });
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The "mrp_time_counter" widget format is incorrect

Current behavior before PR: The hours format was incorrect when the hours were greater than 23

Desired behavior after PR is merged: If the duration exceeds 23 hours it is displayed correctly




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
