### PR TITLE
[16.0][IMP] account,account_edi,account_edi_ubl_cii,l10n_ch: check if invoice report in separate function

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -44,10 +44,13 @@ class IrActionsReport(models.Model):
                 }
         return collected_streams
 
+    def _is_invoice_report(self, report_ref):
+        return True if self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice') else False
+
     def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.
         # + append context data with the display_name_in_footer parameter
-        if self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+        if self._is_invoice_report(report_ref):
             invoices = self.env['account.move'].browse(res_ids)
             if self.env['ir.config_parameter'].sudo().get_param('account.display_name_in_footer'):
                 data = data and dict(data) or {}

--- a/addons/account_edi/models/ir_actions_report.py
+++ b/addons/account_edi/models/ir_actions_report.py
@@ -16,7 +16,7 @@ class IrActionsReport(models.Model):
         if collected_streams \
                 and res_ids \
                 and len(res_ids) == 1 \
-                and self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+                and self._is_invoice_report(report_ref):
             invoice = self.env['account.move'].browse(res_ids)
             if invoice.is_sale_document() and invoice.state != 'draft':
                 to_embed = invoice.edi_document_ids

--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -59,7 +59,7 @@ class IrActionsReport(models.Model):
 
         if collected_streams \
                 and res_ids \
-                and self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+                and self._is_invoice_report(report_ref):
             for res_id, stream_data in collected_streams.items():
                 invoice = self.env['account.move'].browse(res_id)
                 self._add_pdf_into_invoice_xml(invoice, stream_data)

--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -33,7 +33,7 @@ class IrActionsReport(models.Model):
         if not res_ids:
             return res
         report = self._get_report(report_ref)
-        if report.report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
+        if self._is_invoice_report(report_ref):
             invoices = self.env[report.model].browse(res_ids)
             # Determine which invoices need a QR/ISR.
             qr_inv_ids = []


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR moves the check whether requested report is an invoice one in a separate function so that it can be inherited in case we need to have extra invoice report formats.

Current behavior before PR:
In case you generate new invoice reports, EDI document will not be included unless you rewrite (or copy/update) the full code of _render_qweb_pdf() and _render_qweb_pdf_prepare_streams() functions.

Desired behavior after PR is merged:
With this PR, you can only inherits _is_invoice_report() function to add your new report name.

Since this is a IMP PR, I am not sure it would be accepted on 16.0 upstream (I try though with PR https://github.com/odoo/odoo/pull/147124). I also made another PR for master upstream branch : https://github.com/odoo/odoo/pull/147120 (since in 17.0 and master account_edi_ubl_cii does not need update since reformatting done with https://github.com/OCA/OCB/commit/955091e707df1206ccda8314f1f182e2a37a8362)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
