### PR TITLE
Backported freezegun to 13.0 requirements.txt from 14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ chardet==3.0.4
 decorator==4.3.0
 docutils==0.14
 ebaysdk==2.1.5
+freezegun==0.3.11; python_version < '3.8'
+freezegun==0.3.15; python_version >= '3.8'
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version >= '3.7'
 gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
**freezegun** not added to the 13.0 oca-ci container, which caused failed checks on my PR during migrating one of the modules: [https://github.com/OCA/stock-logistics-warehouse/pull/2056](url)

Current behavior before PR:
getting failed checks 

Desired behavior after PR is merged:
checks are successful



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
