### PR TITLE
[14.0][FIX] account: Proper query in invoice reconcile model

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -750,7 +750,7 @@ class AccountReconcileModel(models.Model):
         # to the query to only search on move lines that are younger than this limit.
         if self.past_months_limit:
             date_limit = fields.Date.context_today(self) - relativedelta(months=self.past_months_limit)
-            query += "AND aml.date >= %(aml_date_limit)s"
+            query += "AND aml.date >= %(aml_date_limit)s "
             params['aml_date_limit'] = date_limit
 
         # Filter out excluded account.move.line.


### PR DESCRIPTION
OCB counterpart of #139419

If `past_months_limit` is set in the invoice reconcile model, and some `exclude_ids` are indicated on the call to `_get_invoice_matching_query`, an invalid SQL is built, throwing this error:

```
odoo_1  | Traceback (most recent call last):
odoo_1  |   File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
odoo_1  |     return super(JsonRequest, self)._handle_exception(exception)
odoo_1  |   File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
odoo_1  |     raise exception.with_traceback(None) from new_cause
odoo_1  | psycopg2.errors.SyntaxError: syntax error at or near "aml"
odoo_1  | LINE 25: ...id = 2226)) AND aml.date >= '2022-04-22'::dateAND aml.id NOT...
```

That's because the `past_months_limit` SQL condition is added without extra trailing space, and the excluded_ids condition doesn't contain an starting space.

The solution is to add the trailing space.

@Tecnativa 