### PR TITLE
[12.0][FIX] stock: avoid choosing inactive default location in inventory adjustment

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -15,7 +15,7 @@ class Inventory(models.Model):
     @api.model
     def _default_location_id(self):
         company_user = self.env.user.company_id
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', company_user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', company_user.id), ('lot_stock_id.active', '=', True)], limit=1)
         if warehouse:
             return warehouse.lot_stock_id.id
         else:


### PR DESCRIPTION
If you try to start an inventory with an inactive location, you get an error

```yml
  File "/opt/odoo/auto/addons/stock_inventory_exclude_sublocation/models/stock_inventory.py", line 23, in _get_inventory_lines_values
    vals = super()._get_inventory_lines_values()
  File "/opt/odoo/auto/addons/stock/models/stock_inventory.py", line 280, in _get_inventory_lines_values
    GROUP BY product_id, location_id, lot_id, package_id, partner_id """ % domain, args)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 148, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 225, in execute
    res = self._obj.execute(query, params)
  File "/usr/local/lib/python3.5/site-packages/newrelic/hooks/database_psycopg2.py", line 65, in execute
    **kwargs)
  File "/usr/local/lib/python3.5/site-packages/newrelic/hooks/database_dbapi2.py", line 39, in execute
    *args, **kwargs)
psycopg2.ProgrammingError: syntax error at or near ")"
LINE 5:             WHERE  location_id in () AND quantity != 0 AND a...
```

I will not do a PR to odoo, as they don't accept PRs for too old versions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr