### PR TITLE
[14.0][FIX] mrp inactive product with phantom bom used in other phantom bom

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -291,6 +291,14 @@ class MrpBom(models.Model):
                 update_product_boms()
                 product_ids.clear()
             bom = product_boms.get(current_line.product_id)
+            if not bom and not current_line.product_id.active:
+                # Get inactive phantom bom if a inactive product with phantom bom is in
+                # the current bom.
+                # Else it will duplicate the product requested and delivered.
+                bom = self.env["mrp.bom"].with_context(active_test=False)._bom_find(
+                    product_tmpl=current_line.product_id.product_tmpl_id,
+                    product=current_line.product_id,
+                )
             if bom:
                 converted_line_quantity = current_line.product_uom_id._compute_quantity(line_quantity / bom.product_qty, bom.product_uom_id)
                 bom_lines += [(line, current_line.product_id, converted_line_quantity, current_line) for line in bom.bom_line_ids]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A phantom bom with a component product deactivated with another phantom bom will duplicate the product delivered.

Current behavior before PR:
Picking transfer is created with wrong quantities.

Desired behavior after PR is merged:
Quantities in the picking are correct.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr