### PR TITLE
[12.0][FIX] base: add missing formatter in italian translated string

### DIFF
--- a/odoo/addons/base/i18n/it.po
+++ b/odoo/addons/base/i18n/it.po
@@ -14065,7 +14065,7 @@ msgstr "Il campo \"Type\" non può essere modificato nei modelli."
 #: code:addons/base/models/ir_ui_view.py:1090
 #, python-format
 msgid "Field %r used in attributes must be present in view but is missing:"
-msgstr "Campo % usato negli attributi mancante, è obbligatorio nella vista:"
+msgstr "Campo %r usato negli attributi mancante, è obbligatorio nella vista:"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_model_fields__help


### PR DESCRIPTION
The missing python formatter in the translated string causes all sorts of errors, especially when migrating to a higher version. 

```
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1008, in postprocess_and_fields
    msg_lines.append(msg_fmt % name)
odoo.tools.convert.ParseError: "%u format: a number is required, not str"
```

Normally I wouldn't bother fixing the translation of an old version, but in this case it kept me from migrating at all.

So many hours of my life I'll never get back. Hopefully nobody else will have to go through that as well.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
