### PR TITLE
12.0 fix pos fp

### DIFF
--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -125,3 +125,27 @@ class TestFiscalPosition(common.TransactionCase):
         # Dedicated position has max precedence
         george.property_account_position_id = self.be_nat
         assert_fp(george, self.be_nat, "Forced position has max precedence")
+
+
+    def test_20_fp_one_tax_2m(self):
+
+        self.src_tax = self.env['account.tax'].create({'name': "SRC", 'amount': 0.0})
+        self.dst1_tax = self.env['account.tax'].create({'name': "DST1", 'amount': 0.0})
+        self.dst2_tax = self.env['account.tax'].create({'name': "DST2", 'amount': 0.0})
+
+        self.fp2m = self.fp.create({
+            'name': "FP-TAX2TAXES",
+            'tax_ids': [
+                (0,0,{
+                    'tax_src_id': self.src_tax.id,
+                    'tax_dest_id': self.dst1_tax.id
+                }),
+                (0,0,{
+                    'tax_src_id': self.src_tax.id,
+                    'tax_dest_id': self.dst2_tax.id
+                })
+            ]
+        })
+        mapped_taxes = self.fp2m.map_tax(self.src_tax)
+
+        self.assertEqual(mapped_taxes, self.dst1_tax | self.dst2_tax)

--- a/addons/point_of_sale/static/src/js/tests.js
+++ b/addons/point_of_sale/static/src/js/tests.js
@@ -230,6 +230,20 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         }];
     }
 
+    function set_fiscal_position_on_order(fp_name) {
+        return [{
+            content: 'set fiscal position',
+            trigger: '.control-button.o_fiscal_position_button',
+        }, {
+            content: 'choose fiscal position ' + fp_name + ' to add to the order',
+            trigger: '.popups .popup .selection .selection-item:contains("' + fp_name + '")',
+        }, {
+            content: 'the fiscal position ' + fp_name + ' has been set to the order',
+            trigger: '.control-button.o_fiscal_position_button:contains("' + fp_name + '")',
+            run: function () {}, // it's a check
+        }];
+    }
+
     function generate_keypad_steps(amount_str, keypad_selector) {
         var i, steps = [], current_char;
         for (i = 0; i < amount_str.length; ++i) {
@@ -320,6 +334,12 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
     steps = steps.concat(goto_payment_screen_and_select_payment_method());
     steps = steps.concat(generate_payment_screen_keypad_steps("10"));
     steps = steps.concat(finish_order());
+
+    // Test fiscal position one2many map (align with backend)
+    steps = steps.concat(add_product_to_order('Letter Tray'));
+    steps = steps.concat(verify_order_total('5.28'));
+    steps = steps.concat(set_fiscal_position_on_order('FP-POS-2M'));
+    steps = steps.concat(verify_order_total('5.52'));
 
     steps = steps.concat([{
         content: "close the Point of Sale frontend",

--- a/addons/point_of_sale/static/src/xml/pos.xml
+++ b/addons/point_of_sale/static/src/xml/pos.xml
@@ -124,7 +124,7 @@
     </t>
 
     <t t-name="SetFiscalPositionButton">
-        <div class='control-button'>
+        <div class='control-button o_fiscal_position_button'>
             <i class='fa fa-book' role="img" aria-label="Set fiscal position" title="Set fiscal position"/> <t t-esc='widget.get_current_fiscal_position_name()'/>
         </div>
     </t>

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -269,7 +269,21 @@ class TestUi(odoo.tests.HttpCase):
         all_pricelists = env['product.pricelist'].search([('id', '!=', excluded_pricelist.id)])
         all_pricelists.write(dict(currency_id=main_company.currency_id.id))
 
+        src_tax = env['account.tax'].create({'name': "SRC", 'amount': 10})
+        dst_tax = env['account.tax'].create({'name': "DST", 'amount': 5})
+
+        env.ref('point_of_sale.letter_tray').taxes_id = [(6, 0, [src_tax.id])]
+
         main_pos_config.write({
+            'tax_regime_selection': True,
+            'fiscal_position_ids': [(0, 0, {
+                                            'name': "FP-POS-2M",
+                                            'tax_ids': [
+                                                (0,0,{'tax_src_id': src_tax.id,
+                                                      'tax_dest_id': src_tax.id}),
+                                                (0,0,{'tax_src_id': src_tax.id,
+                                                      'tax_dest_id': dst_tax.id})]
+                                            })],
             'journal_id': test_sale_journal.id,
             'invoice_journal_id': test_sale_journal.id,
             'journal_ids': [(0, 0, {'name': 'Cash Journal - Test',


### PR DESCRIPTION
Backported from: https://github.com/odoo/odoo/commit/a19eb47caa628761424fb512bd3569f9d3020e26
Same logic as in https://github.com/OCA/OCB/pull/822

Before this commit, it was not possible to map one tax to multiple taxes
in the point of sale, just as it is in the account module.

This commit implements fiscal positions that can map to various taxes
on POS.

Furthermore, id adds test to secure that somewhat implicit feature on which
several localisations seem to depend upon.

A typical use case if one tax is not replaced but complemented by another.

**Description of the issue/feature this PR addresses:**

- Taxes can only be replaced in POS.
- Not complemented by a peer tax.
- Behavior not aligned with backend fp mapping.

**Current behavior before PR:**

- Tax cannot be mapped to several taxes (aka: complemented: "to itself and other") on POS

**Desired behavior after PR is merged:**

- Tax can be mapped (aka: complemented) to various taxes on POS


cc @Tecnativa TT27226
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
