### PR TITLE
[12.0][FIX] project: Fix missing groupby parameter on pager

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -172,7 +172,7 @@ class CustomerPortal(CustomerPortal):
         # pager
         pager = portal_pager(
             url="/my/tasks",
-            url_args={'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby, 'filterby': filterby, 'search_in': search_in, 'search': search},
+            url_args={'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby, 'filterby': filterby, 'search_in': search_in, 'search': search, 'groupby': groupby},
             total=task_count,
             page=page,
             step=self._items_per_page


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Pager miss groupby arg on generated urls, so if we select "none" on page 1, when navigate to page 2, default value "project" is set to groupby variable.

Current behavior before PR:
Wrong records on page 2 or higher when "none" value is set to "groupby".

Desired behavior after PR is merged:
Keep right "groupby" value on pagination.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
