### PR TITLE
BUG FIX models.py

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2501,13 +2501,14 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         cr = self._cr
         cols = [name for name, field in self._fields.items()
                      if field.store and field.column_type]
-        cr.execute("SELECT a.attname, a.attnotnull"
-                   "  FROM pg_class c, pg_attribute a"
+   cr.execute("SELECT a.attname, a.attnotnull"
+                   "  FROM pg_class c JOIN pg_namespace n ON (n.oid = c.relnamespace), pg_attribute a"
                    " WHERE c.relname=%s"
                    "   AND c.oid=a.attrelid"
                    "   AND a.attisdropped=%s"
                    "   AND pg_catalog.format_type(a.atttypid, a.atttypmod) NOT IN ('cid', 'tid', 'oid', 'xid')"
-                   "   AND a.attname NOT IN %s", (self._table, False, tuple(cols))),
+                   "   AND a.attname NOT IN %s"
+                   "   AND n.nspname = current_schema", (self._table, False, tuple(cols))),
 
         for row in cr.dictfetchall():
             if log:


### PR DESCRIPTION
This is a FIX for allow Odoo to work alongside with FDW Foreign Data Wrapper normal and common in ERP Implementation. This function allow to filter only the public schema related to Odoo and not use FDW Schema (even if they have the same name)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
