### PR TITLE
[14.0][FIX] base: res_users.has_group inheritance

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -225,7 +225,7 @@ class Groups(models.Model):
         # DLE P139
         if self.ids:
             self.env['ir.model.access'].call_cache_clearing_methods()
-            self.env['res.users'].has_group.clear_cache(self.env['res.users'])
+            self.env['res.users']._has_group.clear_cache(self.env['res.users'])
         return super(Groups, self).write(vals)
 
 
@@ -826,8 +826,6 @@ class Users(models.Model):
                             (SELECT res_id FROM ir_model_data WHERE module=%s AND name=%s)""",
                          (self._uid, module, ext_id))
         return bool(self._cr.fetchone())
-    # for a few places explicitly clearing the has_group cache
-    has_group.clear_cache = _has_group.clear_cache
 
     def action_show_groups(self):
         self.ensure_one()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Issue has been report here: https://github.com/odoo/odoo/issues/68106
upstream PR is there: https://github.com/odoo/odoo/pull/68111 

tl;dr I wasn't able to write the following code on my module without errors:
```python
from odoo import api, models

class Users(models.Model):
    _inherit = "res.users"

    @api.model
    def has_group(self, group_ext_id):
        return super(Users, self).has_group(group_ext_id)
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
