### PR TITLE
[IMP] mail: allow to add cc emails when posting message

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2330,6 +2330,7 @@ class MailThread(models.AbstractModel):
             for recipients_ids_chunk in split_every(recipients_max, recipients_ids):
                 recipient_values = self._notify_email_recipient_values(recipients_ids_chunk)
                 email_to = recipient_values['email_to']
+                email_cc = recipient_values['email_cc']
                 recipient_ids = recipient_values['recipient_ids']
 
                 create_values = {
@@ -2339,6 +2340,8 @@ class MailThread(models.AbstractModel):
                 }
                 if email_to:
                     create_values['email_to'] = email_to
+                if email_cc:
+                    create_values['email_cc'] = email_cc
                 create_values.update(base_mail_values)  # mail_message_id, mail_server_id, auto_delete, references, headers
                 email = SafeMail.create(create_values)
 


### PR DESCRIPTION
In `mail.thread`, there's a `_notify_email_recipient_values` to allow to add additional values when posting a message.

However, to add an `email_cc` value, we also need to use it in the main method `_notify_record_by_email`.