### PR TITLE
[14.0][backport] account: Allow skipping bank account creation on reconciliation

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models, _
 from odoo.osv import expression
 from odoo.tools import float_is_zero
 from odoo.tools import float_compare, float_round, float_repr
-from odoo.tools.misc import formatLang, format_date
+from odoo.tools.misc import formatLang, format_date, str2bool
 from odoo.exceptions import UserError, ValidationError
 
 import time
@@ -1310,7 +1310,9 @@ class AccountBankStatementLine(models.Model):
     def _find_or_create_bank_account(self):
         bank_account = self.env['res.partner.bank'].search(
             [('company_id', '=', self.company_id.id), ('acc_number', '=', self.account_number)])
-        if not bank_account:
+        if not bank_account and not str2bool(
+            self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")
+        ):
             bank_account = self.env['res.partner.bank'].create({
                 'acc_number': self.account_number,
                 'partner_id': self.partner_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Backport of the fix in account module that introduces a system variable to skip creation of bank accounts in the reconciliation of bank statements. See original PR for more information: [https://github.com/odoo/odoo/pull/168029](https://github.com/odoo/odoo/pull/168029)

Current behavior before PR:
In cases where multiple partners (Partner A, Partner B) use the same bank account due to a third-party payment handler, bank account is assigned for a Partner A when first invoice is reconciled. Subsequent invoices with the same bank account are reconciled automatically to Partner A using this stored bank account, and Partner B not proposed by the reconciliation widget

Desired behavior after PR is merged:
Allow to avoid storing bank account and having wrong invoices proposed by the reconciliation widget

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
