### PR TITLE
[11.0][FIX] base_vat_autocomplete plus python-stdnum >= 1.16

### DIFF
--- a/addons/base_vat_autocomplete/models/res_partner.py
+++ b/addons/base_vat_autocomplete/models/res_partner.py
@@ -13,8 +13,13 @@ _logger = logging.getLogger(__name__)
 try:
     import stdnum.eu.vat as stdnum_vat
     if not hasattr(stdnum_vat, "country_codes"):
-        # stdnum version >= 1.9
-        stdnum_vat.country_codes = stdnum_vat._country_codes
+        if hasattr(stdnum_vat, "_country_codes"):
+            # stdnum version >= 1.9 < 1.16
+            stdnum_vat.country_codes = stdnum_vat._country_codes
+        else:
+            # stdnum version >= 1.16
+            stdnum_vat.country_codes = stdnum_vat.MEMBER_STATES
+            
 except ImportError:
     _logger.warning('Python `stdnum` library not found, unable to call VIES service to detect address based on VAT number.')
     stdnum_vat = None


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

https://github.com/odoo/odoo/pull/24395

**Current behavior before PR:**

Error appears when python-stdnum >= 1.16 is used 

**Desired behavior after PR is merged:**

Works well together with python-stdnum >= 1.16


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
