### PR TITLE
[16.0][FIX] hr_recruitment: don't use iap widget when not installed

### DIFF
--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -40,6 +40,17 @@
                                     <div class="content-group" id="interview_forms"/>
                                 </div>
                             </div>
+                            <div class="col-xs-12 col-md-6 o_setting_box" id="sms">
+                                <div class="o_setting_right_pane" id="sms_settings">
+                                    <div class="o_form_label">
+                                        Send SMS
+                                        <a href="https://www.odoo.com/documentation/16.0/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" title="Documentation" class="ms-1 o_doc_link" target="_blank"></a>
+                                    </div>
+                                    <div class="text-muted">
+                                        Send texts to your contacts
+                                    </div>
+                                </div>
+                            </div>
                             <div class="col-xs-12 col-md-6 o_setting_box" id="display_cv">
                                 <div class="o_setting_left_pane">
                                     <field name="group_applicant_cv_display"/>


### PR DESCRIPTION
This reverts commit db1a6602a9cab680d71bbf41b2fdfdfa96cc5f6a.

Description of the issue/feature this PR addresses:
Odoo Enterprise need the XML (https://github.com/odoo/enterprise/blob/16.0/hr_recruitment_extract/views/res_config_settings_views.xml#L14) that has been removed on the commit (https://github.com/OCA/OCB/commit/db1a6602a9cab680d71bbf41b2fdfdfa96cc5f6a) and since this commit has been introduce to fix something that Odoo fixed here: https://github.com/odoo/odoo/pull/114759/files 
It's necessary anymore.

Current behavior before PR:
We cannot install the Enterprise module hr_recruitment_export on the OCB 16.0 branch.

Desired behavior after PR is merged:
We should be able to install Enterprise



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
