### PR TITLE
[11.0][FIX] base: ja.po transration of vat field

### DIFF
--- a/odoo/addons/base/i18n/ja.po
+++ b/odoo/addons/base/i18n/ja.po
@@ -20633,7 +20633,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base.field_res_partner_vat
 #: model:ir.model.fields,field_description:base.field_res_users_vat
 msgid "TIN"
-msgstr "付加価値税登録番号"
+msgstr "事業者登録番号"
 
 #. module: base
 #: selection:ir.mail_server,smtp_encryption:0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixed the translation to be more suitable for Japanese translation.

Current behavior before PR:
vat filed is translated as "付加価値税相続番号"

Desired behavior after PR is merged:
vat filed is translated as "事業者登録番号"


@qrtl


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
