### PR TITLE
[IMP] base: use file_open to filter assets

### DIFF
--- a/openerp/addons/base/ir/ir_qweb.py
+++ b/openerp/addons/base/ir/ir_qweb.py
@@ -13,6 +13,7 @@ import re
 import sys
 import textwrap
 import uuid
+from contextlib import closing
 from subprocess import Popen, PIPE
 from urlparse import urlparse
 
@@ -33,7 +34,7 @@ from openerp.http import request
 from openerp.tools.safe_eval import safe_eval as eval
 from openerp.osv import osv, orm, fields
 from openerp.tools import html_escape as escape
-from openerp.tools.misc import find_in_path
+from openerp.tools.misc import find_in_path, file_open
 from openerp.tools.translate import _
 from openerp.modules.module import get_resource_path
 
@@ -1544,7 +1545,7 @@ class WebAsset(object):
             if self._filename:
                 if not self._filename.lower().endswith(EXTENSIONS):
                     raise ValueError("Unsupported path: %s" % self._filename)
-                with open(self._filename, 'rb') as fp:
+                with closing(file_open(self._filename, 'rb')) as fp:
                     return fp.read().decode('utf-8')
             else:
                 return self._ir_attach['datas'].decode('base64')


### PR DESCRIPTION
Actually, I've missed half of the patch when I refactored : `file_open` is indeed an additional layer of security, it verifies that the asset is in Odoo directories (addons or root path), else it raises a ValueError.

Here the complement of #1088

@pedrobaeza 