### PR TITLE
[FIX]sale: fixes bug that creates more than one invoice per customer …

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -678,6 +678,7 @@ class SaleOrder(models.Model):
         if not grouped:
             new_invoice_vals_list = []
             invoice_grouping_keys = self._get_invoice_grouping_keys()
+            invoice_vals_list = sorted(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys])
             for grouping_keys, invoices in groupby(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys]):
                 origins = set()
                 payment_refs = set()


### PR DESCRIPTION
Impacted versions:
 
 - 13.0

When we select several orders to be invoiced in the tree view and they are unsorted, if we launch the create invoices action, as many invoices as there are customer groups are created.

if we have customer 1, 2 and 3 and the following orders:

order 1 customer 1
order 2 customer 1
order 3 customer 2
order 4 customer 2
order 5 customer 1
order 6 customer 1
order 7 customer 2
order 8 customer 3

5 invoices are created,
invoice 1 orders 1 and 2 customer 1
invoice 2 orders 3 and 4 customer 2
invoice 3 orders 5 and 6 customer 1
invoice 4 orders 7 customer 2
invoice 5 orders 8 customer 3

when it should be:
invoice 1 orders 1, 2, 5 and 6 customer 1
invoice 2 orders 3, 4 and 7 customer 2
invoice 3 order 8 customer 3

this is because the python groupby requires a previous sorted.

I add sorted following the same criteria and their grouping order



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
