### PR TITLE
[9.0][IMP] CVE-2018-15645, mail: only delegate tracking during cron

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1132,7 +1132,7 @@ class MailThread(models.AbstractModel):
 
                 # disabled subscriptions during message_new/update to avoid having the system user running the
                 # email gateway become a follower of all inbound messages
-                MessageModel = Model.sudo(user_id).with_context(mail_create_nosubscribe=True, mail_create_nolog=True)
+                MessageModel = Model.sudo(user_id if self.env.user._is_admin() else None).with_context(mail_create_nosubscribe=True, mail_create_nolog=True)
                 if thread_id and hasattr(MessageModel, 'message_update'):
                     MessageModel.browse(thread_id).message_update(message_dict)
                 else:


### PR DESCRIPTION
Affects: Odoo 12.0 and earlier (Community and Enterprise Editions)
Severity :: High :: 8.1 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
Improper access control in message routing in Odoo Community 12.0 and earlier
and Odoo Enterprise 12.0 and earlier allows remote authenticated users
to create arbitrary records via crafted payloads, which may allow privilege
escalation.

https://github.com/odoo/odoo/issues/63705