### PR TITLE
[14.0][FIX] base: Update wrong cache invalidation

### DIFF
--- a/doc/cla/individual/jbjourget-b.md
+++ b/doc/cla/individual/jbjourget-b.md
@@ -1,0 +1,11 @@
+France, 2023-11-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jean-Benoît Jourget 137054756+jbjourget-b@users.noreply.github.com https://github.com/jbjourget-b

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -111,12 +111,7 @@ class Property(models.Model):
         # we're writing a res_id=False on any record
         default_set = False
         if self._ids:
-            self.env.cr.execute(
-                'SELECT EXISTS (SELECT 1 FROM ir_property WHERE id in %s AND res_id IS NULL)', [self._ids])
-            default_set = self.env.cr.rowcount == 1 or any(
-                v.get('res_id') is False
-                for v in values
-            )
+            default_set = values.get('res_id') is False or any(not p.res_id for p in self)
         r = super(Property, self).write(self._update_values(values))
         if default_set:
             # DLE P44: test `test_27_company_dependent`
@@ -139,13 +134,7 @@ class Property(models.Model):
         return r
 
     def unlink(self):
-        default_deleted = False
-        if self._ids:
-            self.env.cr.execute(
-                'SELECT EXISTS (SELECT 1 FROM ir_property WHERE id in %s)',
-                [self._ids]
-            )
-            default_deleted = self.env.cr.rowcount == 1
+        default_deleted = any(not p.res_id for p in self)
         r = super().unlink()
         if default_deleted:
             self.clear_caches()


### PR DESCRIPTION
Avoid invalidating cache when not needed.
This improves a lot performances.

Closes #143403

Fixes a bug which causes that: self.flush() and self.clear_caches() were called on every property write/update and delete. Known at least in V14/15/16/17.


Backport of odoo/odoo#145171

Related: odoo/enterprise#52207

====

**NOTE:** I removed the call to `self.flush_model()` from the commit as this method doesn't exist in 14.0 and is not directly related to the fix