### PR TITLE
[15.0][FIX] purchase: wrong price rounding on currency conversion

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -380,11 +380,13 @@ class AccountPayment(models.Model):
             else:
                 payment.amount_signed = payment.amount
 
-    @api.depends('partner_id', 'company_id', 'payment_type')
+    @api.depends('partner_id', 'company_id', 'payment_type', 'destination_journal_id', 'is_internal_transfer')
     def _compute_available_partner_bank_ids(self):
         for pay in self:
             if pay.payment_type == 'inbound':
                 pay.available_partner_bank_ids = pay.journal_id.bank_account_id
+            elif pay.is_internal_transfer:
+                pay.available_partner_bank_ids = pay.destination_journal_id.bank_account_id
             else:
                 pay.available_partner_bank_ids = pay.partner_id.bank_ids\
                         .filtered(lambda x: x.company_id.id in (False, pay.company_id.id))._origin

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -446,7 +446,8 @@ class Project(models.Model):
         # We want to copy archived task, but do not propagate an active_test context key
         task_ids = self.env['project.task'].with_context(active_test=False).search([('project_id', '=', self.id)], order='parent_id').ids
         old_to_new_tasks = {}
-        for task in self.env['project.task'].browse(task_ids):
+        all_tasks = self.env['project.task'].browse(task_ids)
+        for task in all_tasks:
             # preserve task name and stage, normally altered during copy
             defaults = self._map_tasks_default_valeus(task, project)
             if task.parent_id:
@@ -460,6 +461,13 @@ class Project(models.Model):
             new_child_ids = [old_to_new_tasks[child.id] for child in task.child_ids if child.id in old_to_new_tasks]
             tasks.browse(new_child_ids).write({'parent_id': new_task.id})
             old_to_new_tasks[task.id] = new_task.id
+            if task.allow_task_dependencies:
+                depend_on_ids = [t.id if t not in all_tasks else old_to_new_tasks.get(t.id, None) for t in
+                                 task.depend_on_ids]
+                new_task.write({'depend_on_ids': [Command.link(tid) for tid in depend_on_ids if tid]})
+                dependent_ids = [t.id if t not in all_tasks else old_to_new_tasks.get(t.id, None) for t in
+                                 task.dependent_ids]
+                new_task.write({'dependent_ids': [Command.link(tid) for tid in dependent_ids if tid]})
             tasks += new_task
 
         return project.write({'tasks': [(6, 0, tasks.ids)]})
@@ -1007,10 +1015,10 @@ class Task(models.Model):
     allow_task_dependencies = fields.Boolean(related='project_id.allow_task_dependencies')
     # Tracking of this field is done in the write function
     depend_on_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="task_id",
-                                     column2="depends_on_id", string="Blocked By", tracking=True,
+                                     column2="depends_on_id", string="Blocked By", tracking=True, copy=False,
                                      domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     dependent_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="depends_on_id",
-                                     column2="task_id", string="Block",
+                                     column2="task_id", string="Block", copy=False,
                                      domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     dependent_tasks_count = fields.Integer(string="Dependent Tasks", compute='_compute_dependent_tasks_count')
 

--- a/addons/project/tests/test_task_dependencies.py
+++ b/addons/project/tests/test_task_dependencies.py
@@ -159,3 +159,26 @@ class TestTaskDependencies(TestProjectCommon):
             'name': 'My Ducks Project'
         })
         self.assertFalse(self.project_ducks.allow_task_dependencies, "New Projects allow_task_dependencies should default to group_project_task_dependencies")
