### PR TITLE
[13.0][FIX] web: form_renderer

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -213,11 +213,11 @@ var FormRenderer = BasicRenderer.extend({
      */
     getLocalState: function () {
         var state = {};
-        this.$('div.o_notebook').each(function () {
+        this.$('div.o_notebook').each(function (k) {
             var $notebook = $(this);
-            var name = $notebook.data('name');
+            var name = k;
             var index = -1;
-            $notebook.find('.nav-link').each(function (i) {
+            $notebook.children('div').children('ul').find('.nav-link').each(function (i) {
                 if ($(this).hasClass('active')) {
                     index = i;
                 }
@@ -247,9 +247,9 @@ var FormRenderer = BasicRenderer.extend({
      * @param {Object} state the result from a getLocalState call
      */
     setLocalState: function (state) {
-        this.$('div.o_notebook').each(function () {
+        this.$('div.o_notebook').each(function (k) {
             var $notebook = $(this);
-            var name = $notebook.data('name');
+            var name = k;
             if (name in state) {
                 var $page = $notebook.find('> .o_notebook_headers > .nav-tabs > .nav-item').eq(state[name]);
                 if (!$page.hasClass('o_invisible_modifier')) {

--- a/doc/cla/individual/vicentecom.md
+++ b/doc/cla/individual/vicentecom.md
@@ -1,0 +1,11 @@
+Spain, 2020-10-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vicente Ángel Gutiérrez Fernández vicente@comunitea.com https://github.com/vicentecom


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a form has nested notebooks there is a misbehaviour:
- Nested notebooks with no name override the index of previous notebooks with no name.
- Notebooks with an inside notebook get the active index of the inside notebook.
Related issue: [odoo#47145](https://github.com/odoo/odoo/issues/47145)

Current behavior before PR:
If the notebook has no name the name in the JavaScript code will be _default_, so the next notebook without name will replace the index.
Also, for each notebook the code look for '.nav-link' elements so, if there is a nested notebook, the active element of the nested notebook will override the current active element of the original notebook.

Desired behavior after PR is merged:
Look only for '.nav-link' elements inside the notebook ul children to avoid getting nested notebook elements.
Use the current position of the notebook elements instead of their name so there will be no override in case of nameless notebooks.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
