### PR TITLE
[15.0][FIX] web:select layouts

### DIFF
--- a/addons/web/static/lib/bootstrap/scss/_variables.scss
+++ b/addons/web/static/lib/bootstrap/scss/_variables.scss
@@ -1119,5 +1119,5 @@ $positions: static, relative, absolute, fixed, sticky !default;
 
 // Printing
 
-$print-page-size:                   a3 !default;
+$print-page-size:                   a3 auto;
 $print-body-min-width:              map-get($grid-breakpoints, "lg") !default;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When printing from Google Chrome using Bootstrap 3, the Chrome print settings has a Layout option. Simply changing the css/js to Bootstrap 4 with, the Chrome print settings no longer has the Layout option.

Current behavior before PR:
Chrome print settings no longer has the Layout option

Desired behavior after PR is merged:
Chrome print settings has a Layout option.

![2022-11-28_17h08_00](https://user-images.githubusercontent.com/101688144/204225770-6b66a2a9-9de9-4d40-b969-aed5e14c06b8.png)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
