### PR TITLE
[13][BUG] website: Doesn't load menu when is a mobile/tablet and you are an user logged. Only Firefox is affected.

### DIFF
--- a/addons/website/static/src/js/menu/navbar.js
+++ b/addons/website/static/src/js/menu/navbar.js
@@ -19,6 +19,7 @@ var WebsiteNavbar = publicWidget.RootWidget.extend({
         'mouseover > ul > li.dropdown:not(.show)': '_onMenuHovered',
         'click .o_mobile_menu_toggle': '_onMobileMenuToggleClick',
         'mouseover #oe_applications:not(:has(.dropdown-item))': '_onOeApplicationsHovered',
+        'click #oe_applications:not(:has(.dropdown-item))': '_onOeApplicationsHovered',
     }),
     custom_events: _.extend({}, publicWidget.RootWidget.prototype.custom_events || {}, {
         'action_demand': '_onActionDemand',


### PR DESCRIPTION
When you are using a mobile/tablet and you are an user logged, the main menu in website doesn't show the menus. Only Firefox is affected.
[website_menu_responsive.zip](https://github.com/odoo/odoo/files/8618665/website_menu_responsive.zip)