### PR TITLE
[10.0][FIX] core/web: back to previous state of form_widget.js

### DIFF
--- a/addons/web/static/src/js/views/form_widgets.js
+++ b/addons/web/static/src/js/views/form_widgets.js
@@ -1224,13 +1224,17 @@ var FieldBinaryFile = FieldBinary.extend({
         if (this.get("effective_readonly")) {
             // Filename from saved state (might render from a discard operation)
             filename = this.view.datarecord[this.node.attrs.filename]; // do not forward-port >= 11.0
-            var visible = !!(this.value && this.res_id);
-            this.$el.empty().css('cursor', 'not-allowed');
-            this.do_toggle(visible);
-            if (visible) {
-                this.$el.empty().css('cursor', 'pointer')
-                                .text(this.filename_value || '')
-                                .prepend('<span class="fa fa-download"/>', ' ');
+            this.do_toggle(!!this.get('value'));
+            if (this.get('value')) {
+                this.$el.empty().append($("<span/>").addClass('fa fa-download'));
+                if (this.view.datarecord.id) {
+                    this.$el.css('cursor', 'pointer');
+                } else {
+                    this.$el.css('cursor', 'not-allowed');
+                }
+                if (filename) {
+                    this.$el.append(" " + filename);
+                }
             }
         } else {
             // Filename at the moment (might be unsaved state)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR reverts the changes introduced by the commit [odoo@ea62945](https://github.com/odoo/odoo/commit/ea62945cc48dd045800c73bfe0d73e7cb42387a5) in form_widgets.js.

This is the issue: https://github.com/OCA/OCB/issues/1111


Current behavior before PR:
When exporting a translation file (.po, .csv, .tgz) the file link does not appear for download in the wizard. Actually this affects all file links using the widget.

Desired behavior after PR is merged:
After reverting the changes the link to download the file reappears.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
