### PR TITLE
[BCP][7.0] [IMP] avoid cycle on request

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -749,7 +749,7 @@ class Proxy(openerpweb.Controller):
         from werkzeug.test import Client
         from werkzeug.wrappers import BaseResponse
 
-        return Client(req.httprequest.app, BaseResponse).get(path).data
+        return Client(http._root, BaseResponse).get(path).data
 
 class Database(openerpweb.Controller):
     _cp_path = "/web/database"

--- a/addons/web/http.py
+++ b/addons/web/http.py
@@ -511,6 +511,9 @@ class Root(object):
     """Root WSGI application for the OpenERP Web Client.
     """
     def __init__(self):
+        global _root
+        if _root is None:
+            _root = self
         self.addons = {}
         self.statics = {}
 
@@ -536,7 +539,6 @@ class Root(object):
         """
         request = werkzeug.wrappers.Request(environ)
         request.parameter_storage_class = werkzeug.datastructures.ImmutableDict
-        request.app = self
 
         handler = self.find_handler(*(request.path.split('/')[1:]))
 
@@ -626,5 +628,8 @@ class Root(object):
 
 def wsgi_postload():
     openerp.wsgi.register_wsgi_handler(Root())
+
+#  main wsgi handler
+_root = None
 
 # vim:et:ts=4:sw=4:


### PR DESCRIPTION
Backport of https://github.com/OCA/OCB/commit/1282375d55802696d3b464c9282ff2f211529824

The patch is not straightforward, because the WSGI root handler was registered differently in OpenERP 7 than in later Odoo releases.