### PR TITLE
[FIX][11.0] Fix Landed Cost Expense Account

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -366,10 +366,11 @@ class AdjustmentLines(models.Model):
 
             # TDE FIXME: oh dear
             if self.env.user.company_id.anglo_saxon_accounting:
+                expense_account_id = self.product_id.product_tmpl_id.get_product_accounts()['expense'].id
                 debit_line = dict(base_line,
                                   name=(self.name + ": " + str(qty_out) + _(' already out')),
                                   quantity=0,
-                                  account_id=credit_account_id)
+                                  account_id=expense_account_id)
                 credit_line = dict(base_line,
                                    name=(self.name + ": " + str(qty_out) + _(' already out')),
                                    quantity=0,

--- a/doc/cla/individual/npandyangsa.md
+++ b/doc/cla/individual/npandyangsa.md
@@ -1,0 +1,9 @@
+Indonesia, 2020-11-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Nanda Pandyangsa nanda@uniteksolusi.com https://github.com/npandyangsa


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Landed Cost created journal items for the product already out use the wrong account.

Current behavior before PR:
Created journal items from landed cost use the landed-cost-product account, instead of the cost-impacted-product's expense account

Desired behavior after PR is merged:
Created journal items from landed cost shall use the cost-impacted-product's expense account


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr