### PR TITLE
[15.0] add pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include requirements.txt
 include LICENSE
 include README.md
+include pyproject.toml
+include setup/pep517_odoo.py
 graft odoo
 recursive-exclude * *.py[co]
 recursive-exclude .git *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=41"]
+build-backend = "pep517_odoo"
+backend-path = ["setup"]

--- a/setup/pep517_odoo.py
+++ b/setup/pep517_odoo.py
@@ -1,0 +1,44 @@
+"""Specialized PEP 517 build backend for Odoo.
+
+It is based on setuptools, and the only thing it does differently from
+setuptools is to symlink all addons into odoo/addons before building,
+so setuptools discovers them automatically.
+"""
+import contextlib
+from pathlib import Path
+
+from setuptools import build_meta
+from setuptools.build_meta import *
+
+
+@contextlib.contextmanager
+def _symlink_addons():
+    symlinks = []
+    try:
+        target_addons_path = Path("addons")
+        addons_path = Path("odoo") / "addons"
+        link_target = Path("..") / ".." / "addons"
+        if target_addons_path.is_dir():
+            for target_addon_path in target_addons_path.iterdir():
+                if not target_addon_path.is_dir():
+                    continue
+                addon_path = addons_path / target_addon_path.name
+                if not addon_path.is_symlink():
+                    addon_path.symlink_to(
+                        link_target / target_addon_path.name, target_is_directory=True
+                    )
+                symlinks.append(addon_path)
+        yield
+    finally:
+        for symlink in symlinks:
+            symlink.unlink()
+
+
+def build_sdist(*args, **kwargs):
+    with _symlink_addons():
+        return build_meta.build_sdist(*args, **kwargs)
+
+
+def build_wheel(*args, **kwargs):
+    with _symlink_addons():
+        return build_meta.build_wheel(*args, **kwargs)

--- a/setup/pep517_odoo.py
+++ b/setup/pep517_odoo.py
@@ -42,3 +42,21 @@ def build_sdist(*args, **kwargs):
 def build_wheel(*args, **kwargs):
     with _symlink_addons():
         return build_meta.build_wheel(*args, **kwargs)
+
+
+if hasattr(build_meta, "build_editable"):
+
+    def build_editable(
+        wheel_directory, config_settings=None, metadata_directory=None, **kwargs
+    ):
+        if config_settings is None:
+            config_settings = {}
+        # Use setuptools's compat editable mode, because the default mode for
+        # flat layout projects is not compatible with pkgutil.extend_path,
+        # and the strict mode is too strict for the Odoo development workflow
+        # where new files are added frequently. This is currently being discussed
+        # by the setuptools maintainers.
+        config_settings["editable-mode"] = "compat"
+        return build_meta.build_editable(
+            wheel_directory, config_settings, metadata_directory, **kwargs
+        )


### PR DESCRIPTION
Add a `pyproject.toml` so `pip install .` works as well as `pip install -e .`.

Upstream PR https://github.com/odoo/odoo/pull/44001.