### PR TITLE
[13.0][FIX] test_mail: correct forward port of some tests

### DIFF
--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -304,7 +304,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
         # Test: No group created, incoming bounce is counted
         self.assertEqual(self.test_record.message_bounce, 0, 'The bounced thread should have no bounced messages by default')
         new_groups = self.format_and_process(
-            MAIL_TEMPLATE,
+            test_mail_data.MAIL_BOUNCE,
             email_from='Valid Lelitre <valid.lelitre@agrolait.com>',
             to='valid.other@gmail.com, oops+{msg_id}-{model}-{res_id}@example.com'.format(
                 msg_id=self.fake_email.id,
@@ -312,9 +312,11 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
                 res_id=self.fake_email.res_id,
             ),
             subject='Your email bounced, be more careful next time plea se',
+            extra=self.fake_email.message_id,
         )
         self.assertFalse(new_groups)
         self.assertEqual(len(self._mails), 0, 'message_process: incoming bounce produces no mails')
+        self.assertEqual(self.partner_1.message_bounce, 1, 'The bounced partner should have 1 bounced message')
         self.assertEqual(self.test_record.message_bounce, 1, 'The bounced thread should have 1 bounced message')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
@@ -339,7 +341,7 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
             to=alien_bounce_partner.email + ', groups@example.com',
         )
         self.assertEqual(new_groups.message_ids[0].author_id, self.partner_1, 'message_process: recognized email -> author_id')
-        self.assertIn('Valid Lelitre <valid.lelitre@agrolait.com>', new_groups.message_ids[0].email_from, 'message_process: recognized email -> email_from')
+        self.assertIn('"Valid Lelitre" <valid.lelitre@agrolait.com>', new_groups.message_ids[0].email_from, 'message_process: recognized email -> email_from')
         self.assertEqual(new_groups.message_ids.partner_ids, alien_bounce_partner, 'message_process: alien bounce-like address should be subscribed as a normal partner')
 
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
Fix the bad forward port of https://github.com/OCA/OCB/pull/944.

 - test_message_process_received_bounce test is adapted to https://github.com/odoo/odoo/commit/f4524f03c32a27b1899562a71cad6f491bfe44ce, which tests bounds with another template used for bounces.

- test_message_process_received_bounce_no_domain_confusion is adapted to https://github.com/odoo/odoo/pull/40298, which add format to headers.

I have tested it in local.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr