### PR TITLE
[16.0][IMP] *: disable auto-install

### DIFF
--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -12,6 +12,6 @@
     # any module necessary for this one to work correctly
     'depends': ['account', 'base_iban'],
 
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/base_install_request/__manifest__.py
+++ b/addons/base_install_request/__manifest__.py
@@ -9,7 +9,7 @@
 Allow internal users requesting a module installation
 =====================================================
     """,
-    'auto_install': True,
+    'auto_install': False,
     'data':[
         'security/ir.model.access.csv',
         'wizard/base_module_install_request_views.xml',

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': 'Add OdooBot in discussions',
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True,
     'data': [
         'views/res_users_views.xml',

--- a/addons/pos_epson_printer/__manifest__.py
+++ b/addons/pos_epson_printer/__manifest__.py
@@ -18,7 +18,7 @@ Use Epson ePOS Printers without the IoT Box in the Point of Sale
         'views/res_config_settings_views.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'point_of_sale.assets': [
             'pos_epson_printer/static/src/js/**/*',

--- a/addons/privacy_lookup/__manifest__.py
+++ b/addons/privacy_lookup/__manifest__.py
@@ -13,7 +13,7 @@
         'security/ir.model.access.csv',
         'data/ir_actions_server_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {},
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Odoo chooses to auto-install some modules that are debatable, so here in OCB we can revert this decision and let the Odoo admin to decide about them. This is the second round of de-activations after a deep analysis done in #1242:

- account_qr_code_sepa: this is just some tooling with no UI, so only modules using this tooling should depend and install it.
- base_install_request: Feature for asking to install a module that doesn't make too much sense to be auto-installed in on premise maintained installations for avoiding false expectations.
- mail_bot: It doesn't bring any real feature per se (only the annoying "Write an emoji" initial conversation).
- pos_epson_printer: Not everyone using PoS has an Epson printer.
- privacy_lookup: Privacy tool that not everyone uses.

@Tecnativa 