### PR TITLE
[ADD] product: Added index on field `product_id` of `product.price.history`

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -75,7 +75,7 @@ class ProductPriceHistory(models.Model):
 
     company_id = fields.Many2one('res.company', string='Company',
         default=_get_default_company_id, required=True)
-    product_id = fields.Many2one('product.product', 'Product', ondelete='cascade', required=True)
+    product_id = fields.Many2one('product.product', 'Product', ondelete='cascade', required=True, index=True)
     datetime = fields.Datetime('Date', default=fields.Datetime.now)
     cost = fields.Float('Cost', digits=dp.get_precision('Product Price'))
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The `product_price_history` table doesn't have any indexes (except on `id`). However, in a DB we have experimented with, the following query took way too long: https://github.com/OCA/OpenUpgrade/blob/f6e1297866e4a4e2d9cf2e6d6cd42465188d7fd5/addons/stock_account/migrations/13.0.1.1/post-migration.py#L94
The query is part of the openupgrade script to 13.0.

The migration of module `stock_account` took over 48 hours for us, and it has taken me less than 10 minutes with this index. Here is the `explain analyze` of results of one execution of the query:
```
EXPLAIN ANALYSE SELECT pph.id, pph.company_id, pph.product_id, pph.datetime, pph.cost, 1 AS account_move_id,
            pph.create_uid, pph.create_date, pph.write_uid, pph.write_date
        FROM product_price_history pph
        WHERE pph.company_id = 1 AND pph.product_id = 1
        ORDER BY pph.datetime, pph.id
;
                                                                      QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Merge  (cost=480793.87..481015.78 rows=1902 width=51) (actual time=2832.951..2848.068 rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 1
   ->  Sort  (cost=479793.84..479796.22 rows=951 width=51) (actual time=2814.552..2814.553 rows=0 loops=2)
         Sort Key: datetime, id
         Sort Method: quicksort  Memory: 25kB
         Worker 0:  Sort Method: quicksort  Memory: 25kB
         ->  Parallel Seq Scan on product_price_history pph  (cost=0.00..479746.80 rows=951 width=51) (actual time=1573.643..2814.465 rows=0 loops=2)
               Filter: ((company_id = 1) AND (product_id = 1))
               Rows Removed by Filter: 13550654
 Planning Time: 0.088 ms
 JIT:
   Functions: 9
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 1.435 ms, Inlining 0.000 ms, Optimization 0.776 ms, Emission 12.072 ms, Total 14.283 ms
 Execution Time: 2848.696 ms
(16 rows)
```
Now, imagine executing this query about 77k times for the migration.
Adding the index solved the issue for us, making it execute in under 10 minutes. We were working with a database that had about 27 million records in the `product_price_history` table. Whether that is unconventional for an odoo instance or not, I don't think adding this index could hurt a lot.

Current behavior before PR:
Query on `product_price_history` takes too long.

Desired behavior after PR is merged:
Query on `product_price_history` takes very little time.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
