### PR TITLE
[IMP] account_edi: support multi-company

### DIFF
--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -14,6 +14,7 @@ governements, etc.)
     'category': 'Accounting/Accounting',
     'depends' : ['account'],
     'data': [
+        'security/account_edi_document_security.xml',
         'security/ir.model.access.csv',
         'views/account_edi_document_views.xml',
         'views/account_move_views.xml',

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -39,6 +39,7 @@ class AccountEdiDocument(models.Model):
     name = fields.Char(related='attachment_id.name')
     edi_format_name = fields.Char(string='Format Name', related='edi_format_id.name')
     edi_content = fields.Binary(compute='_compute_edi_content', compute_sudo=True)
+    company_id = fields.Many2one(related="move_id.company_id")
 
     _sql_constraints = [
         (

--- a/addons/account_edi/security/account_edi_document_security.xml
+++ b/addons/account_edi/security/account_edi_document_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<data noupdate="1">
+
+    <record id="account_edi_document_comp_rule" model="ir.rule">
+        <field name="name">Electronic Document for an account.move multi-company</field>
+        <field name="model_id" ref="model_account_edi_document"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
+</data>
+</odoo>

--- a/doc/cla/individual/dreinabinovo.md
+++ b/doc/cla/individual/dreinabinovo.md
@@ -1,0 +1,11 @@
+Spain, 2024-05-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+David Reina Agrasar dreina@binovo.es https://github.com/dreinabinovo


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Support multi-company for account EDI documents.

Current behavior before PR: All the documents are visible for all companies.

Desired behavior after PR is merged: Each company sees only its EDI documents.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
