### PR TITLE
[12.0] core/web: Fix graph view

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_model.js
+++ b/addons/web/static/src/js/views/graph/graph_model.js
@@ -155,8 +155,12 @@ return AbstractModel.extend({
                 fields = fields.concat(this.chart.measure);
             }
         }
-
-        var context = _.extend({fill_temporal: true}, this.chart.context);
+        var context = _.extend({
+            fill_temporal: this.chart.timeRange.length ? {
+                'fill_from': this.chart.timeRange[1][2],
+                'fill_to': this.chart.timeRange[2][2],
+            } : {}
+        }, this.chart.context);
         var defs = [];
         defs.push(this._rpc({
             model: this.modelName,
@@ -169,10 +173,16 @@ return AbstractModel.extend({
         }).then(this._processData.bind(this, 'data')));
 
         if (this.chart.compare) {
+            var context_compare = _.extend({
+                fill_temporal: this.chart.comparisonTimeRange.length ? {
+                    'fill_from': this.chart.comparisonTimeRange[1][2],
+                    'fill_to': this.chart.comparisonTimeRange[2][2],
+                } : {}
+            }, this.chart.context);
             defs.push(this._rpc({
                 model: this.modelName,
                 method: 'read_group',
-                context: context,
+                context: context_compare,
                 domain: this.chart.domain.concat(this.chart.comparisonTimeRange),
                 fields: fields,
                 groupBy: groupedBy,

--- a/odoo/addons/test_read_group/tests/test_fill_temporal.py
+++ b/odoo/addons/test_read_group/tests/test_fill_temporal.py
@@ -603,3 +603,244 @@ class TestFillTemporal(common.TransactionCase):
         groups = model_fill.read_group([], fields=['datetime', 'value'], groupby=['datetime'])
 
         self.assertEqual(groups, expected)
+
+    def test_with_bounds(self):
+        """Test the alternative dictionary format for the fill_temporal context key (fill_from, fill_to).
+
+        We apply the fill_temporal logic only to a cibled portion of the result of a read_group.
+        [fill_from, fill_to] are the inclusive bounds of this portion.
+        Data outside those bounds will not be filtered out
+        Bounds will be converted to the start of the period which they belong to (depending
+        on the granularity of the groupby). This means that we can put any date of the period as the bound
+        and it will still work.
+        """
+        self.Model.create({'date': '1916-02-15', 'value': 1})
+        self.Model.create({'date': '1916-06-15', 'value': 2})
+        self.Model.create({'date': '1916-11-15', 'value': 3})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-05-01'), ('date', '<', '1916-06-01')],
+            '__range': {'date': {'from': '1916-05-01', 'to': '1916-06-01'}},
+            'date': 'May 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-06-01'), ('date', '<', '1916-07-01')],
+            '__range': {'date': {'from': '1916-06-01', 'to': '1916-07-01'}},
+            'date': 'June 1916',
+            'date_count': 1,
+            'value': 2
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-07-01'), ('date', '<', '1916-08-01')],
+            '__range': {'date': {'from': '1916-07-01', 'to': '1916-08-01'}},
+            'date': 'July 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-08-01'), ('date', '<', '1916-09-01')],
+            '__range': {'date': {'from': '1916-08-01', 'to': '1916-09-01'}},
+            'date': 'August 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-11-01'), ('date', '<', '1916-12-01')],
+            '__range': {'date': {'from': '1916-11-01', 'to': '1916-12-01'}},
+            'date': 'November 1916',
+            'date_count': 1,
+            'value': 3
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={"fill_from": '1916-05-15', "fill_to": '1916-08-15'})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)
+
+    def test_upper_bound(self):
+        """Test the alternative dictionary format for the fill_temporal context key (fill_to).
+
+        Same as with both bounds, but this time the first bound is the earliest group with data
+        (since only fill_to is set)
+        """
+        self.Model.create({'date': '1916-02-15', 'value': 1})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-03-01'), ('date', '<', '1916-04-01')],
+            '__range': {'date': {'from': '1916-03-01', 'to': '1916-04-01'}},
+            'date': 'March 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-04-01'), ('date', '<', '1916-05-01')],
+            '__range': {'date': {'from': '1916-04-01', 'to': '1916-05-01'}},
+            'date': 'April 1916',
+            'date_count': 0,
+            'value': False
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={"fill_to": '1916-04-15'})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)
+
+    def test_lower_bound(self):
+        """Test the alternative dictionary format for the fill_temporal context key (fill_from).
+
+        Same as with both bounds, but this time the second bound is the lastest group with data
+        (since only fill_from is set)
+        """
+        self.Model.create({'date': '1916-04-15', 'value': 1})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-03-01'), ('date', '<', '1916-04-01')],
+            '__range': {'date': {'from': '1916-03-01', 'to': '1916-04-01'}},
+            'date': 'March 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-04-01'), ('date', '<', '1916-05-01')],
+            '__range': {'date': {'from': '1916-04-01', 'to': '1916-05-01'}},
+            'date': 'April 1916',
+            'date_count': 1,
+            'value': 1
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={"fill_from": '1916-02-15'})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)
+
+    def test_empty_context_key(self):
+        """Test the alternative dictionary format for the fill_temporal context key.
+
+        When fill_temporal context key is set to an empty dictionary, it must be equivalent to being True
+        """
+        self.Model.create({'date': '1916-02-15', 'value': 1})
+        self.Model.create({'date': '1916-04-15', 'value': 2})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-03-01'), ('date', '<', '1916-04-01')],
+            '__range': {'date': {'from': '1916-03-01', 'to': '1916-04-01'}},
+            'date': 'March 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-04-01'), ('date', '<', '1916-05-01')],
+            '__range': {'date': {'from': '1916-04-01', 'to': '1916-05-01'}},
+            'date': 'April 1916',
+            'date_count': 1,
+            'value': 2
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)
+
+    def test_min_groups(self):
+        """Test the alternative dictionary format for the fill_temporal context key (min_groups).
+
+        We guarantee that at least a certain amount of contiguous groups is returned, from the
+        earliest group with data.
+        """
+        self.Model.create({'date': '1916-02-15', 'value': 1})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-03-01'), ('date', '<', '1916-04-01')],
+            '__range': {'date': {'from': '1916-03-01', 'to': '1916-04-01'}},
+            'date': 'March 1916',
+            'date_count': 0,
+            'value': False
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={"min_groups": 2})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)
+
+    def test_with_bounds_and_min_groups(self):
+        """Test the alternative dictionary format for the fill_temporal context key (fill_from, fill_to, min_groups).
+
+        We guarantee that at least a certain amount of contiguous groups is returned, from the
+        fill_from bound. The fill_from bound has precedence over the first group with data regarding min_groups
+        (min_groups will first try to anchor itself on fill_from, or, if not specified, on the first group with data).
+        This amount is not restricted by the fill_to bound, so, if necessary, the fill_temporal
+        logic will be applied until min_groups is guaranteed, even for groups later than fill_to
+        Groups outside the specifed bounds are not counted as part of min_groups, unless added specifically
+        to guarantee min_groups.
+        """
+        self.Model.create({'date': '1916-02-15', 'value': 1})
+        self.Model.create({'date': '1916-06-15', 'value': 2})
+        self.Model.create({'date': '1916-11-15', 'value': 3})
+
+        expected = [{
+            '__domain': ['&', ('date', '>=', '1916-02-01'), ('date', '<', '1916-03-01')],
+            '__range': {'date': {'from': '1916-02-01', 'to': '1916-03-01'}},
+            'date': 'February 1916',
+            'date_count': 1,
+            'value': 1
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-05-01'), ('date', '<', '1916-06-01')],
+            '__range': {'date': {'from': '1916-05-01', 'to': '1916-06-01'}},
+            'date': 'May 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-06-01'), ('date', '<', '1916-07-01')],
+            '__range': {'date': {'from': '1916-06-01', 'to': '1916-07-01'}},
+            'date': 'June 1916',
+            'date_count': 1,
+            'value': 2
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-07-01'), ('date', '<', '1916-08-01')],
+            '__range': {'date': {'from': '1916-07-01', 'to': '1916-08-01'}},
+            'date': 'July 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-08-01'), ('date', '<', '1916-09-01')],
+            '__range': {'date': {'from': '1916-08-01', 'to': '1916-09-01'}},
+            'date': 'August 1916',
+            'date_count': 0,
+            'value': False
+        }, {
+            '__domain': ['&', ('date', '>=', '1916-11-01'), ('date', '<', '1916-12-01')],
+            '__range': {'date': {'from': '1916-11-01', 'to': '1916-12-01'}},
+            'date': 'November 1916',
+            'date_count': 1,
+            'value': 3
+        }]
+
+        model_fill = self.Model.with_context(fill_temporal={"fill_from": '1916-05-15', "fill_to": '1916-07-15', "min_groups": 4})
+        groups = model_fill.read_group([], fields=['date', 'value'], groupby=['date'])
+
+        self.assertEqual(groups, expected)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1807,33 +1807,73 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
     @api.model
     def _read_group_fill_temporal(self, data, groupby, aggregated_fields, annotated_groupbys,
-                                  interval=dateutil.relativedelta.relativedelta(months=1)):
+                                  fill_from=False, fill_to=False, min_groups=False):
         """Helper method for filling date/datetime 'holes' in a result set.
 
         We are in a use case where data are grouped by a date field (typically
         months but it could be any other interval) and displayed in a chart.
 
-        Assume we group records by month, and we only have data for August,
+        Assume we group records by month, and we only have data for June,
         September and December. By default, plotting the result gives something
         like:
                                                 ___
                                       ___      |   |
-                                     |   |     |   |
                                      |   | ___ |   |
-                                     |   ||   ||   |
                                      |___||___||___|
-                                      Aug  Sep  Dec
+                                      Jun  Sep  Dec
 
-        The problem is that December data follows immediately September data,
-        which is misleading for the user. Adding explicit zeroes for missing data
-        gives something like:
+        The problem is that December data immediately follow September data,
+        which is misleading for the user. Adding explicit zeroes for missing
+        data gives something like:
+                                                           ___
+                             ___                          |   |
+                            |   |           ___           |   |
+                            |___| ___  ___ |___| ___  ___ |___|
+                             Jun  Jul  Aug  Sep  Oct  Nov  Dec
+
+        To customize this output, the context key "fill_temporal" can be used
+        under its dictionary format, which has 3 attributes : fill_from,
+        fill_to, min_groups (see params of this function)
+
+        Fill between bounds:
+        Using either `fill_from` and/or `fill_to` attributes, we can further
+        specify that at least a certain date range should be returned as
+        contiguous groups. Any group outside those bounds will not be removed,
+        but the filling will only occur between the specified bounds. When not
+        specified, existing groups will be used as bounds, if applicable.
+        By specifying such bounds, we can get empty groups before/after any
+        group with data.
+
+        If we want to fill groups only between August (fill_from)
+        and October (fill_to):
                                                      ___
                                  ___                |   |
-                                |   |               |   |
-                                |   | ___           |   |
-                                |   ||   |          |   |
-                                |___||___| ___  ___ |___|
-                                 Aug  Sep  Oct  Nov  Dec
+                                |   |      ___      |   |
+                                |___| ___ |___| ___ |___|
+                                 Jun  Aug  Sep  Oct  Dec
+
+        We still get June and December. To filter them out, we should match
+        `fill_from` and `fill_to` with the domain e.g. ['&',
+            ('date_field', '>=', 'YYYY-08-01'),
+            ('date_field', '<', 'YYYY-11-01')]:
+                                         ___
+                                    ___ |___| ___
+                                    Aug  Sep  Oct
+
+        Minimal filling amount:
+        Using `min_groups`, we can specify that we want at least that amount of
+        contiguous groups. This amount is guaranteed to be provided from
+        `fill_from` if specified, or from the lowest existing group otherwise.
+        This amount is not restricted by `fill_to`. If there is an existing
+        group before `fill_from`, `fill_from` is still used as the starting
+        group for min_groups, because the filling does not apply on that
+        existing group. If neither `fill_from` nor `fill_to` is specified, and
+        there is no existing group, no group will be returned.
+
+        If we set min_groups = 4:
+                                         ___
+                                    ___ |___| ___ ___
+                                    Aug  Sep  Oct Nov
 
         :param list data: the data containing groups
         :param list groupby: name of the first group by
@@ -1844,21 +1884,50 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         :return: list
         """
         first_a_gby = annotated_groupbys[0]
