### PR TITLE
delivery: choose delivery method by partner_shipping_id

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -26,10 +26,10 @@ class SaleOrder(models.Model):
                 order.delivery_price = order.company_id.currency_id.with_context(date=order.date_order).compute(
                     order.carrier_id.with_context(order_id=order.id).price, order.pricelist_id.currency_id)
 
-    @api.onchange('partner_id')
+    @api.onchange('partner_shipping_id')
     def onchange_partner_id_dtype(self):
-        if self.partner_id:
-            self.carrier_id = self.partner_id.property_delivery_carrier_id
+        if self.partner_shipping_id:
+            self.carrier_id = self.partner_shipping_id.property_delivery_carrier_id.filtered('active')
 
     @api.multi
     def action_confirm(self):


### PR DESCRIPTION
Steps:

* Create a delivery method (1) restricted to Spain (any country would do)
* Create a delivery method (2) restricted to Madagascar (same)
* Create a partner, main company, whose country is Spain and the default
delivery method is the first one.
* Create a delivery address for that customer with Madagascar as country and the
default delivery method as the second one.
* Now place a new quotation with such partner and set the delivery address to
the one of Madagascar (multiple addresses setting must be on).

Before:

* The delivery method for the quotation is set to the one restricted to Spain
although we're sending it to Madagascar.

After:

* The delivery method for the quotation is set to the one restricted to
Madagascar.

Signed-off-by: Tom Blauwendraat <tom@sunflowerweb.nl>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
