### PR TITLE
[16.0][FIX]base: avoid invalid access error in onchange() when editing user

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -50,7 +50,6 @@ HR_WRITABLE_FIELDS = [
     'km_home_work',
     'marital',
     'mobile_phone',
-    'notes',
     'employee_parent_id',
     'passport_id',
     'permit_no',

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -240,3 +240,17 @@ class TestSelfAccessRights(TestHrCommon):
 
         hubert_acc.invalidate_recordset(["display_name"])
         self.assertEqual(hubert_emp.with_user(hubert).sudo().bank_account_id.sudo(False).display_name, 'FR******7890')
+
+    def test_onchange_readable_fields_with_no_access(self):
+        """
+            The purpose is to test that the onchange logic takes into account `SELF_READABLE_FIELDS`.
+
+            The view contains fields that are in `SELF_READABLE_FIELDS` (example: `private_street`).
+            Even if the user does not have read access to the employee,
+            it should not cause an access error if these fields are in `SELF_READABLE_FIELDS`.
+        """
+        self.env['res.lang']._activate_lang("fr_FR")
+        with Form(self.richard.with_user(self.richard), view='hr.res_users_view_form_profile') as form:
+            # triggering an onchange should not trigger some access error
+            form.lang = "fr_FR"
+            form.tz = "Europe/Brussels"

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -619,6 +619,13 @@ class Users(models.Model):
                 user.partner_id.toggle_active()
         super(Users, self).toggle_active()
 
+    def onchange(self, values, field_names, fields_spec):
+        # Hacky fix to access fields in `SELF_READABLE_FIELDS` in the onchange logic.
+        # Put field values in the cache.
+        if self == self.env.user:
+            [self.sudo()[field_name] for field_name in self.SELF_READABLE_FIELDS]
+        return super().onchange(values, field_names, fields_spec)
+
     def read(self, fields=None, load='_classic_read'):
         if fields and self == self.env.user:
             readable = self.SELF_READABLE_FIELDS

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2446,6 +2446,8 @@ class Form(object):
         self._changed.update(self._view['fields'])
 
     def _init_from_values(self, values):
+        self._env.flush_all()
+        self._env.clear()  # discard cache and pending recomputations
         self._values.update(
             record_to_values(self._view['fields'], values))
 


### PR DESCRIPTION
Cherry-picked two fixes that avoid Access Error because can't read some fields on the employee that corresponds to the user.

Original PR:
https://github.com/odoo/odoo/pull/148997

There was a refactor of class Form between 16.0 and 17.0 versions. The class moved from tests/common.py (16.0) to tests/form.py (17.0), so I just copied the two lines of the fix in `_init_from_values`  method.