### PR TITLE
[BCP][9.0] [FIX] base: prevent messing up existing registry

### DIFF
--- a/openerp/modules/registry.py
+++ b/openerp/modules/registry.py
@@ -404,6 +404,7 @@ class RegistryManager(object):
                     cr.close()
 
         registry.ready = True
+        registry.new = registry.init = registry.registries = None
 
         if update_module:
             # only in case of update, otherwise we'll have an infinite reload loop!


### PR DESCRIPTION
Backport of c70e9d10cfa.

NOTE: the original change is not compatible with v < 10.0
hence I did a manual change and forced the original author.