### PR TITLE
[15.0][FIX] Stock: res_config_settings.py search_count with invalid parameter

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -58,7 +58,7 @@ class ResConfigSettings(models.TransientModel):
     def _onchange_group_stock_production_lot(self):
         if not self.group_stock_production_lot:
             self.group_lot_on_delivery_slip = False
-            if self.env['product.product'].search_count([('tracking', '!=', 'none')], limit=1):
+            if self.env['product.product'].search_count([('tracking', '!=', 'none')]):
                 raise UserError(_("You have product(s) in stock that have lot/serial number tracking enabled. \nSwitch off tracking on all the products before switching off this setting."))
 
     @api.onchange('group_stock_adv_location')


### PR DESCRIPTION
search_count has no limit parameter.

search_count is defined at https://github.com/OCA/OCB/blob/433bb3d77eb5f99098b00b36ce87f14b7beda3c2/odoo/models.py#L1785C22-L1785C22 and has only one parameter: the search domain.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
