### PR TITLE
[FIX][16.0] Invoices in Italy can be negative

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3402,7 +3402,7 @@ class AccountMove(models.Model):
                     "The recipient bank account linked to this invoice is archived.\n"
                     "So you cannot confirm the invoice."
                 ))
-            if float_compare(invoice.amount_total, 0.0, precision_rounding=invoice.currency_id.rounding) < 0:
+            if invoice.company_id.country_id != self.env.ref('base.it') and float_compare(invoice.amount_total, 0.0, precision_rounding=invoice.currency_id.rounding) < 0:
                 raise UserError(_(
                     "You cannot validate an invoice with a negative total amount. "
                     "You should create a credit note instead. "


### PR DESCRIPTION
Description of the issue/feature this PR addresses: negative invoices are permitted in Italy

Current behavior before PR: the user cannot validate a negative invoice

Desired behavior after PR is merged: the user can validate a negative invoice

Odoo PR: https://github.com/odoo/odoo/pull/140039


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr