### PR TITLE
[15.0][IMP] core: add odoo.__main__

### DIFF
--- a/odoo/__main__.py
+++ b/odoo/__main__.py
@@ -1,0 +1,3 @@
+from .cli.command import main
+
+main()


### PR DESCRIPTION
This allows launching Odoo with "python -m odoo".

This manner of launching python application is now widespread. In particular it makes it easier to configure an IDE debugger to run with the correct python version.

Upstream PR: https://github.com/odoo/odoo/pull/81864