### PR TITLE
[12.0][FIX] account: Show full name in vendor_display_name

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -410,7 +410,7 @@ class AccountInvoice(models.Model):
     @api.depends('partner_id', 'source_email')
     def _get_vendor_display_info(self):
         for invoice in self:
-            vendor_display_name = invoice.partner_id.name
+            vendor_display_name = invoice.partner_id.display_name
             invoice.invoice_icon = ''
             if not vendor_display_name:
                 if invoice.source_email:


### PR DESCRIPTION
Steps to reproduce:

- Create a partner called "Company X".
- Create a partner contact "Child" inside "Company X", with full name "Company X, Child".
- Create a vendor bill for "Company X, Child".

Current behavior:

On vendor list, you see as vendor "Child".

Expected behavior:

On vendor list, you see as vendor "Company X, Child".

---

Proposed to Odoo and rejected for stable versions in odoo/odoo#47837

@Tecnativa TT23010