### PR TITLE
[ENH][14.0]Include invoice number and -reference in Outstanding debits

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1558,7 +1558,7 @@ class AccountMove(models.Model):
                     continue
 
                 payments_widget_vals['content'].append({
-                    'journal_name': line.ref or line.move_id.name,
+                    'journal_name': ': '.join(filter(None, (line.move_id.name, line.ref))),
                     'amount': amount,
                     'currency': move.currency_id.symbol,
                     'id': line.id,

--- a/doc/cla/individual/driehuis.md
+++ b/doc/cla/individual/driehuis.md
@@ -1,0 +1,11 @@
+The Netherlands, 2022-03-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Bert Driehuis <driehuis@playbeing.org> https://github.com/driehuis


### PR DESCRIPTION
Include invoice number and -reference in available payments

Description of the issue/feature this PR addresses:

In 14.0, when payments or credits can be allocated to an invoice, the description only includes the invoice reference. In some cases, it would be helpful to also see the invoice number, to be able to quickly locate the source of the available funds.

Current behavior before PR:

When a refunded invoice and a bank payment are available, the "Outstanding debits" would show

```
Add    parts              99.52
Add    PARTS              506.20
```

Desired behavior after PR is merged:

Include the move names, so the previous example becomes:

```
Add    RINV/2022/01/0003: parts              99.52
Add    BNK1/2022/01/0022: PARTS              506.20
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
