### PR TITLE
[BCP][11.0] [FIX] base: prevent messing up existing registry

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -104,6 +104,7 @@ class Registry(Mapping):
 
         registry.ready = True
         registry.registry_invalidated = bool(update_module)
+        registry.new = registry.init = registry.registries = None
 
         return registry
 


### PR DESCRIPTION
Backport of 04e4e70bcb822d169cdee4fc702640b10a3a75ad