### PR TITLE
[14.0][FIX] crm: check if email_from is defined

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1581,7 +1581,7 @@ class Lead(models.Model):
             name_from_email = self.partner_name or self.contact_name
             emails_normalized = tools.email_normalize_all(email)
             email_normalized = emails_normalized[0] if emails_normalized else False
-            if email.lower() == self.email_from.lower() or (email_normalized and self.email_normalized == email_normalized):
+            if (email and self.email_from and email.lower() == self.email_from.lower()) or (email_normalized and self.email_normalized == email_normalized):
                 partner_info['full_name'] = tools.formataddr((
                     name_from_email,
                     ','.join(emails_normalized) if emails_normalized else email))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Facing a special case with both CRM and mail_tracking (from OCA social repo) installed.
When an opportunity or a lead was created from an incoming e-mail and then you remove the email_from on opportunity/lead (for instance because you have forwarded an email to Odoo to create opportunity but you do not want to keep your own email address as email_from for the lead), you get an error that boolean does not have lower() method.
This issue has been introduced with https://github.com/odoo/odoo/commit/9ef715fb994564af9e933ba31933a09eca97c24f part of https://github.com/odoo/odoo/pull/74474

Since mail_tracking is trying to suggest extra emails, you get all message_ids.email_to as emails parameter when calling _message_partner_info_from_emails(emails) which it tries to compare with crm_lead.email_from

This PR fixes this issue by checking that email and self.email_from exist before trying to lower() them (as it was done before the above commit)

Current behavior before PR:
Stack trace when accessing lead / opportunity created from incoming e-mail where email_from has been emptied.

Desired behavior after PR is merged:
No more error, working correctly


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
