### PR TITLE
[13.0][FIX] hr_skill_slides: fix duplicate hr.resume.line on slide-channel completion

### DIFF
--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -9,19 +9,21 @@ class SlideChannelPartner(models.Model):
 
     def _recompute_completion(self):
         res = super(SlideChannelPartner, self)._recompute_completion()
-        partner_has_completed = {channel_partner.partner_id.id: channel_partner.channel_id for channel_partner in self}
-        employees = self.env['hr.employee'].sudo().search([('user_id.partner_id', 'in', list(partner_has_completed.keys()))])
-        for employee in employees:
-            line_type = self.env.ref('hr_skills_slides.resume_type_training', raise_if_not_found=False)
-            channel = partner_has_completed[employee.user_id.partner_id.id]
-            self.env['hr.resume.line'].create({
-                'employee_id': employee.id,
-                'name': channel.name,
-                'date_start': fields.Date.today(),
-                'date_end': fields.Date.today(),
-                'description': channel.description,
-                'line_type_id': line_type and line_type.id,
-                'display_type': 'course',
-                'channel_id': channel.id
-            })
+        partner_has_completed = {channel_partner.partner_id.id: channel_partner.channel_id
+                                 for channel_partner in self if channel_partner.completed}
+        if partner_has_completed:
+            employees = self.env['hr.employee'].sudo().search([('user_id.partner_id', 'in', list(partner_has_completed.keys()))])
+            for employee in employees:
+                line_type = self.env.ref('hr_skills_slides.resume_type_training', raise_if_not_found=False)
+                channel = partner_has_completed[employee.user_id.partner_id.id]
+                self.env['hr.resume.line'].create({
+                    'employee_id': employee.id,
+                    'name': channel.name,
+                    'date_start': fields.Date.today(),
+                    'date_end': fields.Date.today(),
+                    'description': channel.description,
+                    'line_type_id': line_type and line_type.id,
+                    'display_type': 'course',
+                    'channel_id': channel.id
+                })
         return res

--- a/doc/cla/individual/anwarirl.md
+++ b/doc/cla/individual/anwarirl.md
@@ -1,0 +1,11 @@
+Indonesia, 2020-10-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Anwari Rahman anwari96@gmail.com https://github.com/anwarirl


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix to prevent duplicate data on hr.resume.line (for the same partner and channel) when a partner/user completes slides in a channel

Current behavior before PR:
For example, channel "Basics Of Gardening" has 3 slides (slide no 1, no 2 and no. 3).
when a user/partner completes slide no 1, new data will be created in hr.resume.line (for that user and channel ABC).
when a user completes slide no 2, a new record will be created again (duplicate data in hr.resume.line).

![image](https://user-images.githubusercontent.com/9793126/100584909-518b0480-331f-11eb-8c55-dc75d01dfdf0.png)

Desired behavior after PR is merged:
the data in hr.resume.line should only be created once when all slides have been completed (when a partner completed a channel).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
