### PR TITLE
[16.0] [FIX] werkzeug socket

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -815,7 +815,7 @@ class WebsocketConnectionHandler:
         cls._handle_public_configuration(request)
         try:
             response = cls._get_handshake_response(request.httprequest.headers)
-            socket = request.httprequest._HTTPRequest__environ['socket']
+            socket = request.httprequest._HTTPRequest__environ['werkzeug.socket']
             session, db, httprequest = request.session, request.db, request.httprequest
             response.call_on_close(lambda: cls._serve_forever(
                 Websocket(socket, session),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

websockets are failing in multiprocessing server

Current behavior before PR:

Trying to use websocket (chatter etc.) leads to exceptions:

```
2024-03-14 13:51:39,696 1747665 ERROR odovrsdem16 odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/home/openeyedev/projecten/vwnvrs16.0/auto/addons/bus/websocket.py", line 818, in open_connection
    socket = request.httprequest._HTTPRequest__environ['socket']
KeyError: 'socket'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/http.py", line 2044, in __call__
    response = request._serve_db()
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/http.py", line 1633, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/http.py", line 1660, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/http.py", line 1774, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/openeyedev/projecten/vwnvrs16.0/custom/src/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/openeyedev/projecten/vwnvrs16.0/auto/addons/bus/controllers/websocket.py", line 18, in websocket
    return WebsocketConnectionHandler.open_connection(request)
  File "/home/openeyedev/projecten/vwnvrs16.0/auto/addons/bus/websocket.py", line 830, in open_connection
    raise RuntimeError(
RuntimeError: Couldn't bind the websocket. Is the connection opened on the evented port (8072)?
```

Desired behavior after PR is merged:

websocket works as designed

Tested that indeed this solve3s the problem.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
