### PR TITLE
[16.0][FIX] hr_recruitment: don't use iap widget when not installed

### DIFF
--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -40,18 +40,6 @@
                                     <div class="content-group" id="interview_forms"/>
                                 </div>
                             </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box" id="sms">
-                                <div class="o_setting_right_pane" id="sms_settings">
-                                    <div class="o_form_label">
-                                        Send SMS
-                                        <a href="https://www.odoo.com/documentation/16.0/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
-                                    </div>
-                                    <div class="text-muted">
-                                        Send texts to your contacts
-                                    </div>
-                                    <widget name="iap_buy_more_credits" service_name="sms" hide_service="1"/>
-                                </div>
-                            </div>
                             <div class="col-xs-12 col-md-6 o_setting_box" id="display_cv">
                                 <div class="o_setting_left_pane">
                                     <field name="group_applicant_cv_display"/>


### PR DESCRIPTION
This PR was raised to close issue  [#114747](https://github.com/odoo/odoo/issues/114747) by removing incriminated section.

A PR was created for odoo here : https://github.com/odoo/odoo/pull/114759 but not updated since March 2023. 
Following below discussion, it was decided to remove the entire section when above PR only removed the widget.