### PR TITLE
[12.0][ADD] adyen paybylink backport

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -472,6 +472,11 @@ file_filter = addons/payment_adyen/i18n/<lang>.po
 source_file = addons/payment_adyen/i18n/payment_adyen.pot
 source_lang = en
 
+[odoo-12.payment_adyen_paybylink]
+file_filter = addons/payment_adyen_paybylink/i18n/<lang>.po
+source_file = addons/payment_adyen_paybylink/i18n/payment_adyen_paybylink.pot
+source_lang = en
+
 [odoo-12.payment_authorize]
 file_filter = addons/payment_authorize/i18n/<lang>.po
 source_file = addons/payment_authorize/i18n/payment_authorize.pot
@@ -971,4 +976,3 @@ source_lang = en
 file_filter = addons/website_twitter/i18n/<lang>.po
 source_file = addons/website_twitter/i18n/website_twitter.pot
 source_lang = en
-

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -478,7 +478,9 @@ class PaymentAcquirer(models.Model):
             values = method(values)
 
         values.update({
-            'tx_url': self._context.get('tx_url', self.get_form_action_url()),
+            'tx_url':  self._context.get(
+                'tx_url', self.with_context(form_action_url_values=values).get_form_action_url()
+            ),
             'submit_class': self._context.get('submit_class', 'btn btn-link'),
             'submit_txt': self._context.get('submit_txt'),
             'acquirer': self,

--- a/addons/payment_adyen_paybylink/__init__.py
+++ b/addons/payment_adyen_paybylink/__init__.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, SUPERUSER_ID
+
+from . import models
+from . import controllers
+
+def _post_init_hook(cr, registry):
+    """ Disable the acquirer because new mandatory fields are added in this module. """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    acquirers = env['payment.acquirer'].search([
+        ('provider', '=', 'adyen'),
+        ('state', '!=', 'disabled'),
+    ])
+    acquirers.write({
+        'state': 'disabled',
+    })

--- a/addons/payment_adyen_paybylink/__init__.py
+++ b/addons/payment_adyen_paybylink/__init__.py
@@ -1,17 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, SUPERUSER_ID
-
-from . import models
 from . import controllers
-
-def _post_init_hook(cr, registry):
-    """ Disable the acquirer because new mandatory fields are added in this module. """
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    acquirers = env['payment.acquirer'].search([
-        ('provider', '=', 'adyen'),
-        ('state', '!=', 'disabled'),
-    ])
-    acquirers.write({
-        'state': 'disabled',
-    })
+from . import models

--- a/addons/payment_adyen_paybylink/__init__.py
+++ b/addons/payment_adyen_paybylink/__init__.py
@@ -10,8 +10,8 @@ def _post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     acquirers = env['payment.acquirer'].search([
         ('provider', '=', 'adyen'),
-        ('state', '!=', 'disabled'),
+        ('website_published', '!=', False),
     ])
     acquirers.write({
-        'state': 'disabled',
+        'website_published': False,
     })

--- a/addons/payment_adyen_paybylink/__init__.py
+++ b/addons/payment_adyen_paybylink/__init__.py
@@ -1,17 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, SUPERUSER_ID
-
-from . import models
 from . import controllers
-
-def _post_init_hook(cr, registry):
-    """ Disable the acquirer because new mandatory fields are added in this module. """
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    acquirers = env['payment.acquirer'].search([
-        ('provider', '=', 'adyen'),
-        ('website_published', '!=', False),
-    ])
-    acquirers.write({
-        'website_published': False,
-    })
+from . import models

--- a/addons/payment_adyen_paybylink/__manifest__.py
+++ b/addons/payment_adyen_paybylink/__manifest__.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': "Adyen Payment Acquirer/Pay by Link Patch",
+    'category': 'Accounting/Payment',
+    'summary': "Payment Acquirer: Adyen Pay by Link Patch",
+    'version': '1.0',
+    'description': """
+This module migrates the Adyen implementation from the Hosted Payment Pages API to the Pay by Link
+API.
+    """,
+    'depends': ['payment_adyen'],
+    'data': [
+        'views/payment_views.xml',
+    ],
+    'post_init_hook': '_post_init_hook',
+    'auto_install': True,
+    'license': 'LGPL-3'
+}

--- a/addons/payment_adyen_paybylink/__manifest__.py
+++ b/addons/payment_adyen_paybylink/__manifest__.py
@@ -4,9 +4,11 @@
     'category': 'Accounting',
     'summary': "Payment Acquirer: Adyen Pay by Link Patch",
     'version': '1.0',
-    'description': """ This module migrates the Adyen implementation from 
+    'description': """ This module migrates the Adyen implementation from
         the Hosted Payment Pages API to the Pay by Link API. """,
-    'depends': ['payment_adyen'],
+    'depends': ['payment_adyen',
+                'sale_block_delivery',
+                ],
     'data': [
         'data/payment_acquirer_data.xml',
         'views/payment_views.xml',

--- a/addons/payment_adyen_paybylink/__manifest__.py
+++ b/addons/payment_adyen_paybylink/__manifest__.py
@@ -1,18 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': "Adyen Payment Acquirer/Pay by Link Patch",
-    'category': 'Accounting/Payment',
+    'category': 'Accounting',
     'summary': "Payment Acquirer: Adyen Pay by Link Patch",
     'version': '1.0',
-    'description': """
-This module migrates the Adyen implementation from the Hosted Payment Pages API to the Pay by Link
-API.
-    """,
+    'description': """ This module migrates the Adyen implementation from 
+        the Hosted Payment Pages API to the Pay by Link API. """,
     'depends': ['payment_adyen'],
     'data': [
+        'data/payment_acquirer_data.xml',
         'views/payment_views.xml',
     ],
-    'post_init_hook': '_post_init_hook',
-    'auto_install': True,
+    'installable': True,
     'license': 'LGPL-3'
 }

--- a/addons/payment_adyen_paybylink/__manifest__.py
+++ b/addons/payment_adyen_paybylink/__manifest__.py
@@ -1,18 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': "Adyen Payment Acquirer/Pay by Link Patch",
-    'category': 'Accounting/Payment',
+    'category': 'Accounting',
     'summary': "Payment Acquirer: Adyen Pay by Link Patch",
     'version': '1.0',
-    'description': """
-This module migrates the Adyen implementation from the Hosted Payment Pages API to the Pay by Link
-API.
-    """,
+    'description': """ This module migrates the Adyen implementation from 
+        the Hosted Payment Pages API to the Pay by Link API. """,
     'depends': ['payment_adyen'],
     'data': [
+        'data/payment_acquirer_data.xml',
         'views/payment_views.xml',
     ],
     'post_init_hook': '_post_init_hook',
-    'auto_install': True,
+    'installable': True,
     'license': 'LGPL-3'
 }

--- a/addons/payment_adyen_paybylink/__manifest__.py
+++ b/addons/payment_adyen_paybylink/__manifest__.py
@@ -11,7 +11,6 @@
         'data/payment_acquirer_data.xml',
         'views/payment_views.xml',
     ],
-    'post_init_hook': '_post_init_hook',
     'installable': True,
     'license': 'LGPL-3'
 }

--- a/addons/payment_adyen_paybylink/const.py
+++ b/addons/payment_adyen_paybylink/const.py
@@ -1,0 +1,7 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+# Endpoints of the API.
+# See https://docs.adyen.com/api-explorer/#/CheckoutService/v68/overview for Checkout API
+API_ENDPOINT_VERSIONS = {
+    '/paymentLinks': 68,          # Checkout API
+}

--- a/addons/payment_adyen_paybylink/const.py
+++ b/addons/payment_adyen_paybylink/const.py
@@ -4,4 +4,5 @@
 # See https://docs.adyen.com/api-explorer/#/CheckoutService/v68/overview for Checkout API
 API_ENDPOINT_VERSIONS = {
     '/paymentLinks': 68,          # Checkout API
+    '/payments/{}/refunds': 69,
 }

--- a/addons/payment_adyen_paybylink/controllers/__init__.py
+++ b/addons/payment_adyen_paybylink/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/payment_adyen_paybylink/controllers/main.py
+++ b/addons/payment_adyen_paybylink/controllers/main.py
@@ -1,0 +1,135 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import pprint
+
+from werkzeug.exceptions import Forbidden
+
+from odoo.exceptions import ValidationError
+from odoo.http import request, route
+
+from odoo.addons.payment_adyen.controllers.main import AdyenController
+
+_logger = logging.getLogger(__name__)
+
+
+class AdyenPayByLinkController(AdyenController):
+
+    @route()
+    def adyen_notification(self, **post):
+        """ Process the data sent by Adyen to the webhook based on the event code.
+
+        See https://docs.adyen.com/development-resources/webhooks/understand-notifications for the
+        exhaustive list of event codes.
+
+        :return: The '[accepted]' string to acknowledge the notification
+        :rtype: str
+        """
+        _logger.info(
+            "notification received from Adyen with data:\n%s", pprint.pformat(post)
+        )
+        try:
+            # Check the integrity of the notification
+            tx_sudo = request.env['payment.transaction'].sudo()._adyen_form_get_tx_from_data(post)
+            self._verify_notification_signature(post, tx_sudo)
+
+            # Check whether the event of the notification succeeded and reshape the notification
+            # data for parsing
+            event_code = post['eventCode']
+            if event_code == 'AUTHORISATION' and post['success'] == 'true':
+                post['authResult'] = 'AUTHORISED'
+
+                # Handle the notification data
+                request.env['payment.transaction'].sudo().form_feedback(post, 'adyen')
+        except ValidationError:  # Acknowledge the notification to avoid getting spammed
+            _logger.exception("unable to handle the notification data; skipping to acknowledge")
+
+        return '[accepted]'  # Acknowledge the notification
+
+    @staticmethod
+    def _verify_notification_signature(notification_data, tx_sudo):
+        """ Check that the received signature matches the expected one.
+
+        :param dict notification_data: The notification payload containing the received signature
+        :param recordset tx_sudo: The sudoed transaction referenced by the notification data, as a
+                                  `payment.transaction` record
+        :return: None
+        :raise: :class:`werkzeug.exceptions.Forbidden` if the signatures don't match
+        """
+        # Retrieve the received signature from the payload
+        received_signature = notification_data.get('additionalData.hmacSignature')
+        if not received_signature:
+            _logger.warning("received notification with missing signature")
+            raise Forbidden()
+
+        # Compare the received signature with the expected signature computed from the payload
+        hmac_key = tx_sudo.acquirer_id.adyen_hmac_key
+        expected_signature = AdyenPayByLinkController._compute_signature(
+            notification_data, hmac_key
+        )
+        if not hmac.compare_digest(received_signature, expected_signature):
+            _logger.warning("received notification with invalid signature")
+            raise Forbidden()
+
+    @staticmethod
+    def _compute_signature(payload, hmac_key):
+        """ Compute the signature from the payload.
+
+        See https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
+
+        :param dict payload: The notification payload
+        :param str hmac_key: The HMAC key of the acquirer handling the transaction
+        :return: The computed signature
+        :rtype: str
+        """
+        def _flatten_dict(_value, _path_base='', _separator='.'):
+            """ Recursively generate a flat representation of a dict.
+
+            :param Object _value: The value to flatten. A dict or an already flat value
+            :param str _path_base: They base path for keys of _value, including preceding separators
+            :param str _separator: The string to use as a separator in the key path
+            """
+            if isinstance(_value, dict):  # The inner value is a dict, flatten it
+                _path_base = _path_base if not _path_base else _path_base + _separator
+                for _key in _value:
+                    yield from _flatten_dict(_value[_key], _path_base + str(_key))
+            else:  # The inner value cannot be flattened, yield it
+                yield _path_base, _value
+
+        def _to_escaped_string(_value):
+            """ Escape payload values that are using illegal symbols and cast them to string.
+
+            String values containing `\\` or `:` are prefixed with `\\`.
+            Empty values (`None`) are replaced by an empty string.
+
+            :param Object _value: The value to escape
+            :return: The escaped value
+            :rtype: string
+            """
+            if isinstance(_value, str):
+                return _value.replace('\\', '\\\\').replace(':', '\\:')
+            elif _value is None:
+                return ''
+            else:
+                return str(_value)
+
+        signature_keys = [
+            'pspReference', 'originalReference', 'merchantAccountCode', 'merchantReference',
+            'value', 'currency', 'eventCode', 'success'
+        ]
+        # Build the list of signature values as per the list of required signature keys
+        signature_values = [payload.get(key) for key in signature_keys]
+        # Escape values using forbidden symbols
+        escaped_values = [_to_escaped_string(value) for value in signature_values]
+        # Concatenate values together with ':' as delimiter
+        signing_string = ':'.join(escaped_values)
+        # Convert the HMAC key to the binary representation
+        binary_hmac_key = binascii.a2b_hex(hmac_key.encode('ascii'))
+        # Calculate the HMAC with the binary representation of the signing string with SHA-256
+        binary_hmac = hmac.new(binary_hmac_key, signing_string.encode('utf-8'), hashlib.sha256)
+        # Calculate the signature by encoding the result with Base64
+        return base64.b64encode(binary_hmac.digest()).decode()

--- a/addons/payment_adyen_paybylink/controllers/main.py
+++ b/addons/payment_adyen_paybylink/controllers/main.py
@@ -21,32 +21,40 @@ class AdyenPayByLinkController(AdyenController):
 
     @route()
     def adyen_notification(self, **post):
-        """ Process the data sent by Adyen to the webhook based on the event code.
+        """ Process the data sent by Adyen to the webhook based on the
+        event code.
 
-        See https://docs.adyen.com/development-resources/webhooks/understand-notifications for the
+        See https://docs.adyen.com/development-resources/
+        webhooks/understand-notifications for the
         exhaustive list of event codes.
 
         :return: The '[accepted]' string to acknowledge the notification
         :rtype: str
         """
         _logger.info(
-            "notification received from Adyen with data:\n%s", pprint.pformat(post)
+            "notification received from Adyen with data:\n%s",
+            pprint.pformat(post)
         )
         try:
             # Check the integrity of the notification
-            tx_sudo = request.env['payment.transaction'].sudo()._adyen_form_get_tx_from_data(post)
+            tx_sudo = request.env['payment.transaction'].sudo().\
+                _adyen_form_get_tx_from_data(post)
             self._verify_notification_signature(post, tx_sudo)
 
-            # Check whether the event of the notification succeeded and reshape the notification
-            # data for parsing
+            # Check whether the event of the notification succeeded and
+            # reshape the notification data for parsing
             event_code = post['eventCode']
             if event_code == 'AUTHORISATION' and post['success'] == 'true':
                 post['authResult'] = 'AUTHORISED'
 
                 # Handle the notification data
-                request.env['payment.transaction'].sudo().form_feedback(post, 'adyen')
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the notification data; skipping to acknowledge")
+                request.env['payment.transaction'].sudo().form_feedback(
+                    post, 'adyen')
+        # Acknowledge the notification to avoid getting spammed
+        except ValidationError:
+            _logger.exception(
+                "unable to handle the notification data; "
+                "skipping to acknowledge")
 
         return '[accepted]'  # Acknowledge the notification
 
@@ -54,19 +62,24 @@ class AdyenPayByLinkController(AdyenController):
     def _verify_notification_signature(notification_data, tx_sudo):
         """ Check that the received signature matches the expected one.
 
-        :param dict notification_data: The notification payload containing the received signature
-        :param recordset tx_sudo: The sudoed transaction referenced by the notification data, as a
+        :param dict notification_data: The notification payload containing the
+                                       received signature
+        :param recordset tx_sudo: The sudoed transaction referenced by
+                                  the notification data, as a
                                   `payment.transaction` record
         :return: None
-        :raise: :class:`werkzeug.exceptions.Forbidden` if the signatures don't match
+        :raise: :class:`werkzeug.exceptions.Forbidden`
+                        if the signatures don't match
         """
         # Retrieve the received signature from the payload
-        received_signature = notification_data.get('additionalData.hmacSignature')
+        received_signature = notification_data.get(
+            'additionalData.hmacSignature')
         if not received_signature:
             _logger.warning("received notification with missing signature")
             raise Forbidden()
 
-        # Compare the received signature with the expected signature computed from the payload
+        # Compare the received signature with the expected
+        # signature computed from the payload
         hmac_key = tx_sudo.acquirer_id.adyen_hmac_key
         expected_signature = AdyenPayByLinkController._compute_signature(
             notification_data, hmac_key
@@ -79,29 +92,38 @@ class AdyenPayByLinkController(AdyenController):
     def _compute_signature(payload, hmac_key):
         """ Compute the signature from the payload.
 
-        See https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
+        See https://docs.adyen.com/development-resources/
+        webhooks/verify-hmac-signatures
 
         :param dict payload: The notification payload
-        :param str hmac_key: The HMAC key of the acquirer handling the transaction
+        :param str hmac_key: The HMAC key of the acquirer handling the
+                             transaction
         :return: The computed signature
         :rtype: str
         """
         def _flatten_dict(_value, _path_base='', _separator='.'):
             """ Recursively generate a flat representation of a dict.
 
-            :param Object _value: The value to flatten. A dict or an already flat value
-            :param str _path_base: They base path for keys of _value, including preceding separators
-            :param str _separator: The string to use as a separator in the key path
+            :param Object _value: The value to flatten. A dict or an already
+                                  flat value
+            :param str _path_base: They base path for keys of _value, including
+                                   preceding separators
+            :param str _separator: The string to use as a separator in the key
+                                   path
             """
-            if isinstance(_value, dict):  # The inner value is a dict, flatten it
-                _path_base = _path_base if not _path_base else _path_base + _separator
+            # The inner value is a dict, flatten it
+            if isinstance(_value, dict):
+                _path_base = (_path_base if not _path_base else
+                              _path_base + _separator)
                 for _key in _value:
-                    yield from _flatten_dict(_value[_key], _path_base + str(_key))
+                    yield from _flatten_dict(
+                        _value[_key], _path_base + str(_key))
             else:  # The inner value cannot be flattened, yield it
                 yield _path_base, _value
 
         def _to_escaped_string(_value):
-            """ Escape payload values that are using illegal symbols and cast them to string.
+            """ Escape payload values that are using illegal symbols and cast
+            them to string.
 
             String values containing `\\` or `:` are prefixed with `\\`.
             Empty values (`None`) are replaced by an empty string.
@@ -118,18 +140,22 @@ class AdyenPayByLinkController(AdyenController):
                 return str(_value)
 
         signature_keys = [
-            'pspReference', 'originalReference', 'merchantAccountCode', 'merchantReference',
-            'value', 'currency', 'eventCode', 'success'
+            'pspReference', 'originalReference', 'merchantAccountCode',
+            'merchantReference', 'value', 'currency', 'eventCode', 'success'
         ]
-        # Build the list of signature values as per the list of required signature keys
+        # Build the list of signature values as per the list of
+        # required signature keys
         signature_values = [payload.get(key) for key in signature_keys]
         # Escape values using forbidden symbols
-        escaped_values = [_to_escaped_string(value) for value in signature_values]
+        escaped_values = [_to_escaped_string(value) for value in
+                          signature_values]
         # Concatenate values together with ':' as delimiter
         signing_string = ':'.join(escaped_values)
         # Convert the HMAC key to the binary representation
         binary_hmac_key = binascii.a2b_hex(hmac_key.encode('ascii'))
-        # Calculate the HMAC with the binary representation of the signing string with SHA-256
-        binary_hmac = hmac.new(binary_hmac_key, signing_string.encode('utf-8'), hashlib.sha256)
+        # Calculate the HMAC with the binary representation of the signing
+        # string with SHA-256
+        binary_hmac = hmac.new(binary_hmac_key, signing_string.encode('utf-8'),
+                               hashlib.sha256)
         # Calculate the signature by encoding the result with Base64
         return base64.b64encode(binary_hmac.digest()).decode()

--- a/addons/payment_adyen_paybylink/controllers/main.py
+++ b/addons/payment_adyen_paybylink/controllers/main.py
@@ -44,7 +44,7 @@ class AdyenPayByLinkController(AdyenController):
             # Check whether the event of the notification succeeded and
             # reshape the notification data for parsing
             event_code = post['eventCode']
-            if event_code == 'AUTHORISATION' and post['success'] == 'true':
+            if event_code in ('AUTHORISATION', 'REFUND') and post['success'] == 'true':
                 post['authResult'] = 'AUTHORISED'
 
                 # Handle the notification data

--- a/addons/payment_adyen_paybylink/controllers/main.py
+++ b/addons/payment_adyen_paybylink/controllers/main.py
@@ -50,6 +50,12 @@ class AdyenPayByLinkController(AdyenController):
                 # Handle the notification data
                 request.env['payment.transaction'].sudo().form_feedback(
                     post, 'adyen')
+
+            # Handle fraud cases
+            elif (event_code == 'NOTIFICATION_OF_CHARGEBACK' and
+                    post['success'] == 'true'):
+                tx_sudo.process_fraud_case(post)
+
         # Acknowledge the notification to avoid getting spammed
         except ValidationError:
             _logger.exception(

--- a/addons/payment_adyen_paybylink/data/payment_acquirer_data.xml
+++ b/addons/payment_adyen_paybylink/data/payment_acquirer_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="payment.payment_acquirer_adyen" model="payment.acquirer">
+            <field name="name">Adyen</field>
+            <field name="image" type="base64" file="payment_adyen/static/src/img/adyen_icon.png"/>
+            <field name="provider">adyen</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="environment">test</field>
+            <field name="pre_msg"><![CDATA[
+<p>You will be redirected to the Adyen website after clicking on the payment button.</p>]]></field>
+            <field name="adyen_api_key">dummy</field>
+            <field name="adyen_hmac_key">dummy</field>
+            <field name="adyen_checkout_api_url">dummy</field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/payment_adyen_paybylink/i18n/payment_adyen_paybylink.pot
+++ b/addons/payment_adyen_paybylink/i18n/payment_adyen_paybylink.pot
@@ -1,0 +1,111 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* payment_adyen_paybylink
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-02 15:44+0000\n"
+"PO-Revision-Date: 2022-06-02 15:44+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_transaction.py:0
+#, python-format
+msgid "; multiple order found"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_transaction.py:0
+#, python-format
+msgid "; no order found"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,field_description:payment_adyen_paybylink.field_payment_acquirer__adyen_api_key
+msgid "API Key"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_transaction.py:0
+#, python-format
+msgid "Adyen: received data for reference %s"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_transaction.py:0
+#, python-format
+msgid ""
+"Adyen: received data with missing reference (%s) or missing pspReference "
+"(%s)"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,field_description:payment_adyen_paybylink.field_payment_acquirer__adyen_checkout_api_url
+msgid "Checkout API URL"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_acquirer.py:0
+#, python-format
+msgid "Could not establish the connection to the API."
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,field_description:payment_adyen_paybylink.field_payment_acquirer__adyen_hmac_key
+msgid "HMAC Key"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#. openerp-web
+#: code:addons/payment_adyen_paybylink/static/src/js/adyen.js:0
+#, python-format
+msgid "Just one more second, We are redirecting you to Adyen..."
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model,name:payment_adyen_paybylink.model_payment_acquirer
+msgid "Payment Acquirer"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model,name:payment_adyen_paybylink.model_payment_transaction
+msgid "Payment Transaction"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,field_description:payment_adyen_paybylink.field_payment_acquirer__adyen_skin_code
+msgid "Skin Code"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,field_description:payment_adyen_paybylink.field_payment_acquirer__adyen_skin_hmac_key
+msgid "Skin HMAC Key"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,help:payment_adyen_paybylink.field_payment_acquirer__adyen_api_key
+msgid "The API key of the webservice user"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,help:payment_adyen_paybylink.field_payment_acquirer__adyen_hmac_key
+msgid "The HMAC key of the webhook"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: model:ir.model.fields,help:payment_adyen_paybylink.field_payment_acquirer__adyen_checkout_api_url
+msgid "The base URL for the Checkout API endpoints"
+msgstr ""
+
+#. module: payment_adyen_paybylink
+#: code:addons/payment_adyen_paybylink/models/payment_acquirer.py:0
+#, python-format
+msgid "The communication with the API failed."
+msgstr ""

--- a/addons/payment_adyen_paybylink/models/__init__.py
+++ b/addons/payment_adyen_paybylink/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import payment_acquirer
+from . import payment_transaction

--- a/addons/payment_adyen_paybylink/models/payment_acquirer.py
+++ b/addons/payment_adyen_paybylink/models/payment_acquirer.py
@@ -1,0 +1,158 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import re
+import requests
+
+from werkzeug import urls
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+from odoo.addons.payment_adyen_paybylink.const import API_ENDPOINT_VERSIONS
+
+
+_logger = logging.getLogger(__name__)
+
+
+class PaymentAcquirer(models.Model):
+    _inherit = 'payment.acquirer'
+
+    adyen_api_key = fields.Char(
+        string="API Key",
+        help="The API key of the webservice user",
+        required_if_provider='adyen',
+        groups='base.group_user',
+    )
+    adyen_hmac_key = fields.Char(
+        string="HMAC Key",
+        help="The HMAC key of the webhook",
+        required_if_provider='adyen',
+        groups='base.group_user',
+    )
+    adyen_checkout_api_url = fields.Char(
+        string="Checkout API URL",
+        help="The base URL for the Checkout API endpoints",
+        required_if_provider='adyen',
+    )
+    # We set a default for the now unused key fields rather than making them not required to avoid
+    # the error log at DB init when the ORM tries to set the 'NOT NULL' constraint on those fields.
+    adyen_skin_code = fields.Char(default="Do not use this field")
+    adyen_skin_hmac_key = fields.Char(default="Do not use this field")
+
+    @api.model_create_multi
+    def create(self, values_list):
+        for values in values_list:
+            self._adyen_trim_api_urls(values)
+        return super().create(values_list)
+
+    def write(self, values):
+        self._adyen_trim_api_urls(values)
+        # We set a default for the now unused key fields rather than making them not required to
+        # avoid the error log at DB init when the ORM tries to set the 'NOT NULL' constraint on
+        # those fields.
+        values.update(
+            adyen_skin_code="Do not use this field",
+            adyen_skin_hmac_key="Do not use this field",
+        )
+        return super().write(values)
+
+    @api.model
+    def _adyen_trim_api_urls(self, values):
+        """ Remove the version and the endpoint from the url of Adyen API fields.
+
+        :param dict values: The create or write values
+        :return: None
+        """
+        # Test the value in case we're duplicating an acquirer
+        if values.get('adyen_checkout_api_url'):
+            values['adyen_checkout_api_url'] = re.sub(
+                r'[vV]\d+(/.*)?', '', values['adyen_checkout_api_url']
+            )
+
+    def adyen_form_generate_values(self, values):
+        base_url = self.get_base_url()
+
+        payment_amount = self._adyen_convert_amount(values['amount'], values['currency'])
+        values['adyen_paybylink_data'] = {
+            'reference': values['reference'],
+            'amount': {
+                'value': '%d' % payment_amount,
+                'currency': values['currency'] and values['currency'].name or '',
+            },
+            'merchantAccount': self.adyen_merchant_account,
+            'shopperLocale': values.get('partner_lang', ''),
+            'returnUrl': urls.url_join(base_url, '/payment/process'),
+            'shopperEmail': values.get('partner_email') or values.get('billing_partner_email', ''),
+        }
+
+        return values
+
+    def adyen_get_form_action_url(self):
+        """ Override of adyen_get_form_action_url """
+        form_action_url_values = self._context.get('form_action_url_values')
+        if form_action_url_values:
+            return self._adyen_get_paybylink(form_action_url_values['adyen_paybylink_data'])
+        return False
+
+    def _adyen_get_paybylink(self, data):
+        paybylink_response = self._adyen_make_request(
+            url_field_name='adyen_checkout_api_url',
+            endpoint='/paymentLinks',
+            payload=data,
+        )
+        return paybylink_response['url']
+
+    def _adyen_make_request(
+        self, url_field_name, endpoint, endpoint_param=None, payload=None, method='POST'
+    ):
+        """ Make a request to Adyen API at the specified endpoint.
+
+        Note: self.ensure_one()
+
+        :param str url_field_name: The name of the field holding the base URL for the request
+        :param str endpoint: The endpoint to be reached by the request
+        :param str endpoint_param: A variable required by some endpoints which are interpolated with
+                                   it if provided. For example, the acquirer reference of the source
+                                   transaction for the '/payments/{}/refunds' endpoint.
+        :param dict payload: The payload of the request
+        :param str method: The HTTP method of the request
+        :return: The JSON-formatted content of the response
+        :rtype: dict
+        :raise: ValidationError if an HTTP error occurs
+        """
+
+        def _build_url(_base_url, _version, _endpoint):
+            """ Build an API URL by appending the version and endpoint to a base URL.
+
+            The final URL follows this pattern: `<_base>/V<_version>/<_endpoint>`.
+
+            :param str _base_url: The base of the url prefixed with `https://`
+            :param int _version: The version of the endpoint
+            :param str _endpoint: The endpoint of the URL.
+            :return: The final URL
+            :rtype: str
+            """
+            _base = _base_url.rstrip('/')  # Remove potential trailing slash
+            _endpoint = _endpoint.lstrip('/')  # Remove potential leading slash
+            return f'{_base}/V{_version}/{_endpoint}'
+
+        self.ensure_one()
+
+        base_url = self[url_field_name]  # Restrict request URL to the stored API URL fields
+        version = API_ENDPOINT_VERSIONS[endpoint]
+        endpoint = endpoint if not endpoint_param else endpoint.format(endpoint_param)
+        url = _build_url(base_url, version, endpoint)
+        headers = {'X-API-Key': self.adyen_api_key}
+        try:
+            response = requests.request(method, url, json=payload, headers=headers, timeout=60)
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError:
+            _logger.exception("unable to reach endpoint at %s", url)
+            raise ValidationError("Adyen: " + _("Could not establish the connection to the API."))
+        except requests.exceptions.HTTPError as error:
+            _logger.exception(
+                "invalid API request at %s with data %s: %s", url, payload, error.response.text
+            )
+            raise ValidationError("Adyen: " + _("The communication with the API failed."))
+        return response.json()

--- a/addons/payment_adyen_paybylink/models/payment_transaction.py
+++ b/addons/payment_adyen_paybylink/models/payment_transaction.py
@@ -1,0 +1,49 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+_logger = logging.getLogger(__name__)
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    # --------------------------------------------------
+    # FORM RELATED METHODS
+    # --------------------------------------------------
+
+    @api.model
+    def _adyen_form_get_tx_from_data(self, data):
+        """ Override of _adyen_form_get_tx_from_data """
+        reference, psp_reference = data.get('merchantReference'), data.get('pspReference')
+        if not reference or not psp_reference:
+            error_msg = _(
+                "Adyen: received data with missing reference (%s) or missing pspReference (%s)"
+            ) % (reference, psp_reference)
+            _logger.info(error_msg)
+            raise ValidationError(error_msg)
+
+        tx = self.env['payment.transaction'].search([
+            ('reference', '=', reference), ('provider', '=', 'adyen')
+        ])
+        if not tx or len(tx) > 1:
+            error_msg = _("Adyen: received data for reference %s") % reference
+            if not tx:
+                error_msg += _("; no order found")
+            else:
+                error_msg += _("; multiple order found")
+            _logger.info(error_msg)
+            raise ValidationError(error_msg)
+
+        return tx
+
+    def _adyen_form_get_invalid_parameters(self, data):
+        """ Override of _adyen_form_get_invalid_parameters to disable this method.
+
+        The pay-by-link implementation doesn't need or want to check for invalid parameters.
+        """
+        return []

--- a/addons/payment_adyen_paybylink/models/payment_transaction.py
+++ b/addons/payment_adyen_paybylink/models/payment_transaction.py
@@ -19,10 +19,12 @@ class PaymentTransaction(models.Model):
     @api.model
     def _adyen_form_get_tx_from_data(self, data):
         """ Override of _adyen_form_get_tx_from_data """
-        reference, psp_reference = data.get('merchantReference'), data.get('pspReference')
+        reference = data.get('merchantReference')
+        psp_reference = data.get('pspReference')
         if not reference or not psp_reference:
             error_msg = _(
-                "Adyen: received data with missing reference (%s) or missing pspReference (%s)"
+                "Adyen: received data with missing reference (%s) or "
+                "missing pspReference (%s)"
             ) % (reference, psp_reference)
             _logger.info(error_msg)
             raise ValidationError(error_msg)
@@ -42,8 +44,10 @@ class PaymentTransaction(models.Model):
         return tx
 
     def _adyen_form_get_invalid_parameters(self, data):
-        """ Override of _adyen_form_get_invalid_parameters to disable this method.
+        """ Override of _adyen_form_get_invalid_parameters to disable
+        this method.
 
-        The pay-by-link implementation doesn't need or want to check for invalid parameters.
+        The pay-by-link implementation doesn't need or want to check for
+        invalid parameters.
         """
         return []

--- a/addons/payment_adyen_paybylink/readme/CONTRIBUTORS.rst
+++ b/addons/payment_adyen_paybylink/readme/CONTRIBUTORS.rst
@@ -1,0 +1,5 @@
+This module is a backport from Odoo SA and as such, it is not included in the 
+OCA CLA. That means we do not have a copy of the copyright on it like all other 
+OCA modules.
+
+* Valentin Chevalier <contact@chevalierv.be>

--- a/addons/payment_adyen_paybylink/tests/__init__.py
+++ b/addons/payment_adyen_paybylink/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_webhooks

--- a/addons/payment_adyen_paybylink/tests/test_webhooks.py
+++ b/addons/payment_adyen_paybylink/tests/test_webhooks.py
@@ -1,0 +1,126 @@
+# © 2019 - 2021 Vanmoof BV (<https://www.vanmoof.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import mock
+import requests
+from odoo.tests import tagged
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase
+
+@tagged("post_install", "-at_install")
+class TestAdyenWebhooks(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.config = cls.env["payment.acquirer"].create(
+            {
+                "name": __name__,
+                "provider": "adyen",
+                "environment": "test",
+                "adyen_valid_for_days": 10,
+                "adyen_skin_code": "obsolete_dummy",
+                "adyen_skin_hmac_key": "obsolete_dummy",
+                "adyen_merchant_account": "VANMOOF_NL",
+                "adyen_api_key": "a_very_long_key",
+                "adyen_checkout_api_url": "https://adyen",
+                "adyen_hmac_key": "42",
+                "company_id": cls.env.ref("base.main_company").id,
+            }
+        )
+
+        cls.so = cls.env.ref('sale.sale_order_8')
+        # create payment transaction
+        values = {
+            "acquirer_id": cls.config.id,
+            "reference": cls.so.name,
+            "amount": 201,
+            "currency_id": cls.env.ref("base.GBP").id,
+            "partner_id": cls.env.ref("base.res_partner_12").id,
+            "type": "form",
+            "sale_order_ids": [(6, 0, cls.so.ids)]
+        }
+        cls.transaction = (
+            cls.env["payment.transaction"].sudo().with_context(
+                lang=None).create(values)
+        )
+
+    def test_fraud_notification(self):
+        """Test the webhook by simulating Adyen sending us a open dispute
+        notification. Cancel Order cae
+         'eventCode': 'NOTIFICATION_OF_CHARGEBACK',
+        """
+        self.assertEqual(self.transaction.state, "draft")
+
+        # mock adyen webhook response for authorized transaction
+        base_url = self.env["ir.config_parameter"].get_param("web.base.url")
+        url = base_url + "/payment/adyen/notification"
+        payload = (
+            "additionalData.autoDefended=false&"
+            "additionalData.chargebackReasonCode=10.4&"
+            "additionalData.chargebackSchemeCode=visa&"
+            "additionalData.defendable=true&"
+            "additionalData.defensePeriodEndsAt=2023-01-24T12:17:23+01:00&"
+            "additionalData.disputeStatus=Undefended&"
+            "additionalData.hmacSignature=xxx&"
+            "currency=EUR&"
+            "eventCode=NOTIFICATION_OF_CHARGEBACK&"
+            "eventDate=2022-09-26T10:17:23.00Z&"
+            "live=false&"
+            "merchantAccountCode=VANMOOF_NL&"
+            "merchantReference={merchantReference}&"
+            "operations=&"
+            "originalReference=NXDJ258MG5BV9D82&"
+            "paymentMethod=visa&"
+            "pspReference=8626641874058257&"
+            "reason=Other Fraud-Card Absent Environment&"
+            "success=true&"
+            "value=1000"
+        ).format(merchantReference=self.so.name)
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        # mock where we search for the transaction beacuse tests run in a
+        # separate transaction from the requests.request() call. Because of
+        # this you will never find the transaction created above.
+        mock_method = (
+            "odoo.addons.payment_adyen_paybylink.models."
+            "payment_transaction.PaymentTransaction."
+            "_adyen_form_get_tx_from_data"
+        )
+        with mock.patch(mock_method) as mock_func:
+            mock_func.return_value = self.transaction
+
+            # mock the function where we check the HMAC signature of the
+            # message. Now we can send any message without calculate
+            # message the signature
+            mock_hmac_signature = (
+                "odoo.addons.payment_adyen_paybylink."
+                "controllers.main.AdyenPayByLinkController."
+                "_verify_notification_signature"
+            )
+            with mock.patch(mock_hmac_signature) as mock_signature:
+                mock_signature.return_value = True
+
+                response = requests.request(
+                    "POST", url, headers=headers, data=payload)
+
+        self.assertEqual(response.text, "[accepted]")
+        self.assertEqual(response.status_code, 200)
+
+        self.transaction.refresh()
+        self.assertEqual(self.transaction.state, "cancel")
+        self.assertEqual(self.transaction.sale_order_ids.state, 'cancel')
+
+        # does the transaction state message contain all of the elements
+        for message_element in ['NOTIFICATION_OF_CHARGEBACK',
+                                self.so.name,
+                                '10.4',
+                                'Other Fraud-Card Absent Environment']:
+            self.assertTrue(message_element in self.transaction.state_message)
+
+        # does the Sale Order have the cancel message posted
+        cancel_message_posted = False
+        for posted_message in self.so.message_ids:
+            if 'NOTIFICATION_OF_CHARGEBACK' in posted_message.body:
+                cancel_message_posted = True
+        self.assertTrue(cancel_message_posted)

--- a/addons/payment_adyen_paybylink/views/payment_views.xml
+++ b/addons/payment_adyen_paybylink/views/payment_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="acquirer_form_adyen" model="ir.ui.view">
+            <field name="name">acquirer.form.adyen</field>
+            <field name="model">payment.acquirer</field>
+            <field name="inherit_id" ref="payment.acquirer_form"/>
+            <field name="arch" type="xml">
+                <xpath expr='//field[@name="adyen_merchant_account"]' position='after'>
+                    <field name="adyen_api_key"
+                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           password="True"/>
+                    <field name="adyen_hmac_key"
+                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           password="True"/>
+                    <field name="adyen_checkout_api_url"
+                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                </xpath>
+                <xpath expr="//field[@name='adyen_skin_code']" position='replace'></xpath>
+                <xpath expr="//field[@name='adyen_skin_hmac_key']" position='replace'></xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/payment_adyen_paybylink/views/payment_views.xml
+++ b/addons/payment_adyen_paybylink/views/payment_views.xml
@@ -5,17 +5,17 @@
         <record id="acquirer_form_adyen" model="ir.ui.view">
             <field name="name">acquirer.form.adyen</field>
             <field name="model">payment.acquirer</field>
-            <field name="inherit_id" ref="payment.acquirer_form"/>
+            <field name="inherit_id" ref="payment_adyen.acquirer_form_adyen"/>
             <field name="arch" type="xml">
                 <xpath expr='//field[@name="adyen_merchant_account"]' position='after'>
                     <field name="adyen_api_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           attrs="{'required':[('provider', '=', 'adyen')]}"
                            password="True"/>
                     <field name="adyen_hmac_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           attrs="{'required':[('provider', '=', 'adyen')]}"
                            password="True"/>
                     <field name="adyen_checkout_api_url"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                           attrs="{'required':[('provider', '=', 'adyen')]}"/>
                 </xpath>
                 <xpath expr="//field[@name='adyen_skin_code']" position='replace'></xpath>
                 <xpath expr="//field[@name='adyen_skin_hmac_key']" position='replace'></xpath>

--- a/addons/payment_adyen_paybylink/views/payment_views.xml
+++ b/addons/payment_adyen_paybylink/views/payment_views.xml
@@ -5,17 +5,17 @@
         <record id="acquirer_form_adyen" model="ir.ui.view">
             <field name="name">acquirer.form.adyen</field>
             <field name="model">payment.acquirer</field>
-            <field name="inherit_id" ref="payment.acquirer_form"/>
+            <field name="inherit_id" ref="payment_adyen.acquirer_form_adyen"/>
             <field name="arch" type="xml">
                 <xpath expr='//field[@name="adyen_merchant_account"]' position='after'>
                     <field name="adyen_api_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"
                            password="True"/>
                     <field name="adyen_hmac_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"
+                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"
                            password="True"/>
                     <field name="adyen_checkout_api_url"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('state', '!=', 'disabled')]}"/>
+                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"/>
                 </xpath>
                 <xpath expr="//field[@name='adyen_skin_code']" position='replace'></xpath>
                 <xpath expr="//field[@name='adyen_skin_hmac_key']" position='replace'></xpath>

--- a/addons/payment_adyen_paybylink/views/payment_views.xml
+++ b/addons/payment_adyen_paybylink/views/payment_views.xml
@@ -9,13 +9,13 @@
             <field name="arch" type="xml">
                 <xpath expr='//field[@name="adyen_merchant_account"]' position='after'>
                     <field name="adyen_api_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"
+                           attrs="{'required':[('provider', '=', 'adyen')]}"
                            password="True"/>
                     <field name="adyen_hmac_key"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"
+                           attrs="{'required':[('provider', '=', 'adyen')]}"
                            password="True"/>
                     <field name="adyen_checkout_api_url"
-                           attrs="{'required':[('provider', '=', 'adyen'), ('website_published', '!=', False)]}"/>
+                           attrs="{'required':[('provider', '=', 'adyen')]}"/>
                 </xpath>
                 <xpath expr="//field[@name='adyen_skin_code']" position='replace'></xpath>
                 <xpath expr="//field[@name='adyen_skin_hmac_key']" position='replace'></xpath>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Adyen has moved away from HPP to Pay By Link API. This module is a back-port from Odoo SA payment_adyen_paybylink for version 13.0

Current behavior before PR: Adyen will stop sporting HPP soon

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
