### PR TITLE
Update account_move.py

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4532,7 +4532,7 @@ class AccountMoveLine(models.Model):
             # company.
             currency_id = vals.get('currency_id') or move.company_id.currency_id.id
             if currency_id == move.company_id.currency_id.id:
-                balance = vals.get('debit', 0.0) - vals.get('credit', 0.0)
+                balance = float(vals.get('debit', 0.0)) - float(vals.get('credit', 0.0))
                 vals.update({
                     'currency_id': currency_id,
                     'amount_currency': balance,


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
debit and credit is sent as a string and you got an error of trying to "-" two strings.
Current behavior before PR:
balance = vals.get('credit', 0.0) - vals.get('debit', 0.0)
Desired behavior after PR is merged:

balance = float(vals.get('debit', 0.0)) - float(vals.get('credit', 0.0))

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
