### PR TITLE
[15.0][FIX] website_sale: Correction of Portuguese translation

### DIFF
--- a/addons/website_sale/i18n/pt.po
+++ b/addons/website_sale/i18n/pt.po
@@ -341,8 +341,8 @@ msgid ""
 "<span class=\"text-muted\" attrs=\"{'invisible': [('product_variant_count', "
 "'&lt;=', 1)]}\">Based on variants</span>"
 msgstr ""
-"<span class=\"text-muted\" invisible=\"product_variant_count &lt;= 1\">Com "
-"base em variantes</span>"
+"<span class=\"text-muted\" attrs=\"{'invisible': [('product_variant_count', "
+"'&lt;=', 1)]}\">Com base em variantes</span>"
 
 #. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.checkout


### PR DESCRIPTION
The wrong translation of the term in Portuguese causes an error when accessing products.

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 386, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "", line 1, in <module>
NameError: name 'product_variant_count' is not defined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 242, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 702, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 925, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1324, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 467, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 438, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1640, in load_views
    result['fields_views'] = {
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1641, in <dictcomp>
    v_type: self.fields_view_get(v_id, v_type if v_type != 'list' else 'tree',
  File "/opt/odoo/auto/addons/web/models/models.py", line 249, in fields_view_get
    r = super().fields_view_get(view_id, view_type, toolbar, submenu)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1731, in fields_view_get
    xarch, xfields = view.postprocess_and_fields(etree.fromstring(result['arch']), model=self._name)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1029, in postprocess_and_fields
    name_manager = self._postprocess_view(node, model or self.model)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1076, in _postprocess_view
    transfer_node_to_modifiers(node, node_info['modifiers'], self._context)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 100, in transfer_node_to_modifiers
    value = bool(quick_eval(value_str, {'context': context or {}}))
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 55, in quick_eval
    return safe_eval.safe_eval(expr, globals_dict)
  File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 402, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 658, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: <class 'NameError'>: "name 'product_variant_count' is not defined" while evaluating
'product_variant_count <= 1'
```

Correcting the translation solves the error.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
