### PR TITLE
[FIX] stock : full inventory should also propose disabled product if quantity are not null

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -236,7 +236,7 @@ class Inventory(models.Model):
     def _get_inventory_lines_values(self):
         # TDE CLEANME: is sql really necessary ? I don't think so
         locations = self.env['stock.location'].search([('id', 'child_of', [self.location_id.id])])
-        domain = ' sq.location_id in %s AND sq.quantity != 0 AND pp.active'
+        domain = ' sq.location_id in %s AND sq.quantity != 0'
         args = (tuple(locations.ids),)
 
         vals = []


### PR DESCRIPTION
**Current behavior before PR:**

* create a product ;
* make out moves to have negative quantity;
* archive the product ;
* make a full inventory ;
* the inventory doesn't contains (propose) the disabled product
* confirm the inventory

If the user enable the product, the quantity will be bad.

**Desired behavior after PR is merged:**

The product is proposed in the inventory, so the quantity is correct, if the product is enabled again.


Note : if merged, the current module could be proposed to the OCA : 
https://github.com/grap/grap-odoo-incubator/pull/131

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
