### PR TITLE
[12.0][FIX] Wrong number formatting for dutch language.

### DIFF
--- a/odoo/addons/base/data/res.lang.csv
+++ b/odoo/addons/base/data/res.lang.csv
@@ -15,7 +15,7 @@
 "base.lang_cs_CZ","Czech / Čeština","cs_CZ","cs_CZ","Left-to-Right","[3,0]",","," ","%d.%m.%Y","%H:%M:%S","True","1"
 "base.lang_da_DK","Danish / Dansk","da_DK","da_DK","Left-to-Right","[3,0]",",",".","%d-%m-%Y","%H:%M:%S","True","1"
 "base.lang_nl_BE","Dutch (BE) / Nederlands (BE)","nl_BE","nl_BE","Left-to-Right","[3,0]",",",".","%d-%m-%Y","%H:%M:%S","True","1"
-"base.lang_nl","Dutch / Nederlands","nl_NL","nl","Left-to-Right","[]",",",,"%d-%m-%Y","%H:%M:%S","True","1"
+"base.lang_nl","Dutch / Nederlands","nl_NL","nl","Left-to-Right","[3,0]",",",".","%d-%m-%Y","%H:%M:%S","True","1"
 "base.lang_en_AU","English (AU)","en_AU","en_AU","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","True","7"
 "base.lang_en_CA","English (CA)","en_CA","en_CA","Left-to-Right","[3,0]",".",",","%Y-%m-%d","%H:%M:%S","True","7"
 "base.lang_en_GB","English (UK)","en_GB","en_GB","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","True","7"


### PR DESCRIPTION
The correct settings are already in 13.0 and upwards, and also in the Belgian locale.

Description of the issue/feature this PR addresses:

Settings for formatting numbers in dutch local are missing thousands separator and grouping parameter.

Current behavior before PR:

Numbers are shown in the wrong way. Even if correcting language, this will be overwritten on update.

Desired behavior after PR is merged:

Numbers are shown correctly for dutch language.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
