### PR TITLE
[14.0] account: allow OCA localization modules

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -42,7 +42,9 @@ def _auto_install_l10n(env):
             module_list.append('l10n_de_skr03')
             module_list.append('l10n_de_skr04')
         else:
-            if env['ir.module.module'].search([('name', '=', 'l10n_' + country_code.lower())]):
+            if env['ir.module.module'].search([('name', '=', 'l10n_%s_oca' % country_code.lower())]):
+                module_list.append('l10n_%s_oca' % country_code.lower())
+            elif env['ir.module.module'].search([('name', '=', 'l10n_' + country_code.lower())]):
                 module_list.append('l10n_' + country_code.lower())
             else:
                 module_list.append('l10n_generic_coa')


### PR DESCRIPTION
This commit allows to have a fork of a localization module in OCA under a different name (adding '_oca' suffix).

The post-install script of the account module installs localization modules corresponding to the country of the company:
1) first, tries to find a module l10n_xx_oca
2) then tries to find a module l10n_xx
where xx is the country code.