### PR TITLE
[8.0][FIX] CVE-2020-29396, base: make datetime coherent with dateutil

### DIFF
--- a/addons/email_template/email_template.py
+++ b/addons/email_template/email_template.py
@@ -96,7 +96,7 @@ try:
         'str': str,
         'quote': quote,
         'urlencode': urlencode,
-        'datetime': datetime,
+        'datetime': tools.wrap_module(datetime, []),
         'len': len,
         'abs': abs,
         'min': min,

--- a/openerp/addons/base/ir/ir_actions.py
+++ b/openerp/addons/base/ir/ir_actions.py
@@ -25,6 +25,7 @@ import operator
 import os
 import time
 import datetime
+import dateutil
 import pytz
 
 import openerp
@@ -43,16 +44,6 @@ import openerp.workflow
 
 _logger = logging.getLogger(__name__)
 
-
-# build dateutil helper, starting with the relevant *lazy* imports
-import dateutil
-import dateutil.parser
-import dateutil.relativedelta
-import dateutil.rrule
-import dateutil.tz
-mods = {'parser', 'relativedelta', 'rrule', 'tz'}
-attribs = {atr for m in mods for atr in getattr(dateutil, m).__all__}
-dateutil = wrap_module(dateutil, mods | attribs)
 
 class actions(osv.osv):
     _name = 'ir.actions.actions'

--- a/openerp/tools/safe_eval.py
+++ b/openerp/tools/safe_eval.py
@@ -36,7 +36,7 @@ from psycopg2 import OperationalError
 from types import CodeType
 import logging
 
-from .misc import ustr
+from .misc import ustr, wrap_values
 
 import openerp
 
@@ -264,6 +264,9 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
         globals_dict = dict(globals_dict)
         if locals_dict is not None:
             locals_dict = dict(locals_dict)
+
+    wrap_values(globals_dict)
+    wrap_values(locals_dict)
 
     globals_dict.update(
         __builtins__={


### PR DESCRIPTION
As we do not need all the datetime module, we want to restrict the
functions (as we do for dateutil). Also centralise handling of this
and apply it by default, no reason for there to be divergences.

Task 2179629

Affects: Odoo 11.0 through 13.0 (Community and Enterprise Editions)
Severity :: Critical :: 9.9 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L
A sandboxing issue in Odoo Community 11.0 through 14.0 and Odoo Enterprise
11.0 through 14.0, when running with Python 3.6, allows remote authenticated
users to execute arbitrary code, leading to privilege escalation.

https://github.com/odoo/odoo/issues/63712