### PR TITLE
[15.0][fix] account_edi_facturx: translation of statix value udt:Indicator false

### DIFF
--- a/addons/account_edi_facturx/i18n/account_edi_facturx.pot
+++ b/addons/account_edi_facturx/i18n/account_edi_facturx.pot
@@ -132,11 +132,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ar.po
+++ b/addons/account_edi_facturx/i18n/ar.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ar.po
+++ b/addons/account_edi_facturx/i18n/ar.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "خاطئ"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/az.po
+++ b/addons/account_edi_facturx/i18n/az.po
@@ -137,11 +137,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/bn.po
+++ b/addons/account_edi_facturx/i18n/bn.po
@@ -137,11 +137,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ca.po
+++ b/addons/account_edi_facturx/i18n/ca.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ca.po
+++ b/addons/account_edi_facturx/i18n/ca.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "Fals"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/cs.po
+++ b/addons/account_edi_facturx/i18n/cs.po
@@ -143,11 +143,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/da.po
+++ b/addons/account_edi_facturx/i18n/da.po
@@ -139,11 +139,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/da.po
+++ b/addons/account_edi_facturx/i18n/da.po
@@ -141,7 +141,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "Falsk"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/de.po
+++ b/addons/account_edi_facturx/i18n/de.po
@@ -146,7 +146,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "falsch"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/de.po
+++ b/addons/account_edi_facturx/i18n/de.po
@@ -144,11 +144,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/el.po
+++ b/addons/account_edi_facturx/i18n/el.po
@@ -139,11 +139,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/es.po
+++ b/addons/account_edi_facturx/i18n/es.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/es.po
+++ b/addons/account_edi_facturx/i18n/es.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "False"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/es_MX.po
+++ b/addons/account_edi_facturx/i18n/es_MX.po
@@ -143,7 +143,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "falso"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/es_MX.po
+++ b/addons/account_edi_facturx/i18n/es_MX.po
@@ -141,11 +141,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/et.po
+++ b/addons/account_edi_facturx/i18n/et.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "väär"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/et.po
+++ b/addons/account_edi_facturx/i18n/et.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/fa.po
+++ b/addons/account_edi_facturx/i18n/fa.po
@@ -139,11 +139,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/fa.po
+++ b/addons/account_edi_facturx/i18n/fa.po
@@ -141,7 +141,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "نادرست‌"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/fi.po
+++ b/addons/account_edi_facturx/i18n/fi.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/fr.po
+++ b/addons/account_edi_facturx/i18n/fr.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/fr.po
+++ b/addons/account_edi_facturx/i18n/fr.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "faux"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/he.po
+++ b/addons/account_edi_facturx/i18n/he.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/he.po
+++ b/addons/account_edi_facturx/i18n/he.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "לא נכון"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/hr.po
+++ b/addons/account_edi_facturx/i18n/hr.po
@@ -142,7 +142,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "netočno"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/hr.po
+++ b/addons/account_edi_facturx/i18n/hr.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/hu.po
+++ b/addons/account_edi_facturx/i18n/hu.po
@@ -140,7 +140,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "hamis"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/hu.po
+++ b/addons/account_edi_facturx/i18n/hu.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/id.po
+++ b/addons/account_edi_facturx/i18n/id.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/it.po
+++ b/addons/account_edi_facturx/i18n/it.po
@@ -145,7 +145,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "falso"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/it.po
+++ b/addons/account_edi_facturx/i18n/it.po
@@ -143,11 +143,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ja.po
+++ b/addons/account_edi_facturx/i18n/ja.po
@@ -141,11 +141,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ka.po
+++ b/addons/account_edi_facturx/i18n/ka.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ko.po
+++ b/addons/account_edi_facturx/i18n/ko.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ko.po
+++ b/addons/account_edi_facturx/i18n/ko.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "X"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/lo.po
+++ b/addons/account_edi_facturx/i18n/lo.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/lt.po
+++ b/addons/account_edi_facturx/i18n/lt.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/lt.po
+++ b/addons/account_edi_facturx/i18n/lt.po
@@ -142,7 +142,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "ne"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/lv.po
+++ b/addons/account_edi_facturx/i18n/lv.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/mn.po
+++ b/addons/account_edi_facturx/i18n/mn.po
@@ -137,11 +137,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/mn.po
+++ b/addons/account_edi_facturx/i18n/mn.po
@@ -139,7 +139,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "худал"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/nb.po
+++ b/addons/account_edi_facturx/i18n/nb.po
@@ -137,11 +137,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/nb.po
+++ b/addons/account_edi_facturx/i18n/nb.po
@@ -139,7 +139,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "usann"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/nl.po
+++ b/addons/account_edi_facturx/i18n/nl.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/nl.po
+++ b/addons/account_edi_facturx/i18n/nl.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "onwaar"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/pl.po
+++ b/addons/account_edi_facturx/i18n/pl.po
@@ -139,11 +139,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/pt.po
+++ b/addons/account_edi_facturx/i18n/pt.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/pt_BR.po
+++ b/addons/account_edi_facturx/i18n/pt_BR.po
@@ -140,7 +140,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "falso"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/pt_BR.po
+++ b/addons/account_edi_facturx/i18n/pt_BR.po
@@ -138,11 +138,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ro.po
+++ b/addons/account_edi_facturx/i18n/ro.po
@@ -141,11 +141,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/ru.po
+++ b/addons/account_edi_facturx/i18n/ru.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "ложь"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/ru.po
+++ b/addons/account_edi_facturx/i18n/ru.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/sk.po
+++ b/addons/account_edi_facturx/i18n/sk.po
@@ -139,11 +139,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/sk.po
+++ b/addons/account_edi_facturx/i18n/sk.po
@@ -141,7 +141,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "nepravda"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/sl.po
+++ b/addons/account_edi_facturx/i18n/sl.po
@@ -137,11 +137,6 @@ msgid "factur-x.xml"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/sl.po
+++ b/addons/account_edi_facturx/i18n/sl.po
@@ -139,7 +139,7 @@ msgstr ""
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "napačno"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/sv.po
+++ b/addons/account_edi_facturx/i18n/sv.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "falsk"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/sv.po
+++ b/addons/account_edi_facturx/i18n/sv.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/th.po
+++ b/addons/account_edi_facturx/i18n/th.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/th.po
+++ b/addons/account_edi_facturx/i18n/th.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "เป็นเท็จ"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/tr.po
+++ b/addons/account_edi_facturx/i18n/tr.po
@@ -145,7 +145,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "yanlış"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/tr.po
+++ b/addons/account_edi_facturx/i18n/tr.po
@@ -143,11 +143,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/uk.po
+++ b/addons/account_edi_facturx/i18n/uk.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "помилка"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/uk.po
+++ b/addons/account_edi_facturx/i18n/uk.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/vi.po
+++ b/addons/account_edi_facturx/i18n/vi.po
@@ -142,7 +142,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "sai"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/vi.po
+++ b/addons/account_edi_facturx/i18n/vi.po
@@ -140,11 +140,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/zh_CN.po
+++ b/addons/account_edi_facturx/i18n/zh_CN.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "特效"

