### PR TITLE
[15.0][FIX] web: catch ResizeObserver error in chrome 132

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -106,7 +106,8 @@ export const errorService = {
                 // ignore Chrome video internal error: https://crbug.com/809574
                 "ResizeObserver loop limit exceeded"
             ]
-            if (!originalError && errorsToIgnore.includes(message)) {
+            if (!(originalError instanceof Error) && errorsToIgnore.includes(message)) {
+                ev.preventDefault();
                 return;
             }
             const isRedactedError = !filename && !lineno && !colno;


### PR DESCRIPTION
Taking https://github.com/odoo/odoo/pull/196740 as they won't patch v15 anymore. Thanks @abz-odoo ;)

backport of https://github.com/odoo/odoo/pull/194483 Since chrome 132, the shape of error events for the ResizeObserver loop completed with undelivered notifications. error changed: the error key is now set in the event (its value is this specific message, i.e. a string, not an Error instance). As a consequence, those errors are no longer swallowed as they're expected to be, and are thus wrongly identified as CORS errors. Those errors are shown to the user in debug mode.

This happens for instance in the ir.ui.view form view, which contains an AceEditor field. His CodeEditor component listens on the resize event to redrawn itself, which causes this error. This also happens with the website builder, which does not involve the CodeEditor. It probably happens at other places as well. We thus need a global solution, like we had before.


and backport of https://github.com/odoo/odoo/pull/194795

catch ResizeObserver error in chrome 132

In error_service, event.preventDefault() is required to prevent uncaught error message due to latest Chrome version (132) compatibility.

cc @Tecnativa TT54978

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
