### PR TITLE
feat: add yearly period for stock replenishment info wizard

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -22,6 +22,12 @@ class Company(models.Model):
         domain="[('model', '=', 'stock.picking')]",
         default=_default_confirmation_mail_template,
         help="Email sent to the customer once the order is done.")
+    stock_replenishment_info_periods = fields.Selection([
+        ('month', 'Monthly'),
+        ('year', 'Yearly'),
+    ], string='Stock Replenishment Info Periods',
+        default='month',
+        help="The stock replenishment info can be either ordered yearly or monthly")
     annual_inventory_month = fields.Selection([
         ('1', 'January'),
         ('2', 'February'),

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -47,6 +47,8 @@ class ResConfigSettings(models.TransientModel):
     annual_inventory_day = fields.Integer(related='company_id.annual_inventory_day', readonly=False)
     group_stock_reception_report = fields.Boolean("Reception Report", implied_group='stock.group_reception_report')
     group_stock_auto_reception_report = fields.Boolean("Show Reception Report at Validation", implied_group='stock.group_auto_reception_report')
+    stock_replenishment_info_periods = fields.Selection(related='company_id.stock_replenishment_info_periods', readonly=False)
+
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -106,6 +106,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box" id="stock.replenishment_info_period">
+                                <div class="o_setting_right_pane">
+                                    <label for="stock_replenishment_info_periods" string="Replenishment info period"/>
+                                    <div class="text-muted">
+                                        Modify the way stocks are grouped in the stock replenishment info wizard.
+                                    </div>
+                                    <div class="content-group">
+                                        <field name="stock_replenishment_info_periods" class="o_light_label" widget="selection"/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Barcode</h2>
                         <div class="row mt16 o_settings_container" name="barcode_setting_container">

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -6,7 +6,7 @@ from datetime import datetime, time
 
 from odoo import api, fields, models, SUPERUSER_ID
 from odoo.osv.expression import AND
-from odoo.tools import get_month, subtract, format_date
+from odoo.tools import get_month, subtract, format_date, get_fiscal_year
 
 
 class StockReplenishmentInfo(models.TransientModel):
@@ -19,6 +19,12 @@ class StockReplenishmentInfo(models.TransientModel):
     qty_to_order = fields.Float(related='orderpoint_id.qty_to_order')
     json_lead_days = fields.Char(compute='_compute_json_lead_days')
     json_replenishment_history = fields.Char(compute='_compute_json_replenishment_history')
+    periods = fields.Selection([
+        ('year', 'Yearly'),
+        ('month', 'Monthly'),
+    ], string='Stock replenishment info period',
+        default='year',
+        help="The stock replenishments infos can be either ordered monthly or yearly.")
 
     @api.depends('orderpoint_id')
     def _compute_json_lead_days(self):
@@ -46,12 +52,15 @@ class StockReplenishmentInfo(models.TransientModel):
 
     @api.depends('orderpoint_id')
     def _compute_json_replenishment_history(self):
+        res = self.env["res.config.settings"].sudo().search([])[0].stock_replenishment_info_periods
+        today = fields.Datetime.now()
+        get_period = get_fiscal_year if res == 'year' else get_month
+        group_period = "date:year" if res == 'year' else "date:month"
+        start_period = subtract(today, year=2) if res == 'year' else subtract(today, months=2)
         for replenishment_report in self:
             replenishment_history = []
-            today = fields.Datetime.now()
-            first_month = subtract(today, months=2)
-            date_from, dummy = get_month(first_month)
-            dummy, date_to = get_month(today)
+            date_from, dummy = get_period(start_period)
+            dummy, date_to = get_period(today)
             domain = [
                 ('product_id', '=', replenishment_report.product_id.id),
                 ('date', '>=', date_from),
@@ -59,19 +68,19 @@ class StockReplenishmentInfo(models.TransientModel):
                 ('state', '=', 'done'),
                 ('company_id', '=', replenishment_report.orderpoint_id.company_id.id)
             ]
-            quantity_by_month_out = self.env['stock.move'].read_group(
+            quantity_by_period_out = self.env['stock.move'].read_group(
                 AND([domain, [('location_dest_id.usage', '=', 'customer')]]),
-                ['date', 'product_qty'], ['date:month'])
-            quantity_by_month_returned = self.env['stock.move'].read_group(
+                ['date', 'product_qty'], [group_period])
+            quantity_by_period_returned = self.env['stock.move'].read_group(
                 AND([domain, [('location_id.usage', '=', 'customer')]]),
-                ['date', 'product_qty'], ['date:month'])
-            quantity_by_month_returned = {
-                g['date:month']: g['product_qty'] for g in quantity_by_month_returned}
-            for group in quantity_by_month_out:
-                month = group['date:month']
+                ['date', 'product_qty'], [group_period])
+            quantity_by_period_returned = {
+                g[group_period]: g['product_qty'] for g in quantity_by_period_returned}
+            for group in quantity_by_period_out:
+                period = group[group_period]
                 replenishment_history.append({
-                    'name': month,
-                    'quantity': group['product_qty'] - quantity_by_month_returned.get(month, 0),
+                    'name': period,
+                    'quantity': group['product_qty'] - quantity_by_period_returned.get(period, 0),
                     'uom_name': replenishment_report.product_id.uom_id.display_name,
                 })
             replenishment_report.json_replenishment_history = dumps({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
In the stock replenishment info module,  the info wizard contains a sale history. This sale history is only ordered monthly.
Desired behavior after PR is merged:
The stock replenishment info wizard can now be ordered yearly, depending on a res config setting.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