--- a/addons/account_edi_facturx/i18n/zh_CN.po
+++ b/addons/account_edi_facturx/i18n/zh_CN.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "错误"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_facturx/i18n/zh_TW.po
+++ b/addons/account_edi_facturx/i18n/zh_TW.po
@@ -142,11 +142,6 @@ msgid "factur-x.xml"
 msgstr "factur-x.xml"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "false"
-msgstr "false"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "fx"
 msgstr "fx"

--- a/addons/account_edi_facturx/i18n/zh_TW.po
+++ b/addons/account_edi_facturx/i18n/zh_TW.po
@@ -144,7 +144,7 @@ msgstr "factur-x.xml"
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
 msgid "false"
-msgstr "假"
+msgstr "false"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata

--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -36,7 +36,7 @@
                             <!-- Discount. -->
                             <ram:AppliedTradeAllowanceCharge t-if="line.discount">
                                 <ram:ChargeIndicator>
-                                    <udt:Indicator>false</udt:Indicator>
+                                    <udt:Indicator t-translation="off">false</udt:Indicator>
                                 </ram:ChargeIndicator>
                                 <ram:ActualAmount t-out="format_monetary(line_vals['price_discount_unit'], 2)"/>
                             </ram:AppliedTradeAllowanceCharge>


### PR DESCRIPTION
Translations exist for XML static value udt:Indicator which results in a invalid XML. For example in [German](https://github.com/OCA/OCB/blob/15.0/addons/account_edi_facturx/i18n/de.po#L149) the XML includes <udt:Indicator>falsch</udt:Indicator> while <udt:Indicator>false</udt:Indicator> would be correct.

Fixes #1295.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
