### PR TITLE
[14.0][FIX] auth_oauth: make token non-prefetch

### DIFF
--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -18,7 +18,7 @@ class ResUsers(models.Model):
 
     oauth_provider_id = fields.Many2one('auth.oauth.provider', string='OAuth Provider')
     oauth_uid = fields.Char(string='OAuth User ID', help="Oauth Provider user_id", copy=False)
-    oauth_access_token = fields.Char(string='OAuth Access Token', readonly=True, copy=False)
+    oauth_access_token = fields.Char(string='OAuth Access Token', readonly=True, copy=False, prefetch=False)
 
     _sql_constraints = [
         ('uniq_users_oauth_provider_oauth_uid', 'unique(oauth_provider_id, oauth_uid)', 'OAuth UID must be unique per provider'),


### PR DESCRIPTION
Simple patch that prevent the prefetch of the oauth token

closes odoo/odoo#177259

### Description of the issue/feature this PR addresses:

Backport of https://github.com/odoo/odoo/commit/3be513d5cc89ad4fefb84fabd8c9089f9ef95aa2