### PR TITLE
FIX: boolean_toggle: prevent value change readonly

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -3004,7 +3004,7 @@ var BooleanToggle = FieldBoolean.extend({
      */
     _onClick: async function (event) {
         event.stopPropagation();
-        if (!this.$input.prop('disabled')) {
+        if (!this.$input.prop('disabled') && this.mode !== "readonly") {
             await this._setValue(!this.value);
             this._render();
         }


### PR DESCRIPTION
Before this fix, when you are on readonly mode in a form view and you click on a boolean field that has the widget boolean_toggle: 
1. you go on edit mode
2. the boolean value is changed immediatly

Behaviour when  you click on a boolean field without the widget boolean_toggle:
1. you go on edit mode
2. the boolean value is changed when you click again on the boolean field

With this fix, we get back to the "normal" behaviour.

upstream PR: 
https://github.com/odoo/odoo/pull/106004