-        if not data:
-            return data
         if first_a_gby['type'] not in ('date', 'datetime'):
             return data
         interval = first_a_gby['interval']
+        granularity = first_a_gby['granularity']
+        tz = pytz.timezone(self._context['tz']) if first_a_gby["tz_convert"] else False
         groupby_name = groupby[0]
 
         # existing non null datetimes
-        existing = [d[groupby_name] for d in data if d[groupby_name]]
+        existing = [d[groupby_name] for d in data if d[groupby_name]] or [None]
+        # assumption: existing data is sorted by field 'groupby_name'
+        existing_from, existing_to = existing[0], existing[-1]
 
-        if len(existing) < 2:
+        if fill_from:
+            fill_from = date_utils.start_of(odoo.fields.Datetime.to_datetime(fill_from), granularity)
+            if tz:
+                fill_from = tz.localize(fill_from)
+        elif existing_from:
+            fill_from = existing_from
+        if fill_to:
+            fill_to = date_utils.start_of(odoo.fields.Datetime.to_datetime(fill_to), granularity)
+            if tz:
+                fill_to = tz.localize(fill_to)
+        elif existing_to:
+            fill_to = existing_to
+
+        if not fill_to and fill_from:
+            fill_to = fill_from
+        if not fill_from and fill_to:
+            fill_from = fill_to
+        if not fill_from and not fill_to:
             return data
 
