### PR TITLE
[FIX] don't traceback when origin is not filled

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -964,7 +964,7 @@ class MrpProduction(models.Model):
     def _get_move_raw_values(self, product_id, product_uom_qty, product_uom, operation_id=False, bom_line=False):
         source_location = self.location_src_id
         origin = self.name
-        if self.orderpoint_id:
+        if self.orderpoint_id and self.origin:
             origin = self.origin.replace(
                 '%s - ' % (self.orderpoint_id.display_name), '')
             origin = '%s,%s' % (origin, self.name)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In some cases, orderpoint_id is filled but origin is not. I have no idea which exact flows lead to this, but I notice it is fixed in future Odoo versions as part of odoo/odoo/pull/80319. I'm not sure about backporting all of that, but at least this part is IMO harmless to just merge in.

Current behavior before PR:

Upon confirming an MO with `orderpoint_id` but no `origin`:

```
  File "/home/ubuntu/odoo/auto/addons/mrp/models/mrp_production.py", line 968, in _get_move_raw_values
    origin = self.origin.replace(
Exception
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/ubuntu/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/ubuntu/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'bool' object has no attribute 'replace'
```

Desired behavior after PR is merged:

No traceback, MO confirms OK


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
