### PR TITLE
[14.0][FIX] hr_expense: Apply rule to account moves to prevent Expense Team Approver user can access to all moves

### DIFF
--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -64,6 +64,12 @@
             <field name="domain_force">[('company_id', 'in', company_ids)]</field>
         </record>
 
+        <record id="hr_expense_team_approver_account_move_rule" model="ir.rule">
+            <field name="name">Expense Team Approver Account Move</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="domain_force">[('line_ids.expense_id', '!=', False)]</field>
+            <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
+        </record>
         <record id="hr_expense_team_approver_account_move_line_rule" model="ir.rule">
             <field name="name">Expense Team Approver Account Move Line</field>
             <field name="model_id" ref="account.model_account_move_line"/>


### PR DESCRIPTION
Related to https://github.com/odoo/odoo/commit/b6fc5ef468f47c109b2d007f211e02ca5f3fe093

Apply rule to account moves to prevent Expense Team Approver user can access to all moves

**Description of the issue/feature this PR addresses**:
User with Expenses: Team Approver group should not see all moves.

**Example use case**:
- Create a user with Expenses: Team Approver group.
- Login with the created user to /my
- The user will only see invoices linked to expenses.

**Current behavior before PR**:
User with Expenses: Team Approver group will **only** be able to see invoices linked to expenses.

Ping @pedrobaeza 

@Tecnativa TT48242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
