### PR TITLE
[12.0][FIX] core: ability to run tours in Chrome 111

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -768,7 +768,7 @@ class ChromeBrowser():
         raise unittest.SkipTest("Error during Chrome headless connection")
 
     def _open_websocket(self):
-        self.ws = websocket.create_connection(self.ws_url)
+        self.ws = websocket.create_connection(self.ws_url, suppress_origin=True)
         if self.ws.getstatus() != 101:
             raise unittest.SkipTest("Cannot connect to chrome dev tools")
         self.ws.settimeout(0.01)


### PR DESCRIPTION
Chrome 111 enabled checking of websocket origin: if the WS connection sends an Origin head which is not whitelisted with the new `--remote-allow-origins` switch it is rejected.

Turns out websocket-client (amongst others) *does* send an `Origin`, which trips the check, and means tours immediately break when trying to run them as Odoo's test harness is unable to connect to (and control) the devtools.

Suppress sending `Origin` to fix the issue.

Note: this also prevents using the remote developer tools by opening the devtools URL, user needs to go through chrome://inspect from the client and find / select the headless browser from there.

Chrome 111 changeset: https://chromiumdash.appspot.com/commit/0154caeefc74530d5cb57ce71608beb1b77bca39

Chrome tracker issue: https://crbug.com/1422444

closes odoo/odoo#114930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
