### PR TITLE
[FIX] Handle 0% tax on POS

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1787,7 +1787,7 @@ exports.Orderline = Backbone.Model.extend({
                 var tax_amount = self._compute_all(tax, base, quantity);
                 tax_amount = round_pr(tax_amount, currency_rounding);
 
-                if (tax_amount){
+                if (tax){
                     if (tax.price_include) {
                         total_excluded -= tax_amount;
                         base -= tax_amount;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes the behavior described at https://github.com/OCA/OCB/issues/1152

Current behavior before PR:

0% VAT taxes are ignored in POS invoices.

Desired behavior after PR is merged:

POS-generated invoices and electronic invoices reflects now the applied tax.


---
(Pending:  I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr)
