### PR TITLE
[FIX] #79710 payment_stripe_sca: Receive 3D secure payment from anonymous users

### DIFF
--- a/addons/payment_stripe_sca/controllers/main.py
+++ b/addons/payment_stripe_sca/controllers/main.py
@@ -52,7 +52,7 @@ class StripeControllerSCA(StripeController):
         return res.get('client_secret')
 
 
-    @route('/payment/stripe/s2s/process_payment_intent', type='json')
+    @route('/payment/stripe/s2s/process_payment_intent', type='json', auth='public', csrf=False)
     def stripe_s2s_process_payment_intent(self, **post):
         return request.env['payment.transaction'].sudo().form_feedback(post, 'stripe')
 


### PR DESCRIPTION
Anonymous users payment transaction stay in pending state using stripe acquirer with 3D Secure card

This as been report in #79710

upstream PR: https://github.com/odoo/odoo/pull/85145

To reproduce:

* install website_sale and paymet_stripe_sca modules
* configure stripe acquirer to works on test platform
* use new browser session as anonymous users and fill the card
* process payment using 3ds card from https://stripe.com/docs/testing#three-ds-cards
* Validate the 3ds form

Before this PR transaction still in pending
After this PR transaction is mark as done


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
