### PR TITLE
[9.0][FIX] CVE-2018-15638, mail: use consistent placeholder

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -3189,7 +3189,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/mail/static/src/js/chat_manager.js:478
 #, python-format
-msgid "You have been invited to: "
+msgid "You have been invited to: %s"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/js/chat_manager.js
+++ b/addons/mail/static/src/js/chat_manager.js
@@ -672,7 +672,7 @@ function on_chat_session_notification (chat_session) {
     if ((chat_session.channel_type === "channel") && (chat_session.state === "open")) {
         add_channel(chat_session, {autoswitch: false});
         if (!chat_session.is_minimized && chat_session.info !== 'creation') {
-            web_client.do_notify(_t("Invitation"), _t("You have been invited to: ") + chat_session.name);
+            web_client.do_notify(_t("Invitation"), _.str.sprintf(_t("You have been invited to: %s"), _.escape(chat_session.name)));
         }
     }
     // partner specific change (open a detached window for example)

--- a/addons/mail/static/src/js/client_action.js
+++ b/addons/mail/static/src/js/client_action.js
@@ -297,10 +297,10 @@ var ChatAction = Widget.extend(ControlPanelMixin, {
 
         this.$('.o_mail_add_channel[data-type=public]').find("input").autocomplete({
             source: function(request, response) {
-                self.last_search_val = _.escape(request.term);
+                self.last_search_val = request.term;
                 self.do_search_channel(self.last_search_val).done(function(result){
                     result.push({
-                        'label':  _.str.sprintf('<strong>'+_t("Create %s")+'</strong>', '<em>"#'+self.last_search_val+'"</em>'),
+                        'label':  _.str.sprintf('<strong>'+_t("Create %s")+'</strong>', '<em>"#'+_.escape(self.last_search_val)+'"</em>'),
                         'value': '_create',
                     });
                     response(result);
@@ -337,7 +337,7 @@ var ChatAction = Widget.extend(ControlPanelMixin, {
         });
 
         this.$('.o_mail_add_channel[data-type=private]').find("input").on('keyup', this, function (event) {
-            var name = _.escape($(event.target).val());
+            var name = $(event.target).val();
             if(event.which === $.ui.keyCode.ENTER && name) {
                 chat_manager.create_channel(name, "private");
             }
@@ -405,7 +405,7 @@ var ChatAction = Widget.extend(ControlPanelMixin, {
             }
 
             // Update control panel
-            self.set("title", '#' + channel.name);
+            self.set("title", '#' + _.escape(channel.name));
             // Hide 'invite', 'unsubscribe' and 'settings' buttons in static channels and DM
             self.$buttons
                 .find('.o_mail_chat_button_invite, .o_mail_chat_button_unsubscribe, .o_mail_chat_button_settings')
@@ -454,7 +454,7 @@ var ChatAction = Widget.extend(ControlPanelMixin, {
             .then(this.set_channel.bind(this, chat_manager.get_channel("channel_inbox")))
             .then(function () {
                 if (_.contains(['public', 'private'], channel.type)) {
-                    var msg = _.str.sprintf(_t('You unsubscribed from <b>%s</b>.'), channel.name);
+                    var msg = _.str.sprintf(_t('You unsubscribed from <b>%s</b>.'), _.escape(channel.name));
                     self.do_notify(_t("Unsubscribed"), msg);
                 }
                 delete self.channels_scrolltop[channel.id];
@@ -631,7 +631,7 @@ var ChatAction = Widget.extend(ControlPanelMixin, {
     },
 
     on_click_button_invite: function () {
-        var title = _.str.sprintf(_t('Invite people to #%s'), this.channel.name);
+        var title = _.str.sprintf(_t('Invite people to #%s'), _.escape(this.channel.name));
         new PartnerInviteDialog(this, title, this.channel.id).open();
     },
 


### PR DESCRIPTION
When generation the message. add the name of the channel with a
placeholder. In some languages like Japanese, the order of words is
different and adding the name at the end makes an incorrect sentence,
it was not possible to properly translate it.

Affects: Odoo 13.0 and earlier (Community and Enterprise Editions)
Severity :: High :: 7.1 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
Cross-site scripting (XSS) issue in mail module in Odoo Community 13.0
and earlier and Odoo Enterprise 13.0 and earlier, allows remote attackers
to inject arbitrary web script in the browser of a victim via crafted
channel names.

https://github.com/odoo/odoo/issues/63703