### PR TITLE
[16.0][IMP] flag ocb environment

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -699,6 +699,16 @@ class Environment(Mapping):
         # because 'env.lang' may be injected in SQL queries
         return lang if lang and self['res.lang']._lang_get_id(lang) else None
 
+    @property
+    def ocb(self):
+        """Allow to flag OCB environment so we can easily address compatibility issues
+        when making backports or improvements that aren't present in the current Odoo
+        version.
+
+        :rtype bool
+        """
+        return True
+
     def clear(self):
         """ Clear all record caches, and discard all fields to recompute.
             This may be useful when recovering from a failed ORM operation.


### PR DESCRIPTION
fw of https://github.com/OCA/OCB/pull/1193

When making backports we could need to address double compatibility. We can ease it setting a handy flag we can use in our code

cc @Tecnativa TT45385

An example of usage: https://github.com/OCA/purchase-workflow/pull/2022


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
