### PR TITLE
[8.0][FIX] account mark_mail_as_sent nolock

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -1354,9 +1354,13 @@ class account_move(osv.osv):
         return self.post(cursor, user, ids, context=context)
 
     def button_cancel(self, cr, uid, ids, context=None):
+        obj_move_line = self.pool['account.move.line']
         for line in self.browse(cr, uid, ids, context=context):
             if not line.journal_id.update_posted:
                 raise osv.except_osv(_('Error!'), _('You cannot modify a posted entry of this journal.\nFirst you should set the journal to allow cancelling entries.'))
+            obj_move_line._update_journal_check(
+                cr, uid, line.journal_id.id, line.period_id.id,
+                context=context)
         if ids:
             cr.execute('UPDATE account_move '\
                        'SET state=%s '\

--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -1680,12 +1680,13 @@ class mail_compose_message(models.Model):
     @api.multi
     def send_mail(self):
         context = self._context
+        ret = super(mail_compose_message, self).send_mail()
         if context.get('default_model') == 'account.invoice' and \
                 context.get('default_res_id') and context.get('mark_invoice_as_sent'):
             invoice = self.env['account.invoice'].browse(context['default_res_id'])
             invoice = invoice.with_context(mail_post_autofollow=True)
             invoice.write({'sent': True})
             invoice.message_post(body=_("Invoice sent"))
-        return super(mail_compose_message, self).send_mail()
+        return ret
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When mail server is slow to respond and user clicks 'Send by email' on invoice many times, locking ensues

Current behavior before PR:

mark_mail_as_sent executes before the mail is actually sent, thus acquiring a lock on the invoice

Desired behavior after PR is merged:

mark_mail_as_sent executes after the mail is actually sent, thus not acquiring a lock on the invoice unless the invoice is actually sent, and so not blocking other processes.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
