### PR TITLE
[FIX] [18.0] defuse possible endless loop in groupby rendering

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1329,11 +1329,12 @@ actual arch.
         # contain fields on the comodel
         name = node.get('name')
         field = name_manager.model._fields.get(name)
-        if not field or not field.comodel_name:
+        if self.env.context.get('no_nested_groupby') or not field or not field.comodel_name:
             return
         # post-process the node as a nested view, and associate it to the field
         node_info['children'] = []
         self._postprocess_view(node, field.comodel_name, editable=False, node_info=node_info)
+        self.with_context(no_nested_groupby=True)._postprocess_view(node, field.comodel_name, editable=False, node_info=node_info)
         name_manager.has_field(node, name, node_info)
 
     def _postprocess_tag_label(self, node, name_manager, node_info):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The default Odoo Journal Items view (account.move.line tree view) contains a <groupby> component to add a button next to the partner name on the grouping header. When one of the custom modules defines a field called "partner_id" on the "res.partner" model, an endless loop occurs, because the groupby tag is handled again in the nested view postprocessing call and the condition to not handle the groupby tag in the nested call is flawed.

The real solution would probably be to render only the child items underneath the groupby tag, but this solution works also.

**Current behavior before PR:**

If your custom module defines 'partner_id' field on 'res.partner', the default Journal Items tree view in Odoo breaks. This is just one of the examples that can go wrong, there are sure to be others.

**Desired behavior after PR is merged:**

Nested groupby calls are broken off and this bug does not happen anymore.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
