### PR TITLE
[15.0][FIX] hr_expense: show paid_by and message refuse duplicate

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -8,7 +8,8 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def button_cancel(self):
-        for l in self.line_ids:
-            if l.expense_id:
-                l.expense_id.refuse_expense(reason=_("Payment Cancelled"))
+        """Get all expenses for refuse"""
+        expense_lines = self.line_ids.mapped("expense_id.sheet_id").mapped("expense_line_ids")
+        for exp in expense_lines:
+            exp.refuse_expense(reason=_("Payment Cancelled"))
         return super().button_cancel()

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -180,8 +180,8 @@
                             <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags" attrs="{'readonly': [('is_editable', '=', False)]}"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                             <field name="employee_id" groups="hr_expense.group_hr_expense_team_approver" context="{'default_company_id': company_id}" widget="many2one_avatar_employee"/>
-                            <label for="payment_mode" attrs="{'invisible': [('product_has_cost', '=', True)]}"/>
-                            <div id="payment_mode" attrs="{'invisible': [('product_has_cost', '=', True)]}">
+                            <label for="payment_mode"/>
+                            <div id="payment_mode">
                                 <field name="payment_mode" widget="radio"/>
                             </div>
                             <field name="duplicate_expense_ids" invisible="1" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix 2 bug
1. Field Paid By in expense will hide when cost of product is zero only
it should see Paid By with all you choose product cost zero or not.
2. Message refuse is duplicate when cancel journal entries related expense
it should 1 message/ 1 expense


Current behavior before PR:
1. Can't see paid_by when cost of product is not zero
![Selection_013](https://user-images.githubusercontent.com/20896369/220844108-80c8a1fc-61ad-4448-9397-dc4dd4d39a4c.png)

2. Message duplicate when refuse at journal entries
![Selection_017](https://user-images.githubusercontent.com/20896369/220844253-be918bd9-d613-4813-b0db-2fd6437b0502.png)


Desired behavior after PR is merged:
1. Users can see paid_by field with product has cost
![Selection_014](https://user-images.githubusercontent.com/20896369/220844345-b32c7505-9fc2-4c08-8107-b338ffc83e9b.png)

2. Message show 1 message / 1 expense
![Selection_018](https://user-images.githubusercontent.com/20896369/220844497-f85461d6-d2ba-413d-a262-992853ee48d6.png)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
