### PR TITLE
[FIX] Field error with many2many_tags widget

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -2002,10 +2002,12 @@ var BasicModel = AbstractModel.extend({
                 var field = fields[name];
                 var fieldInfo = fieldsInfo[name];
                 var key = prefix + name;
-                specs[key] = (field.onChange) || "";
-                if (field.onChange) {
-                    hasOnchange = true;
-                }
+		if (field !== undefined) {
+                    specs[key] = (field.onChange) || "";
+                    if (field.onChange) {
+                        hasOnchange = true;
+                    }
+		}
                 _.each(fieldInfo.views, function (view) {
                     generateSpecs(view.fieldsInfo[view.type], view.fields, key + '.');
                 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This bug is reproduced as follows.
We define a field in 'res_partner' which is of type One2many.
In turn, this model has a Many2many field.
In the form of 'res_partner' we add the field One2many (No editable property. Form to modify)
and we define the Many2many field of the latter with a widget of the type 'many2many_tags'.
If we have defined a record and we enter to edit it, and then
we add a record with ('add and item') gives us the javascript error (fields is undefined). 

Current behavior before PR:

If the mentioned guidelines are followed, it gives a javascript error 'field is undefined'.
Location: /ocb/addons/web/static/src/js/views/basic/basic_model.js (line 2005). 

Desired behavior after PR is merged:

Being able to insert a record, after an update with many2many_tags widget without javascript error. 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
