### PR TITLE
[12.0][FIX] fields: avoid dropping indexes

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1003,7 +1003,7 @@ class Field(MetaField('DummyField', (object,), {})):
             except psycopg2.OperationalError:
                 _schema.error("Unable to add index for %s", self)
         else:
-            sql.drop_index(model._cr, indexname, model._table)
+            _schema.info("Keep unexpected index %s on table %s", indexname, model._table)
 
     def update_db_related(self, model):
         """ Compute a stored related field directly in SQL. """


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When an index has name 'tablename_fieldname_index', this index is
dropped if the field has index=False.  This lead to dropping a
user-created index or dropping/recreating the index when index=True is
set in a dependent module.  Some info is logged instead.

**Current behavior before PR:**

When updating some modules containing a lot of indexes, odoo will always drop and recreate them. This is really time consuming

**Desired behavior after PR is merged:**

Log an info instead as done in -> https://github.com/odoo/odoo/pull/66700/files

OPW 2530258

NB: I'm quite sure that odoo will not take this in account given the answer on the OPW. It would be great to have it included as it will make us gain time.
```
I will nevertheless transfer your request to the bug resolution team, they will decide whether to back port the fix in V.12. 
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
