### PR TITLE
[12.0][FIX] purchase email template for RFQ with wrong subject ORDER

### DIFF
--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -4,7 +4,7 @@
         <record id="email_template_edi_purchase" model="mail.template">
             <field name="name">Purchase Order: Send RFQ</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
-            <field name="subject">${object.company_id.name} Order (Ref ${object.name or 'n/a' })</field>
+            <field name="subject">${object.company_id.name} RFQ (Ref ${object.name or 'n/a' })</field>
             <field name="partner_to">${object.partner_id.id}</field>
             <field name="body_html" type="html">
 <div style="margin: 0px; padding: 0px;">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: email template for RFQ has subject ORDER, misleading the user/recipient

Current behavior before PR: mail for RFQ to seller are sent with subject <company name> Order Ref <order name>

Desired behavior after PR is merged: mail for RFQ are sent with subject <company name> RFQ Ref <order name>




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr