### PR TITLE
[16.0][IMP] core: add support for NULLS {FIRST | LAST} in ORDER BY clauses

### DIFF
--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -60,6 +60,75 @@ class test_search(TransactionCase):
         id_desc_active_desc = Partner.search([('name', 'like', 'test_search_order%'), '|', ('active', '=', True), ('active', '=', False)], order="id desc, active desc")
         self.assertEqual([e, ab, b, a, d, c], list(id_desc_active_desc), "Search with 'ID DESC, ACTIVE DESC' order failed.")
 
+        a.ref = "ref1"
+        c.ref = "ref2"
+        ids = (a | b | c).ids
+        for order, result in [
+            ('ref', a | c | b),
+            ('ref desc', b | c | a),
+            ('ref asc nulls first', b | a | c),
+            ('ref asc nulls last', a | c | b),
+            ('ref desc nulls first', b | c | a),
+            ('ref desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+        # sorting by an m2o should alias to the natural order of the m2o
+        self.patch_order('res.country', 'phone_code')
+        a.country_id, c.country_id = self.env['res.country'].create([{
+            'name': "Country 1",
+            'code': 'C1',
+            'phone_code': '01',
+        }, {
+            'name': 'Country 2',
+            'code': 'C2',
+            'phone_code': '02'
+        }])
+        for order, result in [
+            ('country_id', a | c | b),
+            ('country_id desc', b | c | a),
+            ('country_id asc nulls first', b | a | c),
+            ('country_id asc nulls last', a | c | b),
+            ('country_id desc nulls first', b | c | a),
+            ('country_id desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+        # NULLS applies to the m2o itself, not its sub-fields, so a null `phone_code`
+        # will sort normally (larger than non-null codes)
+        b.country_id = self.env['res.country'].create({'name': "Country X", 'code': 'C3'})
+        for order, result in [
+            ('country_id', a | c | b),
+            ('country_id desc', b | c | a),
+            ('country_id asc nulls first', a | c | b),
+            ('country_id asc nulls last', a | c | b),
+            ('country_id desc nulls first', b | c | a),
+            ('country_id desc nulls last', b | c | a)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+        # a field DESC should reverse the nested behaviour (and thus the inner
+        # NULLS clauses), but the outer NULLS clause still has no effect
+        self.patch_order('res.country', 'phone_code NULLS FIRST')
+        for order, result in [
+            ('country_id', b | a | c),
+            ('country_id desc', c | a | b),
+            ('country_id asc nulls first', b | a | c),
+            ('country_id asc nulls last', b | a | c),
+            ('country_id desc nulls first', c | a | b),
+            ('country_id desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+
     def test_10_inherits_m2order(self):
         Users = self.env['res.users']
 

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -3,6 +3,7 @@
 
 import json
 
+import unittest
 from unittest.mock import patch
 
 from odoo import Command
@@ -1017,7 +1018,7 @@ class PropertiesCase(TransactionCase):
             'discussion': self.discussion_1.id,
             'author': self.user.id,
             'attributes': [{
-                'name': 'My Tags',
+                'name': 'my_tags',
                 'type': 'many2many',
                 'comodel': 'test_new_api.multi.tag',
                 'value': tags.ids,
@@ -1350,7 +1351,6 @@ class PropertiesCase(TransactionCase):
         }
         self.assertEqual(expected_properties, sql_properties)
 
-    @mute_logger('odoo.fields')
     @users('test')
     def test_properties_field_security(self):
         """Check the access right related to the Properties fields."""
@@ -1456,6 +1456,255 @@ class PropertiesCase(TransactionCase):
         value = self.env.cr.fetchone()
         self.assertTrue(value and value[0])
         return value[0]
+
+class PropertiesSearchCase(PropertiesCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.messages = cls.message_1 | cls.message_2 | cls.message_3
+        cls.env['test_new_api.message'].search([('id', 'not in', cls.messages.ids)]).unlink()
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_boolean(self):
+        # search on boolean
+        self.message_1.attributes = [{
+            'name': 'myboolean',
+            'type': 'boolean',
+            'value': True,
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'myboolean': False}
+        messages = self.env['test_new_api.message'].search([('attributes.myboolean', '=', True)])
+        self.assertEqual(messages, self.message_1)
+        messages = self.env['test_new_api.message'].search([('attributes.myboolean', '!=', False)])
+        self.assertEqual(messages, self.message_1)
+        messages = self.env['test_new_api.message'].search([('attributes.myboolean', '=', False)])
+        # message 2 has a falsy boolean properties
+        # message 3 doesn't have the properties (key in dict doesn't exist)
+        self.assertEqual(messages, self.message_2 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.myboolean', '!=', True)])
+        self.assertEqual(messages, self.message_2 | self.message_3)
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_char(self):
+        # search on text properties
+        self.message_1.attributes = [{
+            'name': 'mychar',
+            'type': 'char',
+            'value': 'Test',
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'mychar': 'TeSt'}
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', 'Test')])
+        self.assertEqual(messages, self.message_1, "Should be able to search on a properties field")
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', '"Test"')])
+        self.assertFalse(messages)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', 'ilike', 'test')])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', 'not ilike', 'test')])
+        self.assertFalse(messages)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', 'ilike', '"test"')])
+        self.assertFalse(messages)
+        for forbidden_char in '! ()"\'.':
+            searches = (
+                f'mychar{forbidden_char}',
+                f'my{forbidden_char}char',
+                f'{forbidden_char}mychar',
+            )
+            for search in searches:
+                with self.assertRaises(ValueError), self.assertQueryCount(0):
+                    self.env['test_new_api.message'].search([(f'attributes.{search}', '=', 'Test')])
+        # search falsy properties
+        self.message_3.discussion = self.message_2.discussion
+        self.message_3.attributes = [{'name': 'mychar', 'value': False}]
+        self.assertEqual(self._get_sql_properties(self.message_3), {'mychar': False})
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', False)])
+        self.assertEqual(messages, self.message_3)
+        # search falsy properties when the key doesn't exist in the dict
+        # message 2 properties is False, message 3 properties doesn't exist in database
+        self.message_2.attributes = [{'name': 'mychar', 'value': False}]
+        self.env.cr.execute(
+            "UPDATE test_new_api_message SET attributes = '{}' WHERE id = %s",
+            [self.message_3.id],
+        )
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', False)])
+        self.assertEqual(messages, self.message_2 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '!=', False)])
+        self.assertEqual(messages, self.message_1)
+        # message 1 property contain a string but is not falsy so it's not returned
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '!=', True)])
+        self.assertEqual(messages, self.message_2 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', True)])
+        self.assertEqual(messages, self.message_1)
+        # message 3 is now null instead of being an empty dict
+        self.env.cr.execute(
+            "UPDATE test_new_api_message SET attributes = NULL WHERE id = %s",
+            [self.message_3.id],
+        )
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '=', False)])
+        self.assertEqual(messages, self.message_2 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mychar', '!=', False)])
+        self.assertEqual(messages, self.message_1)
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_float(self):
+        # search on float
+        self.message_1.attributes = [{
+            'name': 'myfloat',
+            'type': 'float',
+            'value': 3.14,
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'myfloat': 5.55}
+        messages = self.env['test_new_api.message'].search([('attributes.myfloat', '>', 4.4)])
+        self.assertEqual(messages, self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.myfloat', '<', 4.4)])
+        self.assertEqual(messages, self.message_1)
+        messages = self.env['test_new_api.message'].search([('attributes.myfloat', '>', 1.1)])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.myfloat', '<=', 1.1)])
+        self.assertFalse(messages)
+        messages = self.env['test_new_api.message'].search([('attributes.myfloat', '=', 3.14)])
+        self.assertEqual(messages, self.message_1)
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_integer(self):
+        # search on integer
+        self.messages.discussion = self.discussion_1
+        self.message_1.attributes = [{
+            'name': 'myint',
+            'type': 'integer',
+            'value': 33,
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'myint': 111}
+        self.message_3.attributes = {'myint': -2}
+        messages = self.env['test_new_api.message'].search([('attributes.myint', '>', 4)])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.myint', '<', 4)])
+        self.assertEqual(messages, self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.myint', '=', 111)])
+        self.assertEqual(messages, self.message_2)
+        # search on the JSONified value (operator "->>")
+        messages = self.env['test_new_api.message'].search([('attributes.myint', 'ilike', '1')])
+        self.assertEqual(messages, self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.myint', 'not ilike', '1')])
+        self.assertEqual(messages, self.message_1 | self.message_3)
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_many2many(self):
+        self.messages.discussion = self.discussion_1
+        partners = self.env['res.partner'].create([{'name': 'A'}, {'name': 'B'}, {'name': 'C'}])
+        self.message_1.attributes = [{
+            'name': 'mymany2many',
+            'type': 'many2many',
+            'comodel': 'res.partner',
+            'value': partners.ids,
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'mymany2many': [partners[1].id]}
+        self.message_3.attributes = {'mymany2many': [partners[2].id]}
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mymany2many', 'in', partners[0].id)])
+        self.assertEqual(messages, self.message_1)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mymany2many', 'in', partners[1].id)])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mymany2many', 'in', partners[2].id)])
+        self.assertEqual(messages, self.message_1 | self.message_3)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mymany2many', 'not in', partners[0].id)])
+        self.assertEqual(messages, self.message_2 | self.message_3)
+        # IN operator (not supported on many2many and return weird results)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mymany2many', 'in', [partners[0].id, partners[1].id])])
+        self.assertEqual(messages, self.message_2)  # should be self.message_1 | self.message_2
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_many2one(self):
+        # many2one are just like integer
+        self.messages.discussion = self.discussion_1
+        self.message_1.attributes = [{
+            'name': 'mypartner',
+            'type': 'integer',
+            'value': self.partner.id,
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'mypartner': self.partner_2.id}
+        self.message_3.attributes = {'mypartner': False}
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mypartner', 'in', [self.partner.id, self.partner_2.id])])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mypartner', 'not in', [self.partner.id, self.partner_2.id])])
+        self.assertEqual(messages, self.message_3)
+        messages = self.env['test_new_api.message'].search(
+            [('attributes.mypartner', 'ilike', self.partner.display_name)])
+        self.assertFalse(messages, "The ilike on relational properties is not supported")
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_tags(self):
+        self.messages.discussion = self.discussion_1
+        self.message_1.attributes = [{
+            'name': 'mytags',
+            'type': 'tags',
+            'value': ['a', 'b'],
+            'tags': [['a', 'A', 1], ['b', 'B', 2], ['aa', 'AA', 3]],
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'mytags': ['b']}
+        self.message_3.attributes = {'mytags': ['aa']}
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', 'a')])
+        self.assertEqual(messages, self.message_1)
+        # the search is done on the JSONified value (operator "->>")
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'ilike', 'a')])
+        self.assertEqual(messages, self.message_1 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'not ilike', 'a')])
+        self.assertEqual(messages, self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', 'b')])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', 'aa')])
+        self.assertEqual(messages, self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'not in', 'b')])
+        self.assertEqual(messages, self.message_3)
+        # the search is done on the JSONified value (operator "->>")
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'ilike', '["aa"]')])
+        self.assertEqual(messages, self.message_3)
+        # IN operator on array
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', [])])
+        self.assertFalse(messages)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'not in', [])])
+        self.assertEqual(messages, self.message_1 | self.message_2 | self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', ['a', 'b'])])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', ['b', 'a'])])
+        self.assertEqual(messages, self.message_1 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', ['aa'])])
+        self.assertEqual(messages, self.message_3)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'in', ['aa', 'b'])])
+        self.assertEqual(messages, self.message_3 | self.message_2)
+        messages = self.env['test_new_api.message'].search([('attributes.mytags', 'not in', ['a', 'b'])])
+        self.assertEqual(messages, self.message_3)
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_unaccent(self):
+        if not self.registry.has_unaccent:
+            # To enable unaccent feature:
+            # CREATE EXTENSION unaccent;
+            raise unittest.SkipTest("unaccent not enabled")
+        Model = self.env['test_new_api.message']
+        (self.message_1 | self.message_2).discussion = self.discussion_1
+        # search on text properties
+        self.message_1.attributes = [{
+            'name': 'mychar',
+            'type': 'char',
+            'value': 'Hélène',
+            'definition_changed': True,
+        }]
+        self.message_2.attributes = {'mychar': 'Helene'}
+        result = Model.search([('attributes.mychar', 'ilike', 'Helene')])
+        self.assertEqual(self.message_1 | self.message_2, result)
+        result = Model.search([('attributes.mychar', 'ilike', 'hélène')])
+        self.assertEqual(self.message_1 | self.message_2, result)
+        result = Model.search([('attributes.mychar', 'not ilike', 'Helene')])
+        self.assertNotIn(self.message_1, result)
+        self.assertNotIn(self.message_2, result)
+        result = Model.search([('attributes.mychar', 'not ilike', 'hélène')])
+        self.assertNotIn(self.message_1, result)
+        self.assertNotIn(self.message_2, result)
 
     def test_properties_inherits(self):
         email = self.env['test_new_api.emailmessage'].create({

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3241,6 +3241,7 @@ class Properties(Field):
     column_type = ('jsonb', 'jsonb')
     copy = False
     prefetch = False
+    unaccent = True
     write_sequence = 10              # because it must be written after the definition field
 
     # the field is computed editable by design (see the compute method below)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -60,7 +60,6 @@ from .tools import (
     get_lang, LastOrderedSet, lazy_classproperty, OrderedSet, ormcache,
     partition, populate, Query, ReversedIterable, split_every, unique,
 )
-from .tools.func import frame_codeinfo
 from .tools.lru import LRU
 from .tools.translate import _, _lt
 
@@ -68,7 +67,18 @@ _logger = logging.getLogger(__name__)
 _unlink = logging.getLogger(__name__ + '.unlink')
 
 regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
-regex_order = re.compile(r'^(\s*([a-z0-9:_]+|"[a-z0-9:_]+")(\.id)?(\s+(desc|asc))?\s*(,|$))+(?<!,)$', re.I)
+regex_order = re.compile(r'''
+    ^
+    (\s*
+        ((?P<field>[a-z0-9:_]+|"[a-z0-9:_]+")(\.(?P<property>[a-z0-9_]+))?)
+        (\s+(?P<direction>desc|asc))?
+        (\s+(?P<nulls>nulls\ first|nulls\ last))?
+        \s*
+        (,|$)
+    )+
+    (?<!,)
+    $
+''', re.IGNORECASE | re.VERBOSE)
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
 regex_pg_name = re.compile(r'^[a-z_][a-z0-9_$]*$', re.I)
 regex_field_agg = re.compile(r'(\w+)(?::(\w+)(?:\((\w+)\))?)?')
@@ -4563,11 +4573,17 @@ class BaseModel(metaclass=MetaModel):
 
         order_by_elements = []
         for order_part in order_spec.split(','):
-            order_split = order_part.strip().split(' ')
-            order_field = order_split[0].strip()
-            order_direction = order_split[1].strip().upper() if len(order_split) == 2 else ''
+            order_match = regex_order.match(order_part)
+            order_field = order_match['field']
+            property_name = order_match['property']
+            if property_name:
+                check_property_field_value_name(property_name)
+            order_direction = (order_match['direction'] or '').upper()
+            order_nulls = (order_match['nulls'] or '').upper()
             if reverse_direction:
                 order_direction = 'ASC' if order_direction == 'DESC' else 'DESC'
+                if order_nulls:
+                    order_nulls = 'NULLS LAST' if order_nulls == 'NULLS FIRST' else 'NULLS FIRST'
             do_reverse = order_direction == 'DESC'
 
             field = self._fields.get(order_field)
@@ -4575,12 +4591,18 @@ class BaseModel(metaclass=MetaModel):
                 raise ValueError("Invalid field %r on model %r" % (order_field, self._name))
 
             if order_field == 'id':
-                order_by_elements.append('"%s"."%s" %s' % (alias, order_field, order_direction))
+                order_by_elements.append(f'"{alias}"."{order_field}" {order_direction} {order_nulls}')
             else:
                 if field.inherited:
                     field = field.base_field
                 if field.store and field.type == 'many2one':
                     key = (field.model_name, field.comodel_name, order_field)
+                    if order_nulls:
+                        qname = self._inherits_join_calc(alias, order_field, query)
+                        if order_nulls == 'NULLS LAST':
+                            order_by_elements.append(f"{qname} IS NULL")
+                        elif order_nulls == 'NULLS FIRST':
+                            order_by_elements.append(f"{qname} IS NOT NULL")
                     if key not in seen:
                         seen.add(key)
                         order_by_elements += self._generate_m2o_order_by(alias, order_field, query, do_reverse, seen)
@@ -4588,7 +4610,9 @@ class BaseModel(metaclass=MetaModel):
                     qualifield_name = self._inherits_join_calc(alias, order_field, query)
                     if field.type == 'boolean':
                         qualifield_name = "COALESCE(%s, false)" % qualifield_name
-                    order_by_elements.append("%s %s" % (qualifield_name, order_direction))
+                    elif field.type == 'properties' and property_name:
+                        qualifield_name = f"({qualifield_name} -> '{property_name}')"
+                    order_by_elements.append(f"{qualifield_name} {order_direction} {order_nulls}")
                 else:
                     _logger.warning("Model %r cannot be sorted on field %r (not a column)", self._name, order_field)
                     continue  # ignore non-readable or "non-joinable" fields

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -67,6 +67,7 @@ from .tools.translate import _, _lt
 _logger = logging.getLogger(__name__)
 _unlink = logging.getLogger(__name__ + '.unlink')
 
+regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
 regex_order = re.compile(r'^(\s*([a-z0-9:_]+|"[a-z0-9:_]+")(\.id)?(\s+(desc|asc))?\s*(,|$))+(?<!,)$', re.I)
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
 regex_pg_name = re.compile(r'^[a-z_][a-z0-9_$]*$', re.I)
@@ -119,6 +120,12 @@ def check_method_name(name):
     """ Raise an ``AccessError`` if ``name`` is a private method name. """
     if regex_private.match(name):
         raise AccessError(_('Private methods (such as %s) cannot be called remotely.', name))
+
+
+def check_property_field_value_name(property_name):
+    if not regex_alphanumeric.match(property_name):
+        raise ValueError(_("Wrong property field value name %r.", property_name))
+
 
 def fix_import_export_id_paths(fieldname):
     """

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -114,6 +114,7 @@ start the server specifying the ``--unaccent`` flag.
 
 """
 import collections.abc
+import json
 import logging
 import reprlib
 import traceback
@@ -123,7 +124,7 @@ from datetime import date, datetime, time
 from psycopg2.sql import Composable, SQL
 
 import odoo.modules
-from ..models import BaseModel
+from ..models import BaseModel, check_property_field_value_name
 from odoo.tools import pycompat, Query, _generate_table_alias, sql
 
 
@@ -686,6 +687,52 @@ class expression(object):
                 dom = HIERARCHY_FUNCS[operator](left, ids2, model)
                 for dom_leaf in dom:
                     push(dom_leaf, model, alias)
+
+            elif field.type == 'properties':
+                if len(path) != 2 and "." in path[1]:
+                    raise ValueError(f"Wrong path {path}")
+                elif operator not in ('=', '!=', '>', '>=', '<', '<=', 'in', 'not in', 'like', 'ilike', 'not like', 'not ilike'):
+                    raise ValueError(f"Wrong search operator {operator!r}")
+                property_name = path[1]
+                check_property_field_value_name(property_name)
+                if (isinstance(right, bool) or right is None) and operator in ('=', '!='):
+                    # check for boolean value but also for key existence
+                    if right:
+                        # inverse the condition
+                        right = False
+                        operator = '!=' if operator == '=' else '='
+                    sql_path = f'"{alias}"."{field.name}"'
+                    key_existence_expr = ""
+                    if operator == '=':  # property == False
+                        key_existence_expr = (
+                            f"OR ({sql_path} IS NULL) "
+                            f"OR NOT ({sql_path} ? '{property_name}')"
+                        )
+                    expr = f"(({sql_path} -> '{property_name}') {operator} '%s' {key_existence_expr})"
+                    push_result(expr, [right])
+                else:
+                    if 'like' in operator:
+                        right = f'%{pycompat.to_text(right)}%'
+                        unaccent = self._unaccent(field)
+                    else:
+                        unaccent = lambda x: x
+                    inverse = ''
+                    arrow = '->'  # raw value
+                    if operator in ('in', 'not in'):
+                        if operator == 'not in':
+                            inverse = 'NOT'
+                        if isinstance(right, (list, tuple)):
+                            operator = '<@'
+                        else:
+                            operator = '@>'
+                        right = json.dumps(right)
+                    elif isinstance(right, str):
+                        arrow = '->>'  # JSONified value
+                    else:
+                        right = json.dumps(right)
+                    sql_path = f""""{alias}"."{field.name}" {arrow} '{property_name}'"""
+                    expr = f"""({inverse} ({unaccent(sql_path)}) {operator} ({unaccent('%s')}))"""
+                    push_result(expr, [right])
 
             # ----------------------------------------
             # PATH SPOTTED


### PR DESCRIPTION
Backports:

- https://github.com/odoo/odoo/pull/101901
- https://github.com/odoo/odoo/pull/117439

Actually my goal was to merge missing "nulls first/last" in order by clauses, but I saw that there is a function named "check_property_field_value_name" which comes from search on property fields feature PR. So I decided to backport both of them.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
