### PR TITLE
[13.0][FIX] sale_coupon: prevent sending coupon message on failed sale confirm

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -44,10 +44,11 @@ class SaleOrder(models.Model):
         return order
 
     def action_confirm(self):
+        res = super().action_confirm()
         self.generated_coupon_ids.write({'state': 'new'})
         self.applied_coupon_ids.write({'state': 'used'})
         self._send_reward_coupon_mail()
-        return super(SaleOrder, self).action_confirm()
+        return res
 
     def action_cancel(self):
         res = super(SaleOrder, self).action_cancel()


### PR DESCRIPTION
Backport of odoo/odoo#116817

There can be multiple causes that could prevent a sales order gets confirmed when we push the *Confirm* button. This can be common when extension modules come to play.

The simplest way to reproduce it (no extra modules needed) would be to make an automated action on sale.order with a criteria that could avoid the confirmation throwing a UserError.

The coupon email would be sent anyway as we can't rollback a mail sending once it's gone away but it wouldn't be valid as the process stopped after it.

So we want to prevent sending that mail if the sale.order can't be confirmed.

cc @Tecnativa TT42124





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
