### PR TITLE
[15.0] [IMP] Make mail batch size configurable

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -178,8 +178,8 @@ class MailMail(models.Model):
         ]
         if 'filters' in self._context:
             filters.extend(self._context['filters'])
-        # TODO: make limit configurable
-        filtered_ids = self.search(filters, limit=10000).ids
+        batch_size = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail.queue.batch.size', 10000))
+        filtered_ids = self.search(filters, limit=batch_size).ids
         if not ids:
             ids = filtered_ids
         else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Mail_mail imposes 10000 mail per batch. This causes problems with some mail providers, 
- is addressed to change (TODO in code)
- its addressed in newer versions https://github.com/OCA/OCB/blob/3cf0c28f12b8cd5c0b54088d67b1c28905adf244/addons/mail/models/mail_mail.py#L244

Current behavior before PR:
- Mail is sent in 10000 mail batches

Desired behavior after PR is merged:
- Mails is sent in 10000 mail batches OR mail.mail.queue.batch.size system parameter



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
