### PR TITLE
[FIX] point_of_sale: fix fp mapping.

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1559,7 +1559,7 @@ exports.Orderline = Backbone.Model.extend({
             var self = this;
             _(taxes).each(function(tax) {
                 var line_taxes = self._map_tax_fiscal_position(tax);
-                if(tax.price_include && _.contains(line_taxes, tax)){
+                if(tax.price_include && !_.contains(line_taxes, tax)){
                     mapped_included_taxes.push(tax);
                 }
             });


### PR DESCRIPTION
089deba6e49 aligned the behaviour of the the point_of_sale module with
that of the backend but broke the tax mapping when using taxes
included in the price. This commit fixes the issue.

Fixes issue #1020.
