### PR TITLE
[BCP][10.0] [FIX] web: expect explicit sign up parameters

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -5,7 +5,7 @@ import werkzeug
 
 from odoo import http, _
 from odoo.addons.auth_signup.models.res_users import SignupError
-from odoo.addons.web.controllers.main import ensure_db, Home
+from odoo.addons.web.controllers.main import ensure_db, Home, SIGN_UP_REQUEST_PARAMS
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class AuthSignupHome(Home):
 
     def get_auth_signup_qcontext(self):
         """ Shared helper returning the rendering context for signup and reset password """
-        qcontext = request.params.copy()
+        qcontext = {k: v for (k, v) in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         qcontext.update(self.get_auth_signup_config())
         if qcontext.get('token'):
             try:

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -425,6 +425,11 @@ def binary_content(xmlid=None, model='ir.attachment', id=None, field='datas', un
         xmlid=xmlid, model=model, id=id, field=field, unique=unique, filename=filename, filename_field=filename_field,
         download=download, mimetype=mimetype, default_mimetype=default_mimetype, env=env)
 
+# Shared parameters for all login/signup flows
+SIGN_UP_REQUEST_PARAMS = {'db', 'login', 'debug', 'token', 'message', 'error', 'scope', 'mode',
+                          'redirect', 'redirect_hostname', 'email', 'name', 'partner_id',
+                          'password', 'confirm_password', 'city', 'country_id', 'lang'}
+
 #----------------------------------------------------------
 # Odoo Web web Controllers
 #----------------------------------------------------------
@@ -463,7 +468,7 @@ class Home(http.Controller):
         if not request.uid:
             request.uid = odoo.SUPERUSER_ID
 
-        values = request.params.copy()
+        values = {k: v for k, v in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         try:
             values['databases'] = http.db_list()
         except odoo.exceptions.AccessDenied:


### PR DESCRIPTION
Using an explicit list of sign up parameters will avoid
polluting the context with unrelated values, and make
debugging easier.

Backport of https://github.com/OCA/OCB/commit/330ff5b1ff4de4b6c9a874db30c304b04e3f2b77
