### PR TITLE
[FIX] tests: generate tour screencasts properly

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -751,7 +751,7 @@ class ChromeBrowser():
 
         if ffmpeg_path:
             framerate = int(len(self.screencast_frames) / (self.screencast_frames[-1].get('timestamp') - self.screencast_frames[0].get('timestamp')))
-            r = subprocess.run([ffmpeg_path, '-framerate', str(framerate), '-i', '%s/frame_%%05d.png' % self.screencasts_dir, outfile])
+            r = subprocess.run([ffmpeg_path, '-framerate', str(framerate), '-i', '%s/frame_%%05d.png' % self.screencasts_frames_dir, outfile])
             self._logger.log(25, 'Screencast in: %s', outfile)
         else:
             outfile = outfile.strip('.mp4')


### PR DESCRIPTION
Without this patch, screencast generation failed with:

```
 [image2 @ 0x5607e70adfe0] Could find no file with path '/opt/odoo/auto/test-artifacts/prod/screencasts/frame_%05d.png' and index in the range 0-4
/opt/odoo/auto/test-artifacts/prod/screencasts/frame_%05d.png: No such file or directory
```

@Tecnativa TT24462