### PR TITLE
[FIX] stock_account - adds missing parenthesis causing an operator precedence error

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -406,7 +406,7 @@ class ProductProduct(models.Model):
                 'remaining_qty': 0,
                 'stock_move_id': move.id,
                 'company_id': move.company_id.id,
-                'description': 'Revaluation of %s (negative inventory)' % move.picking_id.name or move.name,
+                'description': 'Revaluation of %s (negative inventory)' % (move.picking_id.name or move.name),
                 'stock_valuation_layer_id': svl_to_vacuum.id,
             }
             vacuum_svl = self.env['stock.valuation.layer'].sudo().create(vals)


### PR DESCRIPTION
Impacted versions:
- 13.0
- 14.0
- 15.0
- 16.0

Description of the issue/feature this PR addresses:

A missing of parenthesis around an operator **or** cause a bad  evaluation of **False**, allowing to create a stock.valuation.layer with a description containing False.
See: [Python Operator Precedence Doc ]( https://docs.python.org/3/reference/expressions.html#operator-precedence)

Current behavior before PR:

description: Revaluation of False (negative inventory)

Desired behavior after PR is merged:

description: Revaluation of  Product Quantity Updated (negative inventory)

see original pr: https://github.com/odoo/odoo/pull/112177

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
