### PR TITLE
[12.0][FIX] base: missing xmlid for mixin fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -885,7 +885,12 @@ class IrModelFields(models.Model):
                 keys = [key for key in new_vals if old_vals[key] != new_vals[key]]
                 self.pool.post_init(record.modified, keys)
                 old_vals.update(new_vals)
-            if module and (module == model._original_module or module in field._modules):
+            if module and (module == model._original_module or module in field._modules or any(
+                    # module introduced field on model by inheritance
+                    name in self.env[parent]._fields
+                    for parent, parent_module in model._inherit_module.items()
+                    if module == parent_module
+                )):
                 # remove this and only keep the else clause if version >= saas-12.4
                 if field.manual:
                     self.pool.loaded_xmlids.add(

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -445,6 +445,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 '_name': name,
                 '_register': False,
                 '_original_module': cls._module,
+                '_inherit_module': dict(),              # map parent to introducing module
                 '_inherit_children': OrderedSet(),      # names of children models
                 '_inherits_children': set(),            # names of children models
                 '_fields': OrderedDict(),               # populated in _setup_base()
@@ -463,6 +464,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             else:
                 check_parent(cls, parent_class)
                 bases.add(parent_class)
+                ModelClass._inherit_module[parent] = cls._module
                 parent_class._inherit_children.add(name)
         ModelClass.__bases__ = tuple(bases)
 


### PR DESCRIPTION
Backport from Odoo 14.0: https://github.com/odoo/odoo/commit/5d5a3d7fa455a93d89688cfb613afeb97f0073d5

We want to create a XMLID for every first exhibition of a field in a
model. That is, we just want one XMLID by field by model and not one
XMLID by field by class. Previous implementation was determining the
"first field exhibition" by making sure the field was created and used
as part of the same module.

This assumption is invalid when we consider mixins. A mixin is an
abstract model that define fields and methods to be included in other
models. As it is abstract, it does not exhibits the field by itself. The
field will only be exhibited when included in a concrete model via
inheritance. When it is included in another module, the XMLID creation
is discarded.

Take a module M1 that defines a model A, take another module M2 that
defines a mixin X with a field X1. In a third module M3, extend A to
inherit from X. While M3.A is the first model module to exhibit the
field X1, the XMLID creation was discarded because `"M2" != "M3"`.

See #49354 (comment)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
