### PR TITLE
[8.0][FIX] CVE-2019-11786, base: load a language only when necessary

### DIFF
--- a/openerp/addons/base/module/wizard/base_import_language.py
+++ b/openerp/addons/base/module/wizard/base_import_language.py
@@ -45,6 +45,7 @@ class base_language_import(osv.osv_memory):
         this = self.browse(cr, uid, ids[0])
         if this.overwrite:
             context = dict(context, overwrite=True)
+        self.env["res.lang"].load_lang(cr, uid, lang=self.code, lang_name=self.name)
         fileobj = TemporaryFile('w+')
         try:
             fileobj.write(base64.decodestring(this.data))

--- a/openerp/addons/base/res/res_lang.py
+++ b/openerp/addons/base/res/res_lang.py
@@ -61,6 +61,13 @@ class lang(osv.osv):
         return True
 
     def load_lang(self, cr, uid, lang, lang_name=None):
+        """ Create the given language if necessary, and make it active. """
+        # if the language exists, simply make it active
+        lang_ids = self.search(cr, uid, [('code', '=', lang)], context={'active_test': False})
+        if lang_ids:
+            self.write(cr, uid, lang_ids, {'active': True})
+            return lang_ids[0]
+
         # create the language with locale information
         fail = True
         iso_lang = tools.get_iso_codes(lang)


### PR DESCRIPTION
Could import translation on a non-active translation

Affects: Odoo 13.0 and earlier (Community and Enterprise Editions)
Severity :: Medium :: 4.3 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
Improper access control in Odoo Community 13.0 and earlier and Odoo
Enterprise 13.0 and earlier, allows remote authenticated users to modify
translated terms, which may lead to arbitrary content modification on
translatable elements.

https://github.com/odoo/odoo/issues/63711

In this port, also backport the reason why a call to load_lang fixes this,
which is a (trivial) write on the res.lang, exercising the appropriate
access rights (From https://github.com/odoo/odoo/commit/5aa459a18e3)