### PR TITLE
[FIX][14.0] account move section/line with tax ignored

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1615,8 +1615,8 @@ class AccountMove(models.Model):
             lang_env = move.with_context(lang=move.partner_id.lang).env
             balance_multiplicator = -1 if move.is_inbound() else 1
 
-            tax_lines = move.line_ids.filtered('tax_line_id')
-            base_lines = move.line_ids.filtered('tax_ids')
+            tax_lines = move.line_ids.filtered(lambda r: r.tax_line_id and not r.display_type)
+            base_lines = move.line_ids.filtered(lambda r: r.tax_ids and not r.display_type)
 
             tax_group_mapping = defaultdict(lambda: {
                 'base_lines': set(),


### PR DESCRIPTION

## Description of the issue/feature this PR addresses:

Do not display VAT details for section/line note in account invoice (report)

## Current behavior before PR:

Somehow accounting user have created account invoice with section/note lines
that contains VAT. Probably generated from sale order and may have default values...

Then account manager discover that was the wrong tax and changed it before posted the invoice

In VAT details the old VAT was still present due to the section line related to the old
VAT that the account manager couldn't change in the UI.

## Desired behavior after PR is merged:

This suggest to ignore account move lines with display_type defined while
computing amount_by_group to display useful VAT group in account invoice.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
