### PR TITLE
[12.0] [IMP] xlrd python 3.8+ compatibility

### DIFF
--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import _monkeypatches
 from . import pycompat
 from . import win32
 from . import appdirs

--- a/odoo/tools/_monkeypatches.py
+++ b/odoo/tools/_monkeypatches.py
@@ -1,0 +1,15 @@
+from xlrd import xlsx
+from lxml import etree
+
+# xlrd.xlsx supports defusedxml, defusedxml's etree interface is broken
+# (missing ElementTree and thus ElementTree.iter) which causes a fallback to
+# Element.getiterator(), triggering a warning before 3.9 and an error from 3.9.
+#
+# We have defusedxml installed because zeep has a hard dep on defused and
+# doesn't want to drop it (mvantellingen/python-zeep#1014).
+#
+# Ignore the check and set the relevant flags directly using lxml as we have a
+# hard dependency on it.
+xlsx.ET = etree
+xlsx.ET_has_iterparse = True
+xlsx.Element_has_iter = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,5 +43,6 @@ Werkzeug==0.11.15 ; sys_platform != 'win32'
 Werkzeug==0.16.0  ; sys_platform == 'win32'
 XlsxWriter==0.9.3
 xlwt==1.3.*
-xlrd==1.0.0
+xlrd==1.1.0; python_version < '3.8'
+xlrd==1.2.0; python_version >= '3.8'
 pypiwin32 ; sys_platform == 'win32'


### PR DESCRIPTION
As of odoo v14 and [this commit](https://github.com/odoo/odoo/commit/648635deca67df09417ae55c6eb181c98524b74d), xlrd requirements have been updated to support python 3.8+
I propose to adapt xlrd requirements for odoo v12 the same way.