### PR TITLE
[13.0][FIX] point_of_sale: backport browser ticket printing fixes

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1483,8 +1483,11 @@ td {
     body * {
         visibility: hidden;
     }
+    .pos, .pos * {
+        position: static !important;
+    }
     .pos .receipt-screen .pos-receipt-container {
-        position: fixed;
+        position: absolute !important;
         top: 0;
         left: 0;
     }
@@ -1494,7 +1497,7 @@ td {
         color: black !important;
     }
     .pos .pos-receipt {
-        margin: 0;
+        margin: 0 !important;
         margin-left: auto !important;
         margin-right: auto !important;
         border: none !important;

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1491,7 +1491,7 @@ td {
         top: 0;
         left: 0;
     }
-    .pos .receipt-screen .pos-receipt-container * {
+    .pos .receipt-screen .pos-receipt-container, .pos .receipt-screen .pos-receipt-container  * {
         visibility: visible;
         background: white !important;
         color: black !important;

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1480,82 +1480,26 @@ td {
 }
 
 @media print {
-    * {
+    body * {
+        visibility: hidden;
+    }
+    .pos .receipt-screen .pos-receipt-container {
+        position: fixed;
+        top: 0;
+        left: 0;
+    }
+    .pos .receipt-screen .pos-receipt-container * {
+        visibility: visible;
+        background: white !important;
         color: black !important;
     }
-    body {
-        margin: 0;
-        color: white !important;
-        /* avoid black background if backgrounds are printed */
-        background: initial;
-    }
-    .o_notification_manager,
-    .oe_leftbar,
-    .oe_loading,
-    .pos .pos-topheader, 
-    .pos .pos-leftpane, 
-    .pos .keyboard_frame,
-    .pos .receipt-screen header,
-    .pos .receipt-screen .top-content,
-    .pos .receipt-screen .centered-content .button,
-    .pos .receipt-screen .centered-content .print_invoice {
-        display: none !important;
-    }
-    .pos,
-    .pos .pos-content,
-    .pos .rightpane,
-    .pos .screen, 
-    .pos .window, 
-    .pos .window .subwindow, 
-    .pos .subwindow .subwindow-container{
-        display: block;
-        position: static;
-        height: auto;
-    }
-    .pos{
-        background: white !important;
-    }
-    .pos .rightpane {
-        left: 0px !important;
-        background-color: white;
-    }
-    .pos .receipt-screen {
-        text-align: left;
-    }
-    .pos .receipt-screen .centered-content{
-        position: static;
-        border: none;
-    }
-    .pos .pos-receipt-container {
-        text-align: left;
-    }
-    .pos-actionbar {
-        display: none !important;
-    }
-    .debug-widget{
-        display: none !important;
-    }
-    .pos *{
-        text-shadow: none !important;
-        box-shadow: none !important;
-        background: transparent !important;
-    }
-    .pos .pos-receipt{
+    .pos .pos-receipt {
         margin: 0;
         margin-left: auto !important;
         margin-right: auto !important;
         border: none !important;
         font-size: 13px !important;
         width: 266px !important;
-    }
-    .o_debug_manager {
-        display: none !important;
-    }
-    .o_chat_window {
-        display: none !important;
-    }
-    .blockUI {
-        display: none !important;
     }
 }
 

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1480,6 +1480,9 @@ td {
 }
 
 @media print {
+    body {
+        background: white;
+    }
     body * {
         visibility: hidden;
     }


### PR DESCRIPTION
There are several issues with the PoS ticket printing via browser addressed from 14.0 and beyond. Those are related to the css definitions for the `@media print`.

For example, this one with the recepits cut in the browser:

![image](https://user-images.githubusercontent.com/5040182/208158300-46db4411-76d7-4e42-b75b-9c755415eec2.png)

cc @Tecnativa TT40784

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