+
+    def test_duplicate_project_with_task_dependencies(self):
+
+        self.project_pigs.allow_task_dependencies = True
+        self.task_1.depend_on_ids = self.task_2
+        pigs_copy = self.project_pigs.copy()
+
+        task1_copy = pigs_copy.task_ids.filtered(lambda t: t.name == 'Pigs UserTask')
+        task2_copy = pigs_copy.task_ids.filtered(lambda t: t.name == 'Pigs ManagerTask')
+
+        self.assertEqual(len(task1_copy), 1, "Should only contain 1 copy of UserTask")
+        self.assertEqual(len(task2_copy), 1, "Should only contain 1 copy of ManagerTask")
+
+        self.assertEqual(task1_copy.depend_on_ids.ids, [task2_copy.id],
+                         "Copy should only create a relation between both copy if they are both part of the project")
+
+        task1_copy.depend_on_ids = self.task_1
+
+        pigs_copy_copy = pigs_copy.copy()
+        task1_copy_copy = pigs_copy_copy.task_ids.filtered(lambda t: t.name == 'Pigs UserTask')
+
+        self.assertEqual(task1_copy_copy.depend_on_ids.ids, [self.task_1.id],
+                         "Copy should not alter the relation if the other task is in a different project")

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1187,7 +1187,8 @@ class PurchaseOrderLine(models.Model):
         price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id) if seller else 0.0
         if price_unit and seller and self.order_id.currency_id and seller.currency_id != self.order_id.currency_id:
             price_unit = seller.currency_id._convert(
-                price_unit, self.order_id.currency_id, self.order_id.company_id, self.date_order or fields.Date.today())
+                price_unit, self.order_id.currency_id, self.order_id.company_id, self.date_order or fields.Date.today(), round=False
+            )
 
         if seller and self.product_uom and seller.product_uom != self.product_uom:
             price_unit = seller.product_uom._compute_price(price_unit, self.product_uom)

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -463,3 +463,92 @@ class TestSaleMrpKitBom(TransactionCase):
         self.assertTrue(pick.move_ids_without_package[1].bom_line_id, "All component from kits should have a bom line")
         self.assertTrue(ship.move_ids_without_package[0].bom_line_id, "All component from kits should have a bom line")
         self.assertTrue(ship.move_ids_without_package[1].bom_line_id, "All component from kits should have a bom line")
+
+    def test_qty_delivered_with_bom_using_kit2(self):
+        """Create 2 kits products that have common components and activate 2 steps delivery
+           Then create a sale order with these 2 products, and put everything in a pack in
+           the first step of the delivery. After the shipping is done, check the done quantity
+           is correct for each products.
+        """
+
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        wh.write({'delivery_steps': 'pick_ship'})
+
+        kitAB = self._create_product('Kit AB', 'product', 0.00)
+        kitABC = self._create_product('Kit ABC', 'product', 0.00)
+        compA = self._create_product('ComponentA', 'product', 0.00)
+        compB = self._create_product('ComponentB', 'product', 0.00)
+        compC = self._create_product('ComponentC', 'product', 0.00)
+
+        # Create BoM for KitB
+        bom_product_formA = Form(self.env['mrp.bom'])
+        bom_product_formA.product_id = kitAB
+        bom_product_formA.product_tmpl_id = kitAB.product_tmpl_id
+        bom_product_formA.product_qty = 1.0
+        bom_product_formA.type = 'phantom'
+        with bom_product_formA.bom_line_ids.new() as bom_line:
+            bom_line.product_id = compA
+            bom_line.product_qty = 1
+        with bom_product_formA.bom_line_ids.new() as bom_line:
+            bom_line.product_id = compB
+            bom_line.product_qty = 1
+        bom_product_formA.save()
+
+        # Create BoM for KitA
+        bom_product_formB = Form(self.env['mrp.bom'])
+        bom_product_formB.product_id = kitABC
+        bom_product_formB.product_tmpl_id = kitABC.product_tmpl_id
+        bom_product_formB.product_qty = 1.0
+        bom_product_formB.type = 'phantom'
+        with bom_product_formB.bom_line_ids.new() as bom_line:
+            bom_line.product_id = compA
+            bom_line.product_qty = 1
+        with bom_product_formB.bom_line_ids.new() as bom_line:
+            bom_line.product_id = compB
+            bom_line.product_qty = 1
+        with bom_product_formB.bom_line_ids.new() as bom_line:
+            bom_line.product_id = compC
+            bom_line.product_qty = 1
+        bom_product_formB.save()
+
+        customer = self.env['res.partner'].create({
+            'name': 'customer',
+        })
+
+        so = self.env['sale.order'].create({
+            'partner_id': customer.id,
+            'order_line': [
+                (0, 0, {
+                    'name': kitAB.name,
+                    'product_id': kitAB.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': kitAB.uom_id.id,
+                    'price_unit': 1,
+                    'tax_id': False,
+                }),
+                (0, 0, {
+                    'name': kitABC.name,
+                    'product_id': kitABC.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': kitABC.uom_id.id,
+                    'price_unit': 1,
+                    'tax_id': False,
+                })],
+        })
+        so.action_confirm()
+
+        pick = so.picking_ids[0]
+        ship = so.picking_ids[1]
+
+        pick.move_lines[0].quantity_done = 2
+        pick.move_lines[1].quantity_done = 2
+        pick.move_lines[2].quantity_done = 1
+
+        pick.action_put_in_pack()
+        pick.button_validate()
+
+        ship.package_level_ids.write({'is_done': True})
+        ship.package_level_ids._set_is_done()
+
+        for move in ship.move_line_ids:
+            self.assertEqual(move.product_uom_qty, move.qty_done, "Quantity done should be equal to the quantity reserved in the move line")

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -271,11 +271,11 @@ class ProfitabilityAnalysis(models.Model):
                                         ELSE 0.0
                                     END AS expense_amount_untaxed_invoiced,
                                     CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') AND SOL.is_service IS TRUE THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
                                         ELSE 0.0
                                     END AS amount_untaxed_to_invoice,
                                     CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') AND SOL.is_service IS TRUE THEN (SOL.untaxed_amount_invoiced / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
                                         ELSE 0.0
                                     END AS amount_untaxed_invoiced,
                                     S.date_order AS line_date

