### PR TITLE
[12.0][FIX][WIP] mrp.wizard.change_production_qty sub bom row delete

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -46,6 +46,10 @@ class ChangeProductionQty(models.TransientModel):
         for wizard in self:
             production = wizard.mo_id
             produced = sum(production.move_finished_ids.filtered(lambda m: m.product_id == production.product_id).mapped('quantity_done'))
+
+            # memorize initial MO bom movement rows not added manually
+            mo_ini_bom_move_ids = production.move_raw_ids.filtered(lambda x: x.origin)
+
             if wizard.product_qty < produced:
                 format_qty = '%.{precision}f'.format(precision=precision)
                 raise UserError(_("You have already processed %s. Please input a quantity higher than %s ") % (format_qty % produced, format_qty % produced))
@@ -56,11 +60,14 @@ class ChangeProductionQty(models.TransientModel):
             factor = production.product_uom_id._compute_quantity(production.product_qty - qty_produced, production.bom_id.product_uom_id) / production.bom_id.product_qty
             boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id)
             documents = {}
+            mo_act_bom_move_ids = []
             for line, line_data in lines:
                 move = production.move_raw_ids.filtered(lambda x: x.bom_line_id.id == line.id and x.state not in ('done', 'cancel'))
                 if move:
                     move = move[0]
                     old_qty = move.product_uom_qty
+                    # memorize actual MO bom movement rows
+                    mo_act_bom_move_ids.append(move)
                 else:
                     old_qty = 0
                 iterate_key = production._get_document_iterate_key(move)
@@ -73,6 +80,13 @@ class ChangeProductionQty(models.TransientModel):
                             documents[key] = [value]
 
                 production._update_raw_move(line, line_data)
+
+            # delete initial MO bom rows not present in actual bom
+            if production.state not in ('done', 'cancel'):
+                for mo_ini_move_id in mo_ini_bom_move_ids:
+                    if mo_ini_move_id not in mo_act_bom_move_ids:
+                        mo_ini_move_id.state = 'draft'
+                        mo_ini_move_id.unlink()
 
             production._log_manufacture_exception(documents)
             operation_bom_qty = {}


### PR DESCRIPTION
This is a proposal to solve #57702

Current behavior before PR:
On a MO of a product with a sub-bom of type kit, when a row of the sub-bom is set to quantity 0, the relative row on the MO is deleted; when the the row of a sub-bom is deleted, the relative row on the MO remain inalterated.

Desired behavior after PR is merged:
On a MO of a product with a sub-bom of type kit, when a row of the sub-bom is set to quantity 0 or is deleted, the relative row on the MO is deleted.

[WIP](thanks to those who will help)
Add tests

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
