### PR TITLE
[BCP][9.0] [FIX] web: expect explicit sign up parameters

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -5,7 +5,7 @@ import werkzeug
 
 import openerp
 from openerp.addons.auth_signup.res_users import SignupError
-from openerp.addons.web.controllers.main import ensure_db
+from openerp.addons.web.controllers.main import ensure_db, SIGN_UP_REQUEST_PARAMS
 from openerp import http
 from openerp.http import request
 from openerp.tools.translate import _
@@ -81,7 +81,7 @@ class AuthSignupHome(openerp.addons.web.controllers.main.Home):
 
     def get_auth_signup_qcontext(self):
         """ Shared helper returning the rendering context for signup and reset password """
-        qcontext = request.params.copy()
+        qcontext = {k: v for (k, v) in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         qcontext.update(self.get_auth_signup_config())
         if qcontext.get('token'):
             try:

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -432,6 +432,11 @@ def db_info():
         'server_version_info': version_info.get('server_version_info'),
     }
 
+# Shared parameters for all login/signup flows
+SIGN_UP_REQUEST_PARAMS = {'db', 'login', 'debug', 'token', 'message', 'error', 'scope', 'mode',
+                          'redirect', 'redirect_hostname', 'email', 'name', 'partner_id',
+                          'password', 'confirm_password', 'city', 'country_id', 'lang'}
+
 #----------------------------------------------------------
 # OpenERP Web web Controllers
 #----------------------------------------------------------
@@ -469,7 +474,7 @@ class Home(http.Controller):
         if not request.uid:
             request.uid = openerp.SUPERUSER_ID
 
-        values = request.params.copy()
+        values = {k: v for k, v in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
         values['mono_db'] = len(http.db_list(True, request.httprequest)) == 1
         try:
             values['databases'] = http.db_list()


### PR DESCRIPTION
Using an explicit list of sign up parameters will avoid
polluting the context with unrelated values, and make
debugging easier.

Backport of https://github.com/OCA/OCB/commit/330ff5b1ff4de4b6c9a874db30c304b04e3f2b77
