### PR TITLE
[16.0][FIX][backport] http: remove usage of cgi

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -109,7 +109,6 @@ endpoint
 """
 
 import base64
-import cgi
 import collections
 import collections.abc
 import contextlib
@@ -127,7 +126,6 @@ import threading
 import time
 import traceback
 import warnings
-import zlib
 from abc import ABC, abstractmethod
 from datetime import datetime
 from io import BytesIO
@@ -2013,8 +2011,7 @@ class Application:
         if 'Content-Security-Policy' in headers:
             return
 
-        mime, _params = cgi.parse_header(headers.get('Content-Type', ''))
-        if not mime.startswith('image/'):
+        if not headers.get('Content-Type', '').startswith('image/'):
             return
 
         headers['Content-Security-Policy'] = "default-src 'none'"


### PR DESCRIPTION
This is a backport of the PR https://github.com/odoo/odoo/pull/184845.
It allows Python 3.13 compatibility by removing usage of the `cgi` module, which is deprecated and has been removed in Python 3.13.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
