### PR TITLE
[14.0][REF] mail: make activity_user_type not required on ir.actions.server…

### DIFF
--- a/addons/mail/models/ir_actions.py
+++ b/addons/mail/models/ir_actions.py
@@ -41,7 +41,7 @@ class ServerActions(models.Model):
     ], string='Due type', default='days')
     activity_user_type = fields.Selection([
         ('specific', 'Specific User'),
-        ('generic', 'Generic User From Record')], default="specific", required=True,
+        ('generic', 'Generic User From Record')], default="specific",
         help="Use 'Specific User' to always assign the same user on the next activity. Use 'Generic User From Record' to specify the field name of the user to choose on the record.")
     activity_user_id = fields.Many2one('res.users', string='Responsible')
     activity_user_field_name = fields.Char('User field name', help="Technical name of the user on the record", default="user_id")

--- a/addons/mail/views/ir_actions_views.xml
+++ b/addons/mail/views/ir_actions_views.xml
@@ -22,7 +22,9 @@
                                         'required': [('state', '=', 'next_activity'), ('activity_date_deadline_range', '>', 0)]
                                     }"/>
                                 </div>
-                                <field name="activity_user_type"/>
+                                <field name="activity_user_type" attrs="{
+                                    'required': [('state', '=', 'next_activity')]
+                                }"/>
                                 <field name="activity_user_field_name" attrs="{
                                     'invisible': [('activity_user_type', '=', 'specific')],
                                     'required': [('state', '=', 'next_activity'), ('activity_user_type', '=', 'generic')]


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/61769

… model

PURPOSE

Required fields are annoying, notably when dealing with tests or xml-based data to create in concurrent modules. For example ModuleA adds a required field on Model. ModuleB that does not depend on ModuleA tries to create a data of Model. Currently it crashes as field is required but default is not provided if ModuleA is not loaded in registry.

SPECIFICATIONS

Field activity_user_type on ir.actions.server model in mail is currently required. This field is however not really required as its use is limited to actions linked to activities. Remove the hard required and put it only in views.

If no value is given due to some bad configuration no responsible will be set.

Followup of odoo/odoo@730998142678dc753fc77fb95df1643d0ccb7526

LINKS

Task ID-2367655

closes odoo/odoo#61769

Signed-off-by: Thibault Delavallee (tde) <tde@openerp.com>







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
