### PR TITLE
[14.0][FIX] remove auto-install from account_edi

### DIFF
--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -24,6 +24,6 @@ governements, etc.)
     ],
     'installable': True,
     'application': False,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses: `account_edi` is incompatible with the Italian localization (and others?) as it installs `l10n_it_edi` by default.

Current behavior before PR: the module is installed by default and Italian partners, who want to use the Italian localization, must uninstall it, with many problem if the user has already entered datas on the fields managed from *edi modules.

Desired behavior after PR is merged: the module is not installed. If anyone wants to use it, it can be installed freely.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr