### PR TITLE
[FIX] Set iap modules as not auto-installable

### DIFF
--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -23,5 +23,5 @@ to support In-App purchases inside Odoo. """,
     'qweb': [
         'static/src/xml/iap_templates.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -26,5 +26,5 @@
     'qweb': [
         'static/src/xml/partner_autocomplete.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -43,5 +43,5 @@ The service is provided by the In App Purchase Odoo platform.
         'static/src/components/message/message.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/snailmail/__manifest__.py
+++ b/addons/snailmail/__manifest__.py
@@ -29,5 +29,5 @@ Allows users to send documents by post
         'static/src/components/snailmail_error_dialog/snailmail_error_dialog.xml',
         'static/src/components/snailmail_notification_popover/snailmail_notification_popover.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
Mark `iap` module and dependencies as not auto-installable

Forward port of https://github.com/OCA/OCB/pull/868
 
@Tecnativa
TT28423

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
