### PR TITLE
[15.0][FIX] web: compatibility with Serialized fields

### DIFF
--- a/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_record.js
@@ -618,7 +618,7 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
             const formatter = r.type ? field_utils.format[r.type] : _.identity;
 
             r.raw_value = value;
-            r.value = formatter(value, this.fields[name], recordData, this.state);
+            r.value = formatter && formatter(value, this.fields[name], recordData, this.state) || value;
             switch (r.type) {
             case 'date': case 'datetime':
                 r.raw_value = value && value.toDate();


### PR DESCRIPTION
Forward of 

- https://github.com/OCA/OCB/pull/1261

When we include a Serialized field in a Kanban, it will fail as there's no formatter for such fields. And it isn't needed but these fields can be handy to achieve some special techniques using their raw values.

cc @Tecnativa TT50623

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr