### PR TITLE
[13.0] Backport expiration cron from version 14.0

### DIFF
--- a/addons/sale_coupon/__manifest__.py
+++ b/addons/sale_coupon/__manifest__.py
@@ -17,6 +17,7 @@
         'views/res_config_settings_views.xml',
         'report/sale_coupon_report.xml',
         'report/sale_coupon_report_templates.xml',
+        'data/ir_cron_data.xml',
         'data/sale_coupon_email_data.xml',
     ],
     'demo': [

--- a/addons/sale_coupon/data/ir_cron_data.xml
+++ b/addons/sale_coupon/data/ir_cron_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<odoo noupdate="1">
+    <record id="expire_coupon_cron" model="ir.cron">
+        <field name="name">Coupon: expire coupon based on date</field>
+        <field name="model_id" ref="sale_coupon.model_sale_coupon"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_expire_coupon()</field>
+        <field name="active" eval="True"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+    </record>
+</odoo>

--- a/addons/sale_coupon/models/sale_coupon.py
+++ b/addons/sale_coupon/models/sale_coupon.py
@@ -108,3 +108,14 @@ class SaleCoupon(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+    def cron_expire_coupon(self):
+        self._cr.execute("""
+            SELECT C.id FROM SALE_COUPON as C
+            INNER JOIN SALE_COUPON_PROGRAM as P ON C.program_id = P.id
+            WHERE C.STATE in ('reserved', 'new')
+                AND P.validity_duration > 0
+                AND C.create_date + interval '1 day' * P.validity_duration < now()""")
+
+        expired_ids = [res[0] for res in self._cr.fetchall()]
+        self.browse(expired_ids).write({'state': 'expired'})


### PR DESCRIPTION
Related PR on odoo/odoo: https://github.com/odoo/odoo/pull/66135

_**Description of the issue/feature this PR addresses:**_

Backport the `sale.coupon` expiration cron existing in version 14.0, but not in version 13.0:
* https://github.com/odoo/odoo/blob/14.0/addons/coupon/models/coupon.py#L83-L92
* https://github.com/odoo/odoo/blob/14.0/addons/coupon/data/coupon_email_data.xml#L104-L114

_**Current behavior before PR:**_

Expired sale coupons (by expiration date) keep the `Reserved/Valid` status even if the expiration date is lower than today.

_**Desired behavior after PR is merged:**_

When the cron is executed, expired sale coupons (by expiration date) take automatically the `Expired` status.