### PR TITLE
[14.0][FIX] hr_expense: Amend multicurrency

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -75,7 +75,7 @@ class HrExpense(models.Model):
     untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
     total_amount = fields.Monetary("Total", compute='_compute_amount', store=True, currency_field='currency_id', tracking=True)
     amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual', compute_sudo=True)
-    company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='sheet_id.currency_id', store=True, readonly=False)
+    company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='company_id.currency_id', readonly=True)
     total_amount_company = fields.Monetary("Total (Company Currency)", compute='_compute_total_amount_company', store=True, currency_field='company_currency_id')
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, states={'draft': [('readonly', False)], 'refused': [('readonly', False)]}, default=lambda self: self.env.company)
     # TODO make required in master (sgv)


### PR DESCRIPTION
Prevent `company_currency_id` field from not having the correct value in some cases.

Steps to reproduce the error:

- Enable multi-currency.
- Go to Expenses > Expenses report and create a new one.
- Add a line (creating a new expense)
- Add another line (creating a new expense)
- Modify the unit price of a line
- Save the expense report
- The line that we have not modified the price, will not have the `company_currency_id` value set (the value of `total_amount_company` will also be incorrect).

**Before**
![ejemplo-antes](https://github.com/OCA/OCB/assets/4117568/0d5aaf03-f58b-4948-ab54-0c8958736a07)

**After**
![ejemplo-despues](https://github.com/OCA/OCB/assets/4117568/62d04dce-1499-4ec7-861f-4d0d85dfe1d8)

Please @pedrobaeza can you review it?

This change is NOT required in higher versions.

@Tecnativa TT46648
