### PR TITLE
[IMP] website_sale: avoid accesory products render

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -755,15 +755,15 @@ class WebsiteSale(http.Controller):
             'date': fields.Date.today(),
             'suggested_products': [],
         })
+        if post.get('type') == 'popover':
+            # force no-cache so IE11 doesn't cache this XHR
+            return request.render("website_sale.cart_popover", values, headers={'Cache-Control': 'no-cache'})
+        
         if order:
             values.update(order._get_website_sale_extra_values())
             order.order_line.filtered(lambda l: not l.product_id.active).unlink()
             values['suggested_products'] = order._cart_accessories()
             values.update(self._get_express_shop_payment_values(order))
-
-        if post.get('type') == 'popover':
-            # force no-cache so IE11 doesn't cache this XHR
-            return request.render("website_sale.cart_popover", values, headers={'Cache-Control': 'no-cache'})
 
         return request.render("website_sale.cart", values)
 


### PR DESCRIPTION
In large orders, loading accessory products takes a long time, this is an improvement to avoid unnecesary loads.

When the user hover over the cart icon, the "cart" method is called, which performs loading and rendering of elements and other checks.

There is no reason to render the accessory products if the post is "popover" and that view is rendered, since it only involves the order lines.

![image](https://github.com/OCA/OCB/assets/91630334/2e4253f7-c02e-4519-bfa8-4fef9ce352d7)


With this PR, we seek to optimize the order navigation and the checkout  since in orders with large products there may be many accessory products.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
