### PR TITLE
[BCP][11.0] [FIX] web: expect explicit sign up parameters

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -5,7 +5,7 @@ import werkzeug
 
 from odoo import http, _
 from odoo.addons.auth_signup.models.res_users import SignupError
-from odoo.addons.web.controllers.main import ensure_db, Home
+from odoo.addons.web.controllers.main import ensure_db, Home, SIGN_UP_REQUEST_PARAMS
 from odoo.exceptions import UserError
 from odoo.http import request
 
@@ -100,7 +100,7 @@ class AuthSignupHome(Home):
 
     def get_auth_signup_qcontext(self):
         """ Shared helper returning the rendering context for signup and reset password """
-        qcontext = request.params.copy()
+        qcontext = {k: v for (k, v) in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         qcontext.update(self.get_auth_signup_config())
         if not qcontext.get('token') and request.session.get('auth_signup_token'):
             qcontext['token'] = request.session.get('auth_signup_token')

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -431,6 +431,11 @@ def binary_content(xmlid=None, model='ir.attachment', id=None, field='datas', un
         filename_field=filename_field, download=download, mimetype=mimetype,
         default_mimetype=default_mimetype, access_token=access_token, env=env)
 
+# Shared parameters for all login/signup flows
+SIGN_UP_REQUEST_PARAMS = {'db', 'login', 'debug', 'token', 'message', 'error', 'scope', 'mode',
+                          'redirect', 'redirect_hostname', 'email', 'name', 'partner_id',
+                          'password', 'confirm_password', 'city', 'country_id', 'lang'}
+
 #----------------------------------------------------------
 # Odoo Web web Controllers
 #----------------------------------------------------------
@@ -476,7 +481,7 @@ class Home(http.Controller):
         if not request.uid:
             request.uid = odoo.SUPERUSER_ID
 
-        values = request.params.copy()
+        values = {k: v for k, v in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         try:
             values['databases'] = http.db_list()
         except odoo.exceptions.AccessDenied:


### PR DESCRIPTION
Using an explicit list of sign up parameters will avoid
polluting the context with unrelated values, and make
debugging easier.

Backport of https://github.com/OCA/OCB/commit/330ff5b1ff4de4b6c9a874db30c304b04e3f2b77