--- a/addons/sale_timesheet/tests/test_reporting.py
+++ b/addons/sale_timesheet/tests/test_reporting.py
@@ -941,3 +941,91 @@ class TestReporting(TestCommonReporting):
         self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, after credit note.")
         self.assertAlmostEqual(project_stat['expense_cost'], 0, msg="The expense costs (credit note) of the project should be zero (not taken into account), after credit note.")
         self.assertAlmostEqual(project_stat['other_revenues'], 0, msg="The other revenues of the project should be zero, as it is balanced by credit note.")
+
+    def test_project_profitability_report(self):
+        """ Test profitability report for a project with a task and a SO with a service and a product
+            added linked to the task."""
+
+        # create Analytic Accounts
+        self.analytic_account_1 = self.env['account.analytic.account'].create({
+            'name': 'Test AA 1',
+            'code': 'AA1',
+            'company_id': self.company_data['company'].id,
+            'partner_id': self.partner_a.id
+        })
+
+        self.sale_order_1 = self.env['sale.order'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'analytic_account_id': self.analytic_account_1.id,
+        })
+        self.so_line_deliver_project = self.env['sale.order.line'].create({
+            'name': self.product_delivery_timesheet3.name,
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom': self.product_delivery_timesheet3.uom_id.id,
+            'price_unit': self.product_delivery_timesheet3.list_price,
+            'order_id': self.sale_order_1.id,
+        })
+        self.so_line_deliver_task = self.env['sale.order.line'].create({
+            'name': self.product_delivery_timesheet2.name,
+            'product_id': self.product_delivery_timesheet2.id,
+            'product_uom': self.product_delivery_timesheet2.uom_id.id,
+            'price_unit': self.product_delivery_timesheet2.list_price,
+            'order_id': self.sale_order_1.id,
+        })
+
+        # this test suppose everything is in the same currency as the current one
+        currency = self.env.company.currency_id
+        rounding = currency.rounding
+        # confirm sales orders
+        self.sale_order_1.action_confirm()
+        self.env['project.profitability.report'].flush()
+
+        project_so_1 = self.so_line_deliver_project.project_id
+
+        task_so_1 = self.so_line_deliver_project.task_id
+
+        self.product_material = self.env['product.product'].create({
+            'name': 'My Material Product',
+            'sale_ok': True,
+            'invoice_policy': 'order',
+            'lst_price': 5,
+        })
+
+        self.env['sale.order.line'].create({
+            'order_id': self.sale_order_1.id,
+            'name': self.product_material.name,
+            'product_id': self.product_material.id,
+            'product_uom_qty': 5,
+            'product_uom': self.product_material.uom_id.id,
+            'price_unit': self.product_material.list_price,
+            'task_id': task_so_1.id,
+        })
+
+        InvoiceWizard = self.env['sale.advance.payment.inv'].with_context(mail_notrack=True)
+
+        # invoice the Sales Order SO1 (based on delivered qty)
+        context = {
+            "active_model": 'sale.order',
+            "active_ids": [self.sale_order_1.id],
+            "active_id": self.sale_order_1.id,
+            'open_invoices': True,
+        }
+        payment = InvoiceWizard.create({
+            'advance_payment_method': 'delivered',
+        })
+        action_invoice = payment.with_context(context).create_invoices()
+        invoice_id = action_invoice['res_id']
+        invoice_1 = self.env['account.move'].browse(invoice_id)
+        invoice_1.action_post()
+
+        project_so_1_stat = self.env['project.profitability.report'].read_group([('project_id', 'in', project_so_1.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced', 'other_revenues'], ['project_id'])[0]
+        self.assertTrue(float_is_zero(project_so_1_stat['amount_untaxed_invoiced'], precision_rounding=rounding), "The invoiced amount of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['amount_untaxed_to_invoice'], precision_rounding=rounding), "The amount to invoice of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['timesheet_unit_amount'], precision_rounding=rounding), "The timesheet unit amount of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['timesheet_cost'], precision_rounding=rounding), "The timesheet cost of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['expense_amount_untaxed_to_invoice'], precision_rounding=rounding), "The expense cost to reinvoice of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['expense_amount_untaxed_invoiced'], precision_rounding=rounding), "The expense invoiced amount of the project from SO1 should be 0.0")
+        self.assertTrue(float_is_zero(project_so_1_stat['expense_cost'], precision_rounding=rounding), "The expense cost of the project from SO1 should be 0.0")
+        self.assertEqual(float_compare(project_so_1_stat['other_revenues'], invoice_1.amount_untaxed, precision_rounding=rounding), 0, "The other revenues of the project from SO1 should be the same as the untaxed amount in invoice")

--- a/addons/web/static/src/legacy/scss/modal.scss
+++ b/addons/web/static/src/legacy/scss/modal.scss
@@ -8,7 +8,9 @@
         }
 
         .modal-header .modal-title {
-            word-break: break-word;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
         }
 
         .modal-body {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -21,6 +21,7 @@ const { PeerToPeer } = require('@web_editor/js/wysiwyg/PeerToPeer');
 const { Mutex } = require('web.concurrency');
 
 var _t = core._t;
+const QWeb = core.qweb;
 
 const OdooEditor = OdooEditorLib.OdooEditor;
 const getDeepRange = OdooEditorLib.getDeepRange;
@@ -521,7 +522,7 @@ const Wysiwyg = Widget.extend({
         }, CHECK_OFFLINE_TIME);
 
         this._peerToPeerLoading = new Promise(async (resolve) => {
-            this._currentRecordWriteDate = this._getRecordWriteDate(await this._getCurrentRecord());
+            this._currentRecord = await this._getCurrentRecord();
             let iceServers = await this._rpc({route: '/web_editor/get_ice_servers'});
             if (!iceServers.length) {
                 iceServers = [
@@ -2028,10 +2029,24 @@ const Wysiwyg = Widget.extend({
             this.preSavePromiseReject = undefined;
         }
         try {
-            const record = await this._getCurrentRecord();
-            const newDate = this._getRecordWriteDate(record);
-            if (newDate !== this._currentRecordWriteDate) {
-                this._resetEditor(record.body);
+            const fieldName = this.options.collaborationChannel.collaborationFieldName;
+            const currentContent = this._currentRecord[fieldName];
+            const currentRecordDate = this._getRecordWriteDate(this._currentRecord);
+            const dbRecord = await this._getCurrentRecord();
+            const dbContent = dbRecord[fieldName];
+            const dbRecordDate = this._getRecordWriteDate(dbRecord);
+
+            if (currentContent !== dbContent && dbRecordDate !== currentRecordDate) {
+                const $dialogContent = $(QWeb.render('web_editor.collaboration-reset-dialog'));
+                $dialogContent.append($(this.odooEditor.editable).clone());
+                const dialog = new Dialog(this, {
+                    title: _t("Content conflict"),
+                    $content: $dialogContent,
+                    size: 'medium',
+                });
+                dialog.open({shouldFocusButtons:true});
+
+                this._resetEditor(dbRecord.body);
             }
             this.preSavePromiseResolve();
             resetPreSavePromise();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1212,7 +1212,8 @@ const Wysiwyg = Widget.extend({
         if (!this.options.snippets) {
             $toolbar.find('#justify, #table, #media-insert').remove();
         }
-        $toolbar.find('#create-link, #media-insert, #media-replace, #media-description').click(openTools);
+        $toolbar.find('#media-insert, #media-replace, #media-description').click(openTools);
+        $toolbar.find('#create-link').mousedown(openTools);
         $toolbar.find('#image-shape div, #fa-spin').click(e => {
             if (!this.lastMediaClicked) {
                 return;

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -268,6 +268,24 @@
         </we-customizeblock-options>
     </t>
 
+    <!-- Collaboration reset dialog -->
+    <t t-name="web_editor.collaboration-reset-dialog">
+        <div>
+            <div style="color: red;">
+                <p>
+                    There is a conflict between your version and the one in the database.
+                </p>
+                <p>
+                    The version from the database will be used.
+                    If you need to keep your changes, copy the content below and edit the new document.
+                </p>
+                <p style="font-weight: bold;">
+                    Warning: after closing this dialog, the version you were working on will be discarded and will never be available anymore.
+                </p>
+            </div>
+        </div>
+    </t>
+
     <!--=================-->
     <!-- Snippet options -->
     <!--=================-->

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -468,7 +468,7 @@ QUnit.module('web_editor', {}, function () {
 
             let pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText.firstChild, 0, pText.firstChild, pText.firstChild.length);
-            await testUtils.dom.click($('#toolbar #create-link'));
+            await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'mousedown');
             // load static xml file (dialog, link dialog)
             await defLinkDialog;
             $('.modal .tab-content .tab-pane').removeClass('fade'); // to be sync in test
@@ -517,7 +517,7 @@ QUnit.module('web_editor', {}, function () {
 
             let pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText.firstChild, 0, pText.firstChild, pText.firstChild.length);
-            await testUtils.dom.click($('#toolbar #create-link'));
+            await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'mousedown');
             // load static xml file (dialog, link dialog)
             await defLinkDialog;
             $('.modal .tab-content .tab-pane').removeClass('fade'); // to be sync in test
@@ -566,7 +566,7 @@ QUnit.module('web_editor', {}, function () {
 
             let pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
-            await testUtils.dom.click($('#toolbar #create-link'));
+            await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'mousedown');
             // load static xml file (dialog, link dialog)
             await defLinkDialog;
             $('.modal .tab-content .tab-pane').removeClass('fade'); // to be sync in test
@@ -616,7 +616,7 @@ QUnit.module('web_editor', {}, function () {
 
             let pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
-            await testUtils.dom.click($('#toolbar #create-link'));
+            await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'mousedown');
             // load static xml file (dialog, link dialog)
             await defLinkDialog;
             $('.modal .tab-content .tab-pane').removeClass('fade'); // to be sync in test
@@ -639,7 +639,7 @@ QUnit.module('web_editor', {}, function () {
             $field = form.$('.oe_form_field[name="body"]');
             pText = $field.find('.note-editable a').eq(0).contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
-            await testUtils.dom.click($('#toolbar #create-link'));
+            await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'mousedown');
             // load static xml file (dialog, link dialog)
             await defLinkDialog;
             $('.modal .tab-content .tab-pane').removeClass('fade'); // to be sync in test

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -186,12 +186,12 @@
                                 <t t-call="website_slides.join_course_link"/>
                             </li>
                         </div>
-                        <li class="pl-4">
-                            <a t-if="can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
+                        <li t-if="aside_slide.question_ids and aside_slide.slide_type != 'quiz'" class="pl-4">
+                            <a t-if="can_access" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))"
+                                class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </a>
-                            <span t-elif="not can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'"
-                                class="o_wslides_lesson_aside_list_link text-decoration-none small text-600 text-muted">
+                            <span t-else="" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600 text-muted">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </span>
                         </li>


### PR DESCRIPTION
*Impacted versions:*

15.0

*Steps to reproduce:*

- USD is the default currency and EUR is enabled as additional currency. Suppose 1 EUR = 1.5289
- Set Decimal Accuracy, for "Product Price", to 4 digits
- Edit Product "Office Lamp", Purchase tab. Set top supplier to "Azure Interior", Currency "EUR", Price 1.0
- Create a PO for "Azure Interior", USD currency, and add a line for "Office Lamp"

*Current behavior:*

- Unit price is rounded to two decoimals: 1.53

*Expected behavior:*

- Expected price should be rounded to four decimals: 1.5289

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
