### PR TITLE
[15.0][IMP] *: disable auto-install

### DIFF
--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -15,6 +15,6 @@
     'data': [
     ],
 
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -9,7 +9,7 @@
     'description': "",
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True,
     'application': False,
     'data': [


### PR DESCRIPTION
Odoo chooses to auto-install some modules that are debatable, so here in OCB we can revert this decision and let the Odoo admin to decide about them. This is another round of de-activations after a deep analysis done in #1242:

- account_qr_code_sepa: this is just some tooling with no UI, so only modules using this tooling should depend and install it.
- mail_bot: It doesn't bring any real feature per se (only the annoying "Write an emoji" initial conversation).

@Tecnativa 