### PR TITLE
14.0 ocb mail ignore aliases for other domains

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -889,6 +889,7 @@ class MailThread(models.AbstractModel):
             raise TypeError('message must be an email.message.EmailMessage at this point')
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.alias")
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
+        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -909,12 +910,14 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
         # for all the odd MTAs out there, as there is no standard header for the envelope's `rcpt_to` value.
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(message_dict['recipients'])
+            if not alias_domain or e.endswith('@%s' % alias_domain)
         ]
         rcpt_tos_valid_localparts = [to for to in rcpt_tos_localparts]
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -891,7 +891,7 @@ class MailThread(models.AbstractModel):
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
         # activate strict alias domain check for stable, will be falsy by default to be backward compatible
-        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
+        alias_domain_check = tools.str2bool(self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict", "False"))
         fallback_model = model
 
         # get email.message.Message variables for future processing

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -890,6 +890,8 @@ class MailThread(models.AbstractModel):
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.alias")
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param("mail.bounce.alias")
         alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        # activate strict alias domain check for stable, will be falsy by default to be backward compatible
+        alias_domain_check = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain.strict")
         fallback_model = model
 
         # get email.message.Message variables for future processing
@@ -910,14 +912,14 @@ class MailThread(models.AbstractModel):
         email_to_localparts = [
             e.split('@', 1)[0].lower()
             for e in (tools.email_split(email_to) or [''])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
         # for all the odd MTAs out there, as there is no standard header for the envelope's `rcpt_to` value.
         rcpt_tos_localparts = [
             e.split('@')[0].lower()
             for e in tools.email_split(message_dict['recipients'])
-            if not alias_domain or e.endswith('@%s' % alias_domain)
+            if not alias_domain_check or (not alias_domain or e.endswith('@%s' % alias_domain))
         ]
         rcpt_tos_valid_localparts = [to for to in rcpt_tos_localparts]
 

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -13,6 +13,7 @@ class MailTestSimple(models.Model):
 
     name = fields.Char()
     email_from = fields.Char()
+    message_bounce = fields.Integer(default=0)
 
 
 class MailTestGateway(models.Model):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -439,6 +439,52 @@ class TestMailgateway(TestMailCommon):
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record.message_ids), 1)
 
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_received_bounce(self):
+        """Incoming bounce is properly processed."""
+        self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+
+        # Test: No group created, incoming bounce is counted
+        self.assertEqual(self.test_record.message_bounce, 0, 'The bounced thread should have no bounced messages by default')
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+            to='valid.other@gmail.com, oops+{msg_id}-{model}-{res_id}@example.com'.format(
+                msg_id=self.fake_email.id,
+                model=self.fake_email.model,
+                res_id=self.fake_email.res_id,
+            ),
+            subject='Your email bounced, be more careful next time plea se',
+        )
+        self.assertFalse(new_groups)
+        self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
+        self.assertEqual(self.test_record.message_bounce, 1, 'The bounced thread should have 1 bounced message')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_received_bounce_no_domain_confusion(self):
+        """Incoming bounce-like mails are not confused when in alien domains."""
+        self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        # A partner with an address that seems like our bounce address
+        alien_bounce_partner = self.env["res.partner"].create({
+            "name": "Alien bounce address",
+            "email": 'oops+{msg_id}-{model}-{res_id}@alien.com'.format(
+                msg_id=self.fake_email.id,
+                model=self.fake_email.model,
+                res_id=self.fake_email.res_id,
+            ),
+        })
+        # Test: group created, bounce-similar email is treated as a normal address
+        new_groups = self.format_and_process(
+            MAIL_TEMPLATE,
+            email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+            to=alien_bounce_partner.email + ', groups@example.com',
+        )
+        self.assertEqual(new_groups.message_ids[0].author_id, self.partner_1, 'message_process: recognized email -> author_id')
+        self.assertIn('Valid Lelitre <valid.lelitre@agrolait.com>', new_groups.message_ids[0].email_from, 'message_process: recognized email -> email_from')
+        self.assertEqual(new_groups.message_ids.partner_ids, alien_bounce_partner, 'message_process: alien bounce-like address should be subscribed as a normal partner')
+
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
     def test_message_process_alias_partners_bounce(self):
         """ Incoming email from an unknown partner on a Partners only alias -> bounce + test bounce email """
@@ -1095,6 +1141,17 @@ class TestMailgateway(TestMailCommon):
                           self.format_and_process,
                           MAIL_TEMPLATE, self.email_from, 'noone@test.com',
                           subject='spam', extra='')
+
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
+    def test_message_process_crash_alien_domain_same_alias(self):
+        """Incoming email to the same address in an alien domain must raise."""
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        with self.assertRaises(ValueError):
+            self.format_and_process(
+                MAIL_TEMPLATE,
+                email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
+                to='groups@alien.com, other@gmail.com',
+            )
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_fallback(self):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1148,6 +1148,7 @@ class TestMailgateway(TestMailCommon):
     def test_message_process_crash_alien_domain_same_alias(self):
         """Incoming email to the same address in an alien domain must raise."""
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
         with self.assertRaises(ValueError):
             self.format_and_process(
                 MAIL_TEMPLATE,

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -444,6 +444,7 @@ class TestMailgateway(TestMailCommon):
         """Incoming bounce is properly processed."""
         self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
 
         # Test: No group created, incoming bounce is counted
         self.assertEqual(self.test_record.message_bounce, 0, 'The bounced thread should have no bounced messages by default')
@@ -466,6 +467,7 @@ class TestMailgateway(TestMailCommon):
         """Incoming bounce-like mails are not confused when in alien domains."""
         self.env['ir.config_parameter'].set_param('mail.bounce.alias', 'oops')
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'example.com')
+        self.env['ir.config_parameter'].set_param('mail.catchall.domain.strict', True)
         # A partner with an address that seems like our bounce address
         alien_bounce_partner = self.env["res.partner"].create({
             "name": "Alien bounce address",


### PR DESCRIPTION
Forward port of #944 to v14.

Hopefully something not needed in v15 if https://github.com/odoo/odoo/pull/65094 lands timely.

@Tecnativa TT22715 TT28423