### PR TITLE
[14.0] sale: on change sale order line price unit do not round before compute new price

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -9,8 +9,7 @@ from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.misc import formatLang, get_lang
 from odoo.osv import expression
-from odoo.tools import float_is_zero, float_compare
-
+from odoo.tools import float_is_zero, float_compare, float_round
 
 
 from werkzeug.urls import url_encode
@@ -1878,6 +1877,13 @@ class SaleOrderLine(models.Model):
 
     def _onchange_product_id_set_customer_lead(self):
         pass
+
+    @api.onchange('price_unit')
+    def _onchange_price_unit(self):
+        self.price_unit = float_round(
+            self.price_unit,
+            precision_digits=self.env['decimal.precision'].precision_get('Product Price')
+        )
 
     @api.onchange('product_id', 'price_unit', 'product_uom', 'product_uom_qty', 'tax_id')
     def _onchange_discount(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -753,6 +753,7 @@ class TestSaleOrder(TestSaleCommon):
         with order_form.order_line.edit(1) as line:
             line.product_uom_qty = 9999.9999
             line.price_unit = 0.33333
+            self.assertEqual(line.price_unit, 0.33)
         amount_untaxed_before_save = order_form.amount_untaxed
         order_form.save()
         self.assertEqual(amount_untaxed_before_save, self.sale_order.amount_untaxed)

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -747,3 +747,12 @@ class TestSaleOrder(TestSaleCommon):
         })
         so_no_analytic_account.action_confirm()
         self.assertFalse(sol_no_analytic_account.analytic_tag_ids.id, "The compute should not overwrite what the user has set.")
+
+    def test_onchange_price_unit(self):
+        order_form = Form(self.sale_order)
+        with order_form.order_line.edit(1) as line:
+            line.product_uom_qty = 9999.9999
+            line.price_unit = 0.33333
+        amount_untaxed_before_save = order_form.amount_untaxed
+        order_form.save()
+        self.assertEqual(amount_untaxed_before_save, self.sale_order.amount_untaxed)


### PR DESCRIPTION
upstream PR: https://github.com/odoo/odoo/pull/81530

# Description of the issue/feature this PR addresses:

On change price unit do not round the unit price before compute new price, while after saving the unit price is rounded this make inconsistency price in the mean time when users try to set unit price with greater significant digits than configured.

That frustrate end user that do not understand why the price is not the same before and after saving. This is specially true while using formula in price unit cell trying to get round price.

This happen in domains where price are used to given in a small unit of measure with 4 or 5 significant digits with huge quantities.

# Current behavior before PR:

test only on version 14.0: 

- on a sale order line set new unit price with more significant digits than allowed for price (in the video 382.23 -> 382.2333)
- have a look to the line price (7644.67)
- save the order and have a look to the line price changed (7644.60)  

# Desired behavior after PR is merged:

https://user-images.githubusercontent.com/4328507/146388091-2b27af57-e77d-475c-8422-dd7e018276c6.mp4

On a sale order line setting a new unit price with more significant digits than allowed should:
 - round the unit price
 - recompute the line amount with the rounded unit price
 - ensure that sale order price display before and after saving that change should remain the same




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
# Description of the issue/feature this PR addresses:

On change price unit do not round the unit price before compute new price, while after saving the unit price is rounded this make inconsistency price in the mean time when users try to set unit price with greater significant digits than configured.

That frustrate end user that do not understand why the price is not the same before and after saving. This is specially true while using formula in price unit cell trying to get round price.

This happen in domains where price are used to given in a small unit of measure with 4 or 5 significant digits with huge quantities.

# Current behavior before PR:

test only on version 14.0: 

- on a sale order line set new unit price with more significant digits than allowed for price (in the video 382.23 -> 382.2333)
- have a look to the line price (7644.67)
- save the order and have a look to the line price changed (7644.60)  

# Desired behavior after PR is merged:

https://user-images.githubusercontent.com/4328507/146388091-2b27af57-e77d-475c-8422-dd7e018276c6.mp4

On a sale order line setting a new unit price with more significant digits than allowed should:
 - round the unit price
 - recompute the line amount with the rounded unit price
 - ensure that sale order price display before and after saving that change should remain the same


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
