### PR TITLE
[IMP] google_gmail, web_unsplash: disable auto_install

### DIFF
--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -14,7 +14,7 @@
         "views/ir_mail_server_views.xml",
         "views/res_config_settings_views.xml",
     ],
-    "auto_install": True,
+    "auto_install": False,
     "license": "LGPL-3",
     "assets": {
         "web.assets_backend": [

--- a/addons/web_unsplash/__manifest__.py
+++ b/addons/web_unsplash/__manifest__.py
@@ -10,7 +10,7 @@
     'data': [
         'views/res_config_settings_view.xml',
         ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_frontend': [
             'web_unsplash/static/src/js/unsplash_beacon.js',


### PR DESCRIPTION
As per discussion https://github.com/OCA/OCB/pull/1243#issuecomment-2225273425
I propose to disable auto_install on both `google_gmail` and `web_unsplash` modules




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
