### PR TITLE
[IMP] Changed name string from search for better understanding

### DIFF
--- a/addons/product/i18n/de.po
+++ b/addons/product/i18n/de.po
@@ -2192,8 +2192,8 @@ msgstr "Produktetikett"
 
 #. module: product
 #: model:ir.ui.view,arch_db:product.product_pricelist_view_search
-msgid "Products Price"
-msgstr "Produktpreis"
+msgid "Pricelist name"
+msgstr "Preislisten Name"
 
 #. module: product
 #: model:ir.ui.view,arch_db:product.product_pricelist_view

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -87,7 +87,7 @@
             <field name="model">product.pricelist</field>
             <field name="arch" type="xml">
                 <search string="Products Price Search">
-                    <field name="name" string="Products Price"/>
+                    <field name="name" string="Pricelist name"/>
                     <field name="currency_id" groups="base.group_multi_currency"/>
                     <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 </search>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Our employees were confused when searching for the price list designation. It says "Product Price" so it is assumed that you want to search for the price of a price list. For this reason, we have changed the English name to Pricelist name

Current behavior before PR:

As described above

Desired behavior after PR is merged:

After this string has been changed, the employees now understand what they are looking for. No longer by price, but by price list name 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
