### PR TITLE
[14.0][FIX] web: compatibility with Serialized fields

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -584,7 +584,8 @@ var KanbanRecord = Widget.extend({
 
             if (r.type) {
                 var formatter = field_utils.format[r.type];
-                r.value = formatter(value, self.fields[name], recordData, self.state);
+                // Avoid failing when no formatter is available e.g.: serialized
+                r.value = (formatter && formatter(value, self.fields[name], recordData, self.state)) || r.value;
             } else {
                 r.value = value;
             }


### PR DESCRIPTION
When we include a Serialized field in a Kanban, it will fail as there's no formatter for such fields. And it isn't needed but these fields can be handy to achieve some special techniques using their raw values.

cc @Tecnativa TT50623

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
