### PR TITLE
[10.0][FIX] CVE-2018-15632, loading: require install mode to trigger db init

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -138,6 +138,7 @@ def main(args):
         for db_name in preload:
             try:
                 odoo.service.db._create_empty_database(db_name)
+                config['init']['base'] = True
             except ProgrammingError as err:
                 if err.pgcode == errorcodes.INSUFFICIENT_PRIVILEGE:
                     # We use an INFO loglevel on purpose in order to avoid

--- a/odoo/cli/start.py
+++ b/odoo/cli/start.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import sys
 
+import odoo
 from . import Command
 from .server import main
 from odoo.modules.module import get_module_root, MANIFEST_NAMES
@@ -59,6 +60,7 @@ class Start(Command):
         # TODO: forbid some database names ? eg template1, ...
         try:
             _create_empty_database(args.db_name)
+            odoo.tools.config['init']['base'] = True
         except DatabaseExists, e:
             pass
         except Exception, e:

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -287,6 +287,9 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
     cr = db.cursor()
     try:
         if not odoo.modules.db.is_initialized(cr):
+            if not update_module:
+                _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
+                return
             _logger.info("init db")
             odoo.modules.db.initialize(cr)
             update_module = True # process auto-installed modules


### PR DESCRIPTION
Affects: Odoo 11.0 and earlier (Community and Enterprise Editions)
Severity :: High :: 8.2 :: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H
Improper input validation in database creation logic in Odoo Community 11.0
and earlier and Odoo Enterprise 11.0 and earlier, allows remote attackers
to initialize an empty database on which they can connect with default
credentials.

https://github.com/odoo/odoo/issues/63700