### PR TITLE
[12.0] [FIX] web: properly handle form state with nested notebooks

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -198,7 +198,7 @@ var FormRenderer = BasicRenderer.extend({
             var $notebook = $(this);
             var name = $notebook.data('name');
             var index = -1;
-            $notebook.find('.nav-link').each(function (i) {
+            $notebook.find('> ul > li > a.nav-link').each(function (i) {
                 if ($(this).hasClass('active')) {
                     index = i;
                 }


### PR DESCRIPTION
**Steps to reproduce:**

1. Create a form with a notebook, with pages "A", "B", and "C"
2. In page "B", create another notebook with a name="notebook_B", and pages "1", "2", and "3".
3. Create a record on this form, and focus on page "B" and then page "3".
4. Click on the "Edit" button

**Result:**

- The page "C" is focused

**Expected:**

- Focus shouldn't change

**Explanation:**

The focused page is handled by the `getLocalState` and `setLocalState` methods, which are used to store the focused page index for each notebook on the form.

However, the code doesn't handle properly the case of nested forms: when trying to identify the focused page index, it's looping through all the nested pages.

This commit modifies the selector used to only look for the direct page elements.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