-        # assumption: existing data is sorted by field 'groupby_name'
-        first, last = existing[0], existing[-1]
+        if min_groups > 0:
+            fill_to = max(fill_to, fill_from + (min_groups - 1) * interval)
+
+        if fill_to < fill_from:
+            return data
+
+        required_dates = date_utils.date_range(fill_from, fill_to, interval)
+
+        if existing[0] is None:
+            existing = list(required_dates)
+        else:
+            existing = sorted(set().union(existing, required_dates))
 
         empty_item = {'id': False, (groupby_name.split(':')[0] + '_count'): 0}
         empty_item.update({key: False for key in aggregated_fields})
@@ -1869,8 +1938,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             grouped_data[d[groupby_name]].append(d)
 
         result = []
-
-        for dt in date_utils.date_range(first, last, interval):
+        for dt in existing:
             result.extend(grouped_data[dt] or [dict(empty_item, **{groupby_name: dt})])
 
         if False in grouped_data:
@@ -2229,9 +2297,15 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
         data = [{k: self._read_group_prepare_data(k, v, groupby_dict) for k, v in r.items()} for r in fetched_data]
 
-        if self.env.context.get('fill_temporal') and data:
+        fill_temporal = self.env.context.get('fill_temporal')
+        if (data and fill_temporal) or isinstance(fill_temporal, dict):
+            # fill_temporal = {} is equivalent to fill_temporal = True
+            # if fill_temporal is a dictionary and there is no data, there is a chance that we
+            # want to display empty columns anyway, so we should apply the fill_temporal logic
+            if not isinstance(fill_temporal, dict):
+                fill_temporal = {}
             data = self._read_group_fill_temporal(data, groupby, aggregated_fields,
-                                                  annotated_groupbys)
+                                                  annotated_groupbys, **fill_temporal)
 
         result = [self._read_group_format_result(d, annotated_groupbys, groupby, domain) for d in data]
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1887,9 +1887,9 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         if first_a_gby['type'] not in ('date', 'datetime'):
             return data
         interval = first_a_gby['interval']
