### PR TITLE
[FIX] round to prevent rounding issue, that prevent to write value

### DIFF
--- a/addons/hr_holidays/models/hr.py
+++ b/addons/hr_holidays/models/hr.py
@@ -103,7 +103,7 @@ class Employee(models.Model):
     def _compute_remaining_leaves(self):
         remaining = self._get_remaining_leaves()
         for employee in self:
-            employee.remaining_leaves = remaining.get(employee.id, 0.0)
+            employee.remaining_leaves = round(remaining.get(employee.id, 0.0),2)
 
     @api.multi
     def _inverse_remaining_leaves(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Actually we can have error that lead to a deadlock, if the computed value is like 3.4555555555, odoo prevent to save values because the field float is rounded on the interface to 3.45.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
