### PR TITLE
[14.0][FIX] account: Fix duplicate move line creation

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1014,6 +1014,8 @@ class AccountBankStatementLine(models.Model):
 
         for st_line in self.with_context(skip_account_move_synchronization=True):
             liquidity_lines, suspense_lines, other_lines = st_line._seek_for_lines()
+            if not liquidity_lines:
+                continue
             company_currency = st_line.journal_id.company_id.currency_id
             journal_currency = st_line.journal_id.currency_id if st_line.journal_id.currency_id != company_currency else False
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I've noticed in the OpenUpgrade migration from 13->14, that some move lines were being duplicated. However, this did not necessarily seem to be a migration script issue.

Current behavior before PR:
Move lines get duplicated.

Desired behavior after PR is merged:
Move lines don't get duplicated.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
