### PR TITLE
[9.0][FIX] CVE-2018-15633, document: escape before incrementing

### DIFF
--- a/addons/web/static/src/js/widgets/sidebar.js
+++ b/addons/web/static/src/js/widgets/sidebar.js
@@ -181,6 +181,7 @@ var Sidebar = Widget.extend({
     },
     on_attachments_loaded: function(attachments) {
         _.each(attachments,function(a) {
+            a.name = _.escape(a.name);
             a.label = a.name;
             if(a.type === "binary") {
                 a.url = '/web/content/'  + a.id + '?download=true';


### PR DESCRIPTION
CVE-2018-15633

Affects: Odoo 11.0 and earlier (Community and Enterprise Editions)
Severity :: High :: 7.1 :: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:L/A:N
Cross-site scripting (XSS) issue in Documents module in Odoo Community 11.0
and earlier and Odoo Enterprise 11.0 and earlier, allows remote attackers
to inject arbitrary web script in the browser of a victim via crafted
attachment filenames.

Odoo issue: https://github.com/odoo/odoo/issues/63701
