### PR TITLE
[FIX] mod_wsgi support

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -138,7 +138,10 @@ def init_logger():
     # which has no fileno() method. (mod_wsgi.Log is what is being bound to
     # sys.stderr when the logging.StreamHandler is being constructed above.)
     def is_a_tty(stream):
-        return hasattr(stream, 'fileno') and os.isatty(stream.fileno())
+        try:
+            return hasattr(stream, 'fileno') and os.isatty(stream.fileno())
+        except OSError:
+            return False
 
     if os.name == 'posix' and isinstance(handler, logging.StreamHandler) and is_a_tty(handler.stream):
         formatter = ColoredFormatter(format)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Mod_wsgi now adds `fileno()`: https://github.com/GrahamDumpleton/mod_wsgi/issues/85

Current behavior before PR:

When using Apache/mod_wsgi with Odoo it gives an error of `OSError: Apache/mod_wsgi log object is not associated with a file descriptor.`

Desired behavior after PR is merged:

Mod/wsgi can be used.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
