### PR TITLE
[15.0][FIX] purchase_stock: Use hook method

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -429,7 +429,7 @@ class PurchaseOrderLine(models.Model):
     def _get_stock_move_price_unit(self):
         self.ensure_one()
         order = self.order_id
-        price_unit = self.price_unit
+        price_unit = self._prepare_compute_all_values()['price_unit']
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         if self.taxes_id:
             qty = self.product_qty or 1

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -40,7 +40,7 @@ class StockMove(models.Model):
             price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
             line = self.purchase_line_id
             order = line.order_id
-            price_unit = line.price_unit
+            price_unit = line._prepare_compute_all_values()['price_unit']
             if line.taxes_id:
                 qty = line.product_qty or 1
                 price_unit = line.taxes_id.with_context(round=False).compute_all(price_unit, currency=line.order_id.currency_id, quantity=qty)['total_void']

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -692,6 +692,16 @@ class Environment(Mapping):
         """
         return self.context.get('lang')
 
+    @property
+    def ocb(self):
+        """Allow to flag OCB environment so we can easily address compatibility issues
+        when making backports or improvements that aren't present in the current Odoo
+        version.
+
+        :rtype bool
+        """
+        return True
+
     def clear(self):
         """ Clear all record caches, and discard all fields to recompute.
             This may be useful when recovering from a failed ORM operation.


### PR DESCRIPTION
Proposed to Odoo in parallel: https://github.com/odoo/odoo/pull/136616

Merged into OCB in v13 -> https://github.com/OCA/OCB/pull/1189
Merged into OCB in v14 -> https://github.com/OCA/OCB/pull/1191

Summary:

- This uses the hook method introduced in ce1f1b6 for consistency when used on modules
that modify this behavior.

Also including https://github.com/OCA/OCB/pull/1193 so we can address compatibility issues between versions.

Better merge after:

- [ ] https://github.com/OCA/purchase-workflow/pull/2023

cc @Tecnativa @pedrobaeza 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
