### PR TITLE
[16.0][IMP] account,account_edi,account_edi_ubl_cii,l10n_ch: check if invoice report in separate function

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -44,10 +44,13 @@ class IrActionsReport(models.Model):
                 }
         return collected_streams
 
+    def _is_invoice_report(self, report_ref):
+        return True if self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice') else False
+
     def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.
         # + append context data with the display_name_in_footer parameter
-        if self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+        if self._is_invoice_report(report_ref):
             invoices = self.env['account.move'].browse(res_ids)
             if self.env['ir.config_parameter'].sudo().get_param('account.display_name_in_footer'):
                 data = data and dict(data) or {}

--- a/addons/account_edi/models/ir_actions_report.py
+++ b/addons/account_edi/models/ir_actions_report.py
@@ -16,7 +16,7 @@ class IrActionsReport(models.Model):
         if collected_streams \
                 and res_ids \
                 and len(res_ids) == 1 \
-                and self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+                and self._is_invoice_report(report_ref):
             invoice = self.env['account.move'].browse(res_ids)
             if invoice.is_sale_document() and invoice.state != 'draft':
                 to_embed = invoice.edi_document_ids

--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -59,7 +59,7 @@ class IrActionsReport(models.Model):
 
         if collected_streams \
                 and res_ids \
-                and self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+                and self._is_invoice_report(report_ref):
             for res_id, stream_data in collected_streams.items():
                 invoice = self.env['account.move'].browse(res_id)
                 self._add_pdf_into_invoice_xml(invoice, stream_data)

--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -33,7 +33,7 @@ class IrActionsReport(models.Model):
         if not res_ids:
             return res
         report = self._get_report(report_ref)
-        if report.report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+        if self._is_invoice_report(report_ref):
             invoices = self.env[report.model].browse(res_ids)
             # Determine which invoices need a QR/ISR.
             qr_inv_ids = []

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -280,9 +280,11 @@ odoo.define('point_of_sale.Chrome', function(require) {
             this.tempScreen.name = name;
             this.tempScreen.component = this.constructor.components[name];
             this.tempScreenProps = Object.assign({}, props, { resolve });
+            this.env.pos.tempScreenIsShown = true;
         }
         __closeTempScreen() {
             this.tempScreen.isShown = false;
+            this.env.pos.tempScreenIsShown = false;
             this.tempScreen.name = null;
         }
         __showScreen({ detail: { name, props = {} } }) {

--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
@@ -6,7 +6,7 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
     const { isConnectionError } = require('point_of_sale.utils');
 
     const { debounce } = require("@web/core/utils/timing");
-    const { useListener } = require("@web/core/utils/hooks");
+    const { useListener, useAutofocus } = require("@web/core/utils/hooks");
     const { useAsyncLockedMethod } = require("point_of_sale.custom_hooks");
     const { session } = require("@web/session");
 
@@ -30,6 +30,7 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
     class PartnerListScreen extends PosComponent {
         setup() {
             super.setup();
+            useAutofocus({refName: 'search-word-input-partner'});
             useListener('click-save', () => this.env.bus.trigger('save-partner'));
             useListener('save-changes', useAsyncLockedMethod(this.saveChanges));
             this.searchWordInputRef = useRef('search-word-input-partner');

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -16,7 +16,9 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
     class ProductScreen extends ControlButtonsMixin(PosComponent) {
         setup() {
             super.setup();
-            useListener('update-selected-orderline', this._updateSelectedOrderline);
+            useListener('update-selected-orderline', (...args) => {
+                if (!this.env.pos.tempScreenIsShown) this._updateSelectedOrderline(...args);
+            });
             useListener('select-line', this._selectLine);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-product', this._clickProduct);

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -134,6 +134,7 @@ class PosGlobalState extends PosModel {
             },
         };
 
+        this.tempScreenIsShown = false;
         // these dynamic attributes can be watched for change by other models or widgets
         Object.assign(this, {
             'synch':            { status:'connected', pending:0 },

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4174,7 +4174,7 @@ export class OdooEditor extends EventTarget {
         const content = block && block.innerHTML.trim();
         if (
             block &&
-            (content === '' || content === '<br>') &&
+            content === '<br>' &&
             !block.querySelector('T[t-out]') &&
             ancestors(block, this.editable).includes(this.editable)
         ) {

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -178,6 +178,12 @@ class Page(models.Model):
                             'url_to': url,
                             'website_id': website_id,
                         })
+                    # Sync website's homepage URL
+                    website = self.env['website'].get_current_website()
+                    page_url_normalized = {'homepage_url': page.url}
+                    website._handle_homepage_url(page_url_normalized)
+                    if website.homepage_url == page_url_normalized['homepage_url']:
+                        website.homepage_url = vals['url']
                 vals['url'] = url
 
             # If name has changed, check for key uniqueness

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -306,6 +306,44 @@ class WithContext(HttpCase):
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
 
+    def test_website_homepage_url_change(self):
+        website = self.env['website'].browse([1])
+
+        test_page = self.env['website.page'].create({
+            'name': 'HomepageUrlTest',
+            'type': 'qweb',
+            'arch': '<div>HomepageUrlTest</div>',
+            'key': 'test.homepage_url_test',
+            'url': '/homepage_url_test',
+            'is_published': True,
+        })
+        self.assertEqual(test_page.url, '/homepage_url_test')
+
+        # If one has set the `homepage_url` to a specific page URL..
+        website.write({
+            'name': 'Test Website',
+            'domain': f'http://{HOST}:{config["http_port"]}',
+            'homepage_url': test_page.url,
+        })
+        home_url_full = website.domain + '/'
+        r = self.url_open('/')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.url, home_url_full)
+        self.assertIn(b"HomepageUrlTest", r.content)
+
+        # .. and then change that page URL ..
+        with MockRequest(self.env, website=website):
+            test_page.url = '/url-changed'
+
+        # .. the `homepage_url` should be changed to follow the new page URL
+        r = self.url_open('/')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.url, home_url_full, """URL should still be '/', note that if this
+            `assert` fail, the loaded URL will probably be the first available
+            menu different from '/', see homepage controller.""")
+        self.assertIn(b"HomepageUrlTest", r.content)
+
     def test_06_homepage_url(self):
         # Setup
         website = self.env['website'].browse([1])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR moves the check whether requested report is an invoice one in a separate function so that it can be inherited in case we need to have extra invoice report formats.

Current behavior before PR:
In case you generate new invoice reports, EDI document will not be included unless you rewrite (or copy/update) the full code of _render_qweb_pdf() and _render_qweb_pdf_prepare_streams() functions.

Desired behavior after PR is merged:
With this PR, you can only inherits _is_invoice_report() function to add your new report name.

Since this is a IMP PR, I am not sure it would be accepted on 16.0 upstream (I try though with PR https://github.com/odoo/odoo/pull/147124). I also made another PR for master upstream branch : https://github.com/odoo/odoo/pull/147120 (since in 17.0 and master account_edi_ubl_cii does not need update since reformatting done with https://github.com/OCA/OCB/commit/955091e707df1206ccda8314f1f182e2a37a8362)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
