### PR TITLE
[8.0][BCP] Increase timeout of sending POS orders to server to prevent Odoo hangups

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -598,7 +598,7 @@ function openerp_pos_models(instance, module){ //module is instance.point_of_sal
             options = options || {};
 
             var self = this;
-            var timeout = typeof options.timeout === 'number' ? options.timeout : 7500 * orders.length;
+            var timeout = typeof options.timeout === 'number' ? options.timeout : 30000 * orders.length;
 
             // we try to send the order. shadow prevents a spinner if it takes too long. (unless we are sending an invoice,
             // then we want to notify the user that we are waiting on something )


### PR DESCRIPTION
Backport of [this commit](https://github.com/odoo/odoo/commit/56f2a70346fce521aacc1999fae26fe43f51b951) merged in [this PR](https://github.com/odoo/odoo/pull/44600)

-------------------

When an order is synchronized to the server, there is a timeout of 7.5
seconds that is left before considering that the order has not been
synchronized, and should be re-syncronised.

Since syncronization of order in pos_restaurant have been made, there
are more operations than before that are performed, and the
synchronization of an order can take more than that.

The validation of a picking can also take a lot of time, almost when
products are kits and compose of multiple products.

The problem, is that if it takes more than 7.5, the same order will be
pushed again to the server, even if the previous sychro still running,
which will lead to wait the previous request that has the lok on the
same records, all this blocked request can lead to block all workers of
the server because all requests are trying to modify same objects.

So we've increased the timout for flushed orders.

closes odoo/odoo#44615

X-original-commit: 9452c3f873c86a4c8502695720be942a76d4d25d
Signed-off-by: Olivier Dony (odo) <odo@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
