### PR TITLE
[9.0][FIX] CVE-2020-29396, base: make datetime coherent with dateutil

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -78,7 +78,7 @@ try:
         'str': str,
         'quote': quote,
         'urlencode': urlencode,
-        'datetime': datetime,
+        'datetime': tools.wrap_module(datetime, []),
         'len': len,
         'abs': abs,
         'min': min,

--- a/openerp/addons/base/ir/ir_actions.py
+++ b/openerp/addons/base/ir/ir_actions.py
@@ -7,6 +7,7 @@ import operator
 import os
 import time
 import datetime
+import dateutil
 import pytz
 
 import openerp
@@ -26,16 +27,6 @@ from openerp.exceptions import MissingError, UserError
 
 _logger = logging.getLogger(__name__)
 
-
-# build dateutil helper, starting with the relevant *lazy* imports
-import dateutil
-import dateutil.parser
-import dateutil.relativedelta
-import dateutil.rrule
-import dateutil.tz
-mods = {'parser', 'relativedelta', 'rrule', 'tz'}
-attribs = {atr for m in mods for atr in getattr(dateutil, m).__all__}
-dateutil = wrap_module(dateutil, mods | attribs)
 
 class actions(osv.osv):
     _name = 'ir.actions.actions'

--- a/openerp/tools/misc.py
+++ b/openerp/tools/misc.py
@@ -10,6 +10,7 @@ from functools import wraps
 import cPickle
 import cProfile
 from contextlib import contextmanager
+import datetime
 import subprocess
 import logging
 import os
@@ -37,7 +38,7 @@ except ImportError:
 
 from config import config
 from cache import *
-from .parse_version import parse_version 
+from .parse_version import parse_version
 
 import openerp
 # get_encodings, ustr and exception_to_unicode were originally from tools.misc.
@@ -1236,6 +1237,19 @@ class Pickle(object):
 
 pickle = Pickle
 
+def wrap_values(d):
+    # apparently sometimes people pass raw records as eval context
+    # values
+    if not (d and isinstance(d, dict)):
+        return d
+    for k in d:
+        v = d[k]
+        if isinstance(v, types.ModuleType):
+            d[k] = wrap_module(v, None)
+    return d
+import shutil
+_missing = object()
+_cache = dict.fromkeys([os, os.path, shutil, sys, subprocess])
 def wrap_module(module, attr_list):
     """Helper for wrapping a package/module to expose selected attributes
 
@@ -1244,14 +1258,38 @@ def wrap_module(module, attr_list):
             attributes and their own main attributes. No support for hiding attributes in case
             of name collision at different levels.
     """
-    attr_list = set(attr_list)
+    wrapper = _cache.get(module)
+    if wrapper:
+        return wrapper
+
+    attr_list = attr_list and set(attr_list)
     class WrappedModule(object):
         def __getattr__(self, attrib):
-            if attrib in attr_list:
-                target = getattr(module, attrib)
-                if isinstance(target, types.ModuleType):
-                    return wrap_module(target, attr_list)
-                return target
-            raise AttributeError(attrib)
+            # respect whitelist if there is one
+            if attr_list is not None and attrib not in attr_list:
+                raise AttributeError(attrib)
+
+            target = getattr(module, attrib)
+            if isinstance(target, types.ModuleType):
+                wrapper = _cache.get(target, _missing)
+                if wrapper is None:
+                    raise AttributeError(attrib)
+                if wrapper is _missing:
+                    target = wrap_module(target, attr_list)
+                else:
+                    target = wrapper
+            setattr(self, attrib, target)
+            return target
     # module and attr_list are in the closure
-    return WrappedModule()
+    wrapper = WrappedModule()
+    _cache.setdefault(module, wrapper)
+    return wrapper
+
+# dateutil submodules are lazy so need to import them for them to "exist"
+import dateutil
+mods = ['parser', 'relativedelta', 'rrule', 'tz']
+for mod in mods:
+    __import__('dateutil.%s' % mod)
+attribs = [attr for m in mods for attr in getattr(dateutil, m).__all__]
+dateutil = wrap_module(dateutil, set(mods + attribs))
+datetime = wrap_module(datetime, ['date', 'datetime', 'time', 'timedelta', 'timezone', 'tzinfo', 'MAXYEAR', 'MINYEAR'])

--- a/openerp/tools/safe_eval.py
+++ b/openerp/tools/safe_eval.py
@@ -20,7 +20,7 @@ from psycopg2 import OperationalError
 from types import CodeType
 import logging
 
-from .misc import ustr
+from .misc import ustr, wrap_values
 
 import openerp
 
@@ -284,6 +284,9 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
             globals_dict = dict(globals_dict)
         if locals_dict is not None:
             locals_dict = dict(locals_dict)
+
+    wrap_values(globals_dict)
+    wrap_values(locals_dict)
 
     if globals_dict is None:
         globals_dict = {}


### PR DESCRIPTION
As we do not need all the datetime module, we want to restrict the
functions (as we do for dateutil). Also centralise handling of this
and apply it by default, no reason for there to be divergences.

Task 2179629

Affects: Odoo 11.0 through 13.0 (Community and Enterprise Editions)
Severity :: Critical :: 9.9 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L
A sandboxing issue in Odoo Community 11.0 through 14.0 and Odoo Enterprise
11.0 through 14.0, when running with Python 3.6, allows remote authenticated
users to execute arbitrary code, leading to privilege escalation.

https://github.com/odoo/odoo/issues/63712