### PR TITLE
[8.0][FIX] CVE-2018-15632, loading: require install mode to trigger db init

### DIFF
--- a/openerp/cli/start.py
+++ b/openerp/cli/start.py
@@ -5,6 +5,7 @@ import glob
 import os
 import sys
 
+import openerp
 from . import Command
 from .server import main
 from openerp.modules.module import get_module_root, MANIFEST
@@ -53,6 +54,7 @@ class Start(Command):
         # TODO: forbid some database names ? eg template1, ...
         try:
             _create_empty_database(args.db_name)
+            openerp.tools.config['init']['base'] = True
         except DatabaseExists, e:
             pass
         except Exception, e:

--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -269,6 +269,9 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
     cr = db.cursor()
     try:
         if not openerp.modules.db.is_initialized(cr):
+            if not update_module:
+                _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
+                return
             _logger.info("init db")
             openerp.modules.db.initialize(cr)
             update_module = True # process auto-installed modules


### PR DESCRIPTION
Affects: Odoo 11.0 and earlier (Community and Enterprise Editions)
Severity :: High :: 8.2 :: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:H
Improper input validation in database creation logic in Odoo Community 11.0
and earlier and Odoo Enterprise 11.0 and earlier, allows remote attackers
to initialize an empty database on which they can connect with default
credentials.

https://github.com/odoo/odoo/issues/63700