### PR TITLE
[12.0][FIX] product : add '(copy)' at the end of the name (product.product)

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -409,7 +409,7 @@ class ProductProduct(models.Model):
             # if we copy a variant or create one, we keep the same template
             default['product_tmpl_id'] = self.product_tmpl_id.id
         elif 'name' not in default:
-            default['name'] = self.name
+            default['name'] = _("%s (copy)") % (self.name)
 
         return super(ProductProduct, self).copy(default=default)
 


### PR DESCRIPTION
[FIX] product : add '(copy)' at the end of the name, when copying product.product. (as most of all the models, like res.partner).

Note OCB : Do not port this patch, as it is native is recent Odoo version.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
