### PR TITLE
Revert "[FIX] web: expect explicit sign up parameters"

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -5,7 +5,7 @@ import werkzeug
 
 import openerp
 from openerp.addons.auth_signup.res_users import SignupError
-from openerp.addons.web.controllers.main import ensure_db, SIGN_UP_REQUEST_PARAMS
+from openerp.addons.web.controllers.main import ensure_db
 from openerp import http
 from openerp.http import request
 from openerp.tools.translate import _
@@ -81,7 +81,7 @@ class AuthSignupHome(openerp.addons.web.controllers.main.Home):
 
     def get_auth_signup_qcontext(self):
         """ Shared helper returning the rendering context for signup and reset password """
-        qcontext = {k: v for (k, v) in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
+        qcontext = request.params.copy()
         qcontext.update(self.get_auth_signup_config())
         if qcontext.get('token'):
             try:

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -431,11 +431,6 @@ def db_info():
         'server_version_info': version_info.get('server_version_info'),
     }
 
-# Shared parameters for all login/signup flows
-SIGN_UP_REQUEST_PARAMS = {'db', 'login', 'debug', 'token', 'message', 'error', 'scope', 'mode',
-                          'redirect', 'redirect_hostname', 'email', 'name', 'partner_id',
-                          'password', 'confirm_password', 'city', 'country_id', 'lang'}
-
 #----------------------------------------------------------
 # OpenERP Web web Controllers
 #----------------------------------------------------------
@@ -473,7 +468,7 @@ class Home(http.Controller):
         if not request.uid:
             request.uid = openerp.SUPERUSER_ID
 
-        values = {k: v for k, v in request.params.items() if k in SIGN_UP_REQUEST_PARAMS}
+        values = request.params.copy()
         values['mono_db'] = len(http.db_list(True, request.httprequest)) == 1
         try:
             values['databases'] = http.db_list()


### PR DESCRIPTION
This reverts commit 342c8a0329d6955f6af295f143875e2603e1f3aa.

Discussion with @odony on the backport of matching commit on
odoo/enterprise brought the information that the vulnerability is not
present on odoo 9 so this patch is not required. Since running on Odoo
EE 9.0 also requires a patch on enterprise
(https://github.com/odoo/enterprise/pull/23601) the conclusion is that
we are safer not making the patch on OCB 9.0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
