### PR TITLE
[14.0][FIX] base: KeyError when updating module after removing model with selection field

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1425,12 +1425,14 @@ class IrModelSelection(models.Model):
                 records.invalidate_cache([fname])
 
         for selection in self:
-            Model = self.env[selection.field_id.model]
             # The field may exist in database but not in registry. In this case
             # we allow the field to be skipped, but for production this should
             # be handled through a migration script. The ORM will take care of
             # the orphaned 'ir.model.fields' down the stack, and will log a
             # warning prompting the developer to write a migration script.
+            Model = self.env.get(selection.field_id.model)
+            if Model is None:
+                continue
             field = Model._fields.get(selection.field_id.name)
             if not field or not field.store or not Model._auto:
                 continue


### PR DESCRIPTION
This is a backport of a fix that has been merged in v16/v17/v18: https://github.com/odoo/odoo/pull/184764

Related bug report: https://github.com/odoo/odoo/issues/179392 ORM: KeyError when updating module after removing model with selection field

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