-        granularity = first_a_gby['granularity']
-        tz = pytz.timezone(self._context['tz']) if first_a_gby["tz_convert"] else False
         groupby_name = groupby[0]
+        granularity = groupby_name.split(':')[-1] if ':' in groupby_name else 'month'
+        tz = pytz.timezone(self._context['tz']) if first_a_gby["tz_convert"] else False
 
         # existing non null datetimes
         existing = [d[groupby_name] for d in data if d[groupby_name]] or [None]


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Graph view shows wrong values if it has not values in firsts groups.
First of all I found this commit that fix function  `_read_group_fill_temporal` https://github.com/OCA/OCB/commit/56bcb418c2320a2725a81b2b0fdcef5c39a0b769

After cherry pick this commit I fix it to to work in 12.0 and I modify the file `graph_model.js` to send values of `fill_from` and `fill_to`

**Current behavior before PR:**
The value for day 14 of December are 2960
![graph_bar_before](https://user-images.githubusercontent.com/7404532/152327940-c68b9a59-21a1-48e4-a948-4ff58f667914.png)

If we view it in lines graph 14 of December is compared with 3 of January and graph are not completed.

![graph_lines_before](https://user-images.githubusercontent.com/7404532/152328798-a5ec334e-99c6-497b-a2dd-a47c82c6cfed.png)


**Desired behavior after PR is merged:**
With this commit in lines graph 14 of December is compared with 14 of January.
![graph_lines_after](https://user-images.githubusercontent.com/7404532/152329947-43aa27c6-68c9-4d66-82c9-9473c78bee1b.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
