### PR TITLE
[FIX] No dirty website_description

### DIFF
--- a/addons/website_quote/views/sale_order_views.xml
+++ b/addons/website_quote/views/sale_order_views.xml
@@ -44,7 +44,7 @@
             </xpath>
             <xpath expr="//field[@name='client_order_ref']" position="after">
                 <field name="require_payment" widget="radio"/>
-                <field name="website_description" invisible="1"/>
+                <field name="website_description" readonly="1" invisible="1"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_quote/views/sale_order_views.xml
+++ b/addons/website_quote/views/sale_order_views.xml
@@ -30,7 +30,7 @@
                                 <field name="price_unit"/>
                                 <field name="discount" groups="sale.group_discount_per_so_line"/>
                                 <button name="button_add_to_order" class="oe_link" icon="fa-shopping-cart" string="Add to order lines" type="object"/>
-                                <field name="website_description" invisible="1"/>
+                                <field name="website_description" readonly="1" invisible="1"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When using OCA sale_tier_validation the validate button cannot be clicked because website_description field is dirty and has to be saved first, but sale_tier_validation does not allow this so its stuck

Current behavior before PR:

It cannot be clicked

Desired behavior after PR is merged:

It can be clicked




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
