### PR TITLE
[10.0][FIX] orm: Ensure prefetch working when traversing multi relation rel…

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -925,6 +925,18 @@ class Field(object):
             record.ensure_one()
             try:
                 value = record._cache[self]
+                if self.relational and record and value and self.comodel_name not in record._prefetch:
+                    # we get the value from the cache for a relational field
+                    # If the comodel_name is not into the prefetched dict.
+                    # We must ensure to fill this list with all the values in cache
+                    # for all the record ids into the prefetch of the current record model
+                    prefetched_comodel_ids = record._prefetch[self.comodel_name]
+                    for rec in record.browse(record._prefetch[record._name], prefetch=record._prefetch):
+                        try:
+                            v = rec._cache[self]
+                            prefetched_comodel_ids.update(set(v))
+                        except:
+                            continue
             except KeyError:
                 # cache miss, determine value and retrieve it
                 if record.id:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3089,6 +3089,13 @@ class BaseModel(object):
             # not all records may be accessible, try with only current record
             result = self.read([f.name for f in fs], load='_classic_write')
 
+        # ensure relational_fields are declared into self._prefetch
+        for f in fs:
+            if not f.relational:
+                continue
+            for values in result:
+                self._prefetch[f.comodel_name].update(_normalize_ids(values[f.name]))
+
         # check the cache, and update it if necessary
         if field not in self._cache:
             for values in result:


### PR DESCRIPTION
…ation path

Backport of https://github.com/odoo/odoo/pull/56978

Before this change, the prefect was lost:

* when trying to access a field for a list of records of a child model from a list of records of the grandparent model.

       for record in records:
           for line in record.line_ids:
               for tag in line.tag_ids:
                   tag.name # <- prefetch is lost

* when trying to access a computed field for a list of records of a child model if these children were obtained from the cache

       # popule the cache
       records.mapped(line_ids)
       # reset all prefetch
       filtered = records.filtered(lambda a: True)

       for record in filtered:
           for line in record.line_ids:
               line.computed_value # <- prefetch is lost

Solution:

In the first case, the solution is to make sure that the prefetch is completed for the relational fields whose value has been obtained by reading the fields via the orm (call to read).

In the second case, the solution is to check at the moment of accessing the value of a field in the cache, that if the field is relational its value must be into the prefetch. If it's not the case, then it is necessary to take from the cache all the field values for the records declared in the current prefetch and populate the prefectch for the relational field being accessed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
