### PR TITLE
[FIX] account : display company field on account.payment.term form an…d tree views

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -1816,6 +1816,7 @@
                 <tree string="Payment Terms">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>
@@ -1834,7 +1835,7 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="company_id" invisible="1"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                         </group>
                         <label for="note"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In a multicompany context, the company field is not displayed on payment term tree form views. It is so impossible to change the field by UI, or to create "global payment term".

Note : this fix has been done in odoo core here : https://github.com/odoo/odoo/commit/da0595dc9f92e9af17ead97e14c4f336ef18529d


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
