### PR TITLE
[17.0][IMP] *: disable auto-install

### DIFF
--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -12,6 +12,6 @@ This module adds support for SEPA Credit Transfer QR-code generation.
     # any module necessary for this one to work correctly
     'depends': ['account', 'base_iban'],
 
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/base_install_request/__manifest__.py
+++ b/addons/base_install_request/__manifest__.py
@@ -9,7 +9,7 @@
 Allow internal users requesting a module installation
 =====================================================
     """,
-    'auto_install': True,
+    'auto_install': False,
     'data':[
         'security/ir.model.access.csv',
         'wizard/base_module_install_request_views.xml',

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -19,7 +19,7 @@ to support In-App purchases inside Odoo. """,
         'views/iap_views.xml',
         'views/res_config_settings.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'iap/static/src/**/*.js',

--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -37,6 +37,6 @@ for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
     ],
     'post_init_hook': '_l10n_es_edi_facturae_post_init_hook',
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_es_pos/__manifest__.py
+++ b/addons/l10n_es_pos/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Accounting/Localizations/Point of Sale',
     'summary': """Spanish localization for Point of Sale""",
     'depends': ['point_of_sale', 'l10n_es'],
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
     'data': [
         'views/res_config_settings_views.xml',

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': 'Add OdooBot in discussions',
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True,
     'data': [
         'views/res_users_views.xml',

--- a/addons/pos_epson_printer/__manifest__.py
+++ b/addons/pos_epson_printer/__manifest__.py
@@ -19,7 +19,7 @@ Use Epson ePOS Printers without the IoT Box in the Point of Sale
         'views/pos_printer_views.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'point_of_sale._assets_pos': [
             'pos_epson_printer/static/src/**/*',

--- a/addons/privacy_lookup/__manifest__.py
+++ b/addons/privacy_lookup/__manifest__.py
@@ -12,6 +12,6 @@
         'security/ir.model.access.csv',
         'data/ir_actions_server_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -12,6 +12,6 @@
     'demo': [
         'data/sale_pdf_quote_builder_demo.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/sale_product_configurator/__manifest__.py
+++ b/addons/sale_product_configurator/__manifest__.py
@@ -26,6 +26,6 @@ It also enables the "optional products" feature.
             'sale_product_configurator/static/src/**/*',
         ],
     },
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Odoo chooses to auto-install some modules that are debatable, so here in OCB we can revert this decission and let the Odoo admin to decide about them:

- account_qr_code_sepa: this is just some tooling with no UI, so only modules using this tooling should depend and install it.
- base_install_request: Feature for asking to install a module that doesn't make too much sense to be auto-installed in on premise maintained installations for avoiding false expectations.
- iap: Odoo in-app purchases services should be optional, and more having a lot of dependant modules also being auto-installed (sms, snailmail, partner_autocomplete...). This way, we stop the chain from the beginning.
- l10n_es_edi_facturae: Not everyone in Spain requires Facturae, and even if so, the OCA implementation is more suitable.
- l10n_es_pos: The implementation of this need is faulty (creating one journal entry per PoS order), so the OCA one should be used instead.
- mail_bot: It doesn't bring any real feature per se (only the annoying "Write an emoji" initial conversation).
- pos_epson_printer: Not everyone using PoS has an Epson printer.
- privacy_lookup: Privacy tool that not everyone uses.
- sale_pdf_quote_builder: Optional feature.
- sale_product_configurator: Optional feature.

@Tecnativa 