### PR TITLE
[15.0][IMP] web: Add tooltip to searchpanel items (similar to v16) to see the full name if it is too long.

### DIFF
--- a/addons/web/static/src/legacy/xml/search_panel.xml
+++ b/addons/web/static/src/legacy/xml/search_panel.xml
@@ -87,8 +87,8 @@
                             t-attf-class="fa fa-caret-{{ state.expanded[section.id][valueId] ? 'down' : 'right' }}"
                         />
                     </div>
-                    <b t-if="value.bold" class="o_search_panel_label_title" t-esc="value.display_name"/>
-                    <span t-else="" class="o_search_panel_label_title" t-esc="value.display_name"/>
+                    <b t-if="value.bold" class="o_search_panel_label_title" t-esc="value.display_name" t-att-data-tooltip="value.display_name"/>
+                    <span t-else="" class="o_search_panel_label_title" t-esc="value.display_name" t-att-data-tooltip="value.display_name"/>
                 </label>
                 <span t-if="section.enableCounters and value.__count gt 0"
                     class="o_search_panel_counter text-muted ml-2 small"


### PR DESCRIPTION
Add tooltip to searchpanel items (similar to v16) to see the full name if it is too long.

![web-searchpanel-tooltip](https://github.com/OCA/OCB/assets/4117568/bee826d6-5edc-4597-93c0-e378ba1ce976)

Please @pedrobaeza can you review it?

@Tecnativa TT46388