### PR TITLE
[10.0][FIX] CVE-2019-11786, base: load a language only when necessary

### DIFF
--- a/odoo/addons/base/module/wizard/base_import_language.py
+++ b/odoo/addons/base/module/wizard/base_import_language.py
@@ -29,6 +29,7 @@ class BaseLanguageImport(models.TransientModel):
     def import_lang(self):
         this = self[0]
         this = this.with_context(overwrite=this.overwrite)
+        self.env["res.lang"].load_lang(lang=self.code, lang_name=self.name)
         with TemporaryFile('w+') as buf:
             try:
                 buf.write(base64.decodestring(this.data))


### PR DESCRIPTION
Could import translation on a non-active translation

Affects: Odoo 13.0 and earlier (Community and Enterprise Editions)
Severity :: Medium :: 4.3 :: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
Improper access control in Odoo Community 13.0 and earlier and Odoo
Enterprise 13.0 and earlier, allows remote authenticated users to modify
translated terms, which may lead to arbitrary content modification on
translatable elements.

https://github.com/odoo/odoo/issues/63711