### PR TITLE
[12.0] python 3.9 compatibility

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -92,6 +92,8 @@ _EXPR_OPCODES = _CONST_OPCODES.union(set(opmap[x] for x in [
     # specialised comparisons
     'CONTAINS_OP',
     'DICT_MERGE',
+    # py39
+    'IS_OP',
 ] if x in opmap))
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(set(opmap[x] for x in [

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -93,7 +93,7 @@ _EXPR_OPCODES = _CONST_OPCODES.union(set(opmap[x] for x in [
     'CONTAINS_OP',
     'DICT_MERGE',
     # py39
-    'IS_OP',
+    'IS_OP', 'DICT_MERGE', 'SET_UPDATE', 'DICT_UPDATE',
 ] if x in opmap))
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(set(opmap[x] for x in [


### PR DESCRIPTION
This is a continuation of https://github.com/odoo/odoo/pull/71437 for OCB as it's been rejected in upstream.

- ``base64.decodestring`` has been [deprecated in 3.1](https://docs.python.org/3.7/library/base64.html#base64.decodestring)
- ``xml.etree.ElementTree.Element.getchildren`` has been [deprecated in 3.2](https://docs.python.org/3.7/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren)

This should apply to v13, v14 too. Note that this is not the end of the story as there might be deprecated python code in any other module involved.