### PR TITLE
[BCP][FIX] web: more reliably avoid downloads on new file

### DIFF
--- a/addons/web/static/src/js/views/form_widgets.js
+++ b/addons/web/static/src/js/views/form_widgets.js
@@ -1224,17 +1224,13 @@ var FieldBinaryFile = FieldBinary.extend({
         if (this.get("effective_readonly")) {
             // Filename from saved state (might render from a discard operation)
             filename = this.view.datarecord[this.node.attrs.filename]; // do not forward-port >= 11.0
-            this.do_toggle(!!this.get('value'));
-            if (this.get('value')) {
-                this.$el.empty().append($("<span/>").addClass('fa fa-download'));
-                if (this.view.datarecord.id) {
-                    this.$el.css('cursor', 'pointer');
-                } else {
-                    this.$el.css('cursor', 'not-allowed');
-                }
-                if (filename) {
-                    this.$el.append(" " + filename);
-                }
+            var visible = !!(this.value && this.res_id);
+            this.$el.empty().css('cursor', 'not-allowed');
+            this.do_toggle(visible);
+            if (visible) {
+                this.$el.empty().css('cursor', 'pointer')
+                                .text(this.filename_value || '')
+                                .prepend('<span class="fa fa-download"/>', ' ');
             }
         } else {
             // Filename at the moment (might be unsaved state)


### PR DESCRIPTION
Backport of https://github.com/OCA/OCB/commit/0eccd3973e056b4ac6fcd6754a8b6af2818aac4f

I couldn't apply the unit tests changes as the tests didn't exist in v10.


Commit content:

519555054a3a0e2e0b8a139518da081c4d5e80aa mitigated an issue of being
able to try and download files which don't exist yet, make the fix
more reliable by clearing out the field completely and hiding the
content if the (readonly) field has no value *or the record is not
saved yet*.

Also clean up the code:

* an old-style forward port created a duplicate fixprovement
  (a8d01cbf4ea88f894ff927a6a5424bbb58e630d0) which seems less correct
  as it applies conditionally
* and the code is branchier than necessary, we can make it simpler by
  judiciously leveraging jquery's API

closes odoo/odoo#77603

Signed-off-by: Xavier Morel (xmo) <xmo@odoo.com>


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
