### PR TITLE
[12.0][FIX] stock_account: Correct order in `candidates_receipt` search for FIFO valuation

### DIFF
--- a/addons/stock_account/models/stock.py
+++ b/addons/stock_account/models/stock.py
@@ -115,7 +115,7 @@ class StockMoveLine(models.Model):
                         # no need to adapt `remaining_qty` and `remaining_value` as `_run_fifo` took care of it
                         move_vals['value'] = move_id.value - correction_value
                     elif move_id._is_out() and qty_difference < 0:
-                        candidates_receipt = self.env['stock.move'].search(move_id._get_in_domain(), order='date, id desc', limit=1)
+                        candidates_receipt = self.env['stock.move'].search(move_id._get_in_domain(), order='date desc, id desc', limit=1)
                         if candidates_receipt:
                             candidates_receipt.write({
                                 'remaining_qty': candidates_receipt.remaining_qty + -qty_difference,


### PR DESCRIPTION
Description of issue/feature this PR addresses:
Incorrectly orders the search results by date (a datetime field) in ascending order and then by id in descending order. 
This results in the selection of the oldest record instead of the last one.

Current behavior before PR:
The search query extracts the oldest stock.move record instead of the last one when updating the value and remaining quantity in FIFO cost method during the decrease of qty_done in an outgoing move.

Desired behavior after PR is merged:
The search query correctly extracts the last stock.move record by ordering the results first by date in descending order.

@qrtl QT4562

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
