### PR TITLE
[FIX] website_event_track: crash in SWs fetch listener on Safari 17.0+

### DIFF
--- a/addons/website_event_track/static/src/js/service_worker.js
+++ b/addons/website_event_track/static/src/js/service_worker.js
@@ -57,8 +57,13 @@ const isCacheFull = async () => {
     if (!("storage" in navigator && "estimate" in navigator.storage)) {
         return false;
     }
-    const { usage, quota } = await navigator.storage.estimate();
-    return usage / quota > MAX_CACHE_QUOTA || usage > MAX_CACHE_SIZE;
+    try {
+        const { usage, quota } = await navigator.storage.estimate();
+        return usage / quota > MAX_CACHE_QUOTA || usage > MAX_CACHE_SIZE;
+    } catch (error) {
+        console.error(`call to storage.estimate failed`, error);
+        return false;
+    }
 };
 
 /**


### PR DESCRIPTION
This is a cherry pick of https://github.com/odoo/odoo/commit/7a5cabe88998a958994a957998f2e7463cb6c85b

Description of the issue/feature this PR addresses:
This PR addresses an issue opening events on Safari Browser 17.0+
Opening another event after having looked at another one leads to a Browser Crash

Current behavior before PR:
Before this commit, when browsing the "Events" part of website on Safari
(both macOS and iOS/ipadOS), the page could be loaded only once and
returns a "FetchEvent.respondWith received an error: NotSupportedError:
The operation is not supported." error message on afterward, completely
blocking access to everything under the `/event` path.

This error is actually thrown from the ServiceWorker's `fetch` event's
listener, and more specifically, from the storage availablity check.

Since Safari 17.0, the Storage API - and in this case its `estimate()`
function -  has been enabled in WebKit's builds for Apple platforms (see
WebKit PR [1]). But even if this feature should be available in Web
Workers (cf. MDN [2] and the spec [3]), it returns a NotSupportedError
error when called from the ServiceWorker on Safari 17.0+ (but works fine
in the global scope).

Desired behavior after PR is merged:
Any event can be opened on Safari Browser without Crashing the page



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
