### PR TITLE
[9.0][FIX] CVE-2019-11783, mail: make the current user member of the created channel

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -2846,6 +2846,12 @@ msgid "The owner of records created upon receiving emails on this alias. If this
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+#, python-format
+msgid "The partner can not join this channel"
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/models/mail_message.py:642
 #: code:addons/mail/models/mail_message.py:731
 #, python-format
@@ -3164,6 +3170,24 @@ msgstr ""
 #: code:addons/mail/static/src/xml/thread.xml:29
 #, python-format
 msgid "You can mark any message as 'starred', and it shows up in this channel."
+msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+#, python-format
+msgid "You can not remove this partner from this channel"
+msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+#, python-format
+msgid "You can not write on the record of other users"
+msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_channel.py:0
+#, python-format
+msgid "You can not write on this field"
 msgstr ""
 
 #. module: mail


### PR DESCRIPTION
CVE-2019-11783

Affects: Odoo 14.0 and earlier (Community and Enterprise Editions)
Severity :: Medium :: 6.5 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
Improper access control in mail module (channel partners) in Odoo Community
14.0 and earlier and Odoo Enterprise 14.0 and earlier, allows remote
authenticated users to subscribe to arbitrary mail channels uninvited.

Odoo issue: odoo#63708