### PR TITLE
[13.0] web: backport image widget zoom issues

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1984,6 +1984,7 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
                             this.hide();
                         }
                         core.bus.on('keydown', this, this.hide);
+                        core.bus.on('click', this, this.hide);
                     },
                     beforeAttach: function () {
                         this.$flyout.css({ width: '512px', height: '512px' });

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1983,6 +1983,7 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
                         if( zoomHeight < 128 && zoomWidth < 128) {
                             this.hide();
                         }
+                        core.bus.on('keydown', this, this.hide);
                     },
                     beforeAttach: function () {
                         this.$flyout.css({ width: '512px', height: '512px' });


### PR DESCRIPTION
Backports of:

- https://github.com/odoo/odoo/commit/04af701f7658f260f81eb56f35fb64c4200b1e53 [FIX] web: Fix the zoom image stick top on search of employee.
- https://github.com/odoo/odoo/commit/7304bd20549ded71dc54072738515ea90aa9d6cd [FIX] web: fix picture glitch

Rationale in the coomits' messages

cc @Tecnativa TT42191

ping @pedrobaeza @CarlosRoca13 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
