### PR TITLE
[12.0][FIX] mail: reply_to not being reflected in sent emails

### DIFF
--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -14,6 +14,7 @@
                     <field name="invoice_ids" invisible="1"/>
                     <field name="email_from" invisible="1" />
                     <field name="mail_server_id" invisible="1"/>
+                    <field name="reply_to" invisible="1"/>
                     <div name="option_print">
                         <field name="is_print" />
                         <b><label for="is_print"/></b>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -311,6 +311,7 @@ class MailComposer(models.TransientModel):
                 'author_id': self.author_id.id,
                 'email_from': self.email_from,
                 'record_name': self.record_name,
+                'reply_to': self.reply_to,
                 'no_auto_thread': self.no_auto_thread,
                 'mail_server_id': self.mail_server_id.id,
                 'mail_activity_type_id': self.mail_activity_type_id.id,


### PR DESCRIPTION
This PR fix a problem where setting the reply_to value in the email template does not get reflected in the reply_to field of the sent emails.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@qrtl QT4332