### PR TITLE
[BCP][11.0] [FIX] stock: merge quants when unpacking

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -486,6 +486,11 @@ class QuantPackage(models.Model):
                 move_line_to_modify.write({'package_id': False})
                 package.mapped('quant_ids').sudo().write({'package_id': False})
 
+        # Quant clean-up, mostly to avoid multiple quants of the same product. For example, unpack
+        # 2 packages of 50, then reserve 100 => a quant of -50 is created at transfer validation.
+        self.env['stock.quant']._merge_quants()
+        self.env['stock.quant']._unlink_zero_quants()
+
     def action_view_picking(self):
         action = self.env.ref('stock.action_picking_tree_all').read()[0]
         domain = ['|', ('result_package_id', 'in', self.ids), ('package_id', 'in', self.ids)]


### PR DESCRIPTION
Backport to 11.0 of the fix for this: 

https://github.com/odoo/odoo/issues/53535