### PR TITLE
[10.0][FIX] web: chrome 89 event delegation

### DIFF
--- a/addons/web/static/lib/jquery/jquery.js
+++ b/addons/web/static/lib/jquery/jquery.js
@@ -4667,7 +4667,8 @@ jQuery.event = {
                 // Find delegate handlers
                 // Black-hole SVG <use> instance trees (#13180)
                 // Avoid non-left-click bubbling in Firefox (#3861)
-                if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
+                if ( delegateCount && cur.nodeType &&
+                        ( event.type !== "click" || isNaN( event.button ) || event.button < 1 ) ) {
 
                         /* jshint eqeqeq: false */
                         for ( ; cur != this; cur = cur.parentNode || this ) {


### PR DESCRIPTION
In windows chrome 89 (seemed ok at version 89.0.4389.90 (13 march 2021)
and broken at version 89.0.4389.114 (29 march 2021)), clicking on a
select option doesn't trigger jQuery events if they are delegated.

For example this happen when selecting a field for custom group or
custom filter in the search view and when selecting a field the dropdown
closes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
