### PR TITLE
Support pytest-odoo

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -336,7 +336,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
                     break
             else:  # last try
                 super().run(result)
-                if not result.wasSuccessful() and BaseCase._tests_run_count != 1:
+                if hasattr(result, "wasSuccessful") and not result.wasSuccessful() and BaseCase._tests_run_count != 1:
                     _logger.runbot('Disabling auto-retry after a failed test')
                     BaseCase._tests_run_count = 1
 


### PR DESCRIPTION
uptstream PR: https://github.com/odoo/odoo/pull/184409

## Description of the issue/feature this PR addresses:

Allow other python test launcher than unittest back (this was introduced by this commit https://github.com/odoo/odoo/commit/ccf3c1ed3949f3307909678efe1245aa92ef752f) in odoo 18 only.

`wasSuccessful` function is injected by unitest launcher and not present while using pytest launcher (using pytest-odoo plugin)

## Current behavior before PR:


Tests failed with following error using pytest
```
    def run(self, result):
        testMethod = getattr(self, self._testMethodName)
    
        if getattr(testMethod, '_retry', True) and getattr(self, '_retry', True):
            tests_run_count = self._tests_run_count
        else:
            tests_run_count = 1
            _logger.info('Auto retry disabled for %s', self)
    
        quiet_log = None
        for retry in range(tests_run_count):
            result.had_failure = False  # reset in case of retry without soft_fail
            if retry:
                _logger.runbot(f'Retrying a failed test: {self}')
            if retry < tests_run_count-1:
                with warnings.catch_warnings(), \
                        result.soft_fail(), \
                        lower_logging(25, logging.INFO) as quiet_log:
                    super().run(result)
                if not (result.had_failure or quiet_log.had_error_log):
                    break
            else:  # last try
                super().run(result)
>               if not result.wasSuccessful() and BaseCase._tests_run_count != 1:
E               AttributeError: 'TestCaseFunction' object has no attribute 'wasSuccessful'

.venv/lib/python3.12/site-packages/odoo/tests/common.py:339: AttributeError
```


## Desired behavior after PR is merged:

no errors raised from tests/common.py


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
