### PR TITLE
[FIX] stock: impossible to merge quants with different in_date

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -323,15 +323,17 @@ class StockQuant(models.Model):
                             SELECT min(id) as to_update_quant_id,
                                 (array_agg(id ORDER BY id))[2:array_length(array_agg(id), 1)] as to_delete_quant_ids,
                                 SUM(reserved_quantity) as reserved_quantity,
-                                SUM(quantity) as quantity
+                                SUM(quantity) as quantity,
+                                MIN(in_date) as in_date
                             FROM stock_quant
-                            GROUP BY product_id, company_id, location_id, lot_id, package_id, owner_id, in_date
+                            GROUP BY product_id, company_id, location_id, lot_id, package_id, owner_id
                             HAVING count(id) > 1
                         ),
                         _up AS (
                             UPDATE stock_quant q
                                 SET quantity = d.quantity,
-                                    reserved_quantity = d.reserved_quantity
+                                    reserved_quantity = d.reserved_quantity,
+                                    in_date = d.in_date
                             FROM dupes d
                             WHERE d.to_update_quant_id = q.id
                         )


### PR DESCRIPTION
This is a backport of odoo@5e08aa3 improving the `_merge_quants` method so it behaves correctly in some cases where the quants dates differ.

We think this should be the expected behavior of the method, although in the change discussion (#57224) it was decided to introduce it only in v15 (currently `master`)

So the discussion is open on whether or not this should be applied on OCB.

cc @Tecnativa


Original commit message:

> _When there are no conflict the same quant is used, even of in_date is different.
> During _update_available_quantity https://github.com/odoo/odoo/blob/12.0/addons/stock/models/stock_quant.py#L209, Odoo use an existing quants without worring in_date (and use min()). Indeed During _gather in_date is not used to find quant (only used to use in ORDER BY) https://github.com/odoo/odoo/blob/12.0/addons/stock/models/stock_quant.py#L111.__
> 
> _It sould be logical to don't group by in_date during merge quants._
> 
> _Have two quants with same product_id, location_id, company_id, lot_id, package_id, owner_id but with different in_date.
> Try to merge quants
> --> issue quants is not merge_


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
