### PR TITLE
[15.0][fix] account_edi_facturx: set static values to translation=off

### DIFF
--- a/addons/account_edi_facturx/data/facturx_templates.xml
+++ b/addons/account_edi_facturx/data/facturx_templates.xml
@@ -59,7 +59,7 @@
                         <t t-foreach="tax_details['invoice_line_tax_details'][line]['tax_details'].values()"
                            t-as="tax_detail_vals">
                             <ram:ApplicableTradeTax t-if="tax_detail_vals['amount_type'] == 'percent'">
-                                <ram:TypeCode>VAT</ram:TypeCode>
+                                <ram:TypeCode t-translation="off">VAT</ram:TypeCode>
                                 <ram:CategoryCode t-esc="tax_detail_vals['unece_tax_category_code']"/>
                                 <ram:RateApplicablePercent t-esc="tax_detail_vals['amount']"/>
                             </ram:ApplicableTradeTax>
@@ -119,7 +119,7 @@
                 -->
                 <rsm:ExchangedDocumentContext>
                     <ram:GuidelineSpecifiedDocumentContextParameter>
-                        <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+                        <ram:ID t-translation="off">urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
                     </ram:GuidelineSpecifiedDocumentContextParameter>
                 </rsm:ExchangedDocumentContext>
 
@@ -199,7 +199,7 @@
 
                         <!-- Bank account. -->
                         <ram:SpecifiedTradeSettlementPaymentMeans t-if="record.partner_bank_id.acc_type == 'iban'">
-                        <ram:TypeCode>42</ram:TypeCode>
+                        <ram:TypeCode t-translation="off">42</ram:TypeCode>
                             <ram:PayeePartyCreditorFinancialAccount>
                                 <ram:IBANID t-esc="record.partner_bank_id.sanitized_acc_number"/>
                             </ram:PayeePartyCreditorFinancialAccount>
@@ -210,7 +210,7 @@
                             <ram:ApplicableTradeTax>
                                 <ram:CalculatedAmount
                                     t-esc="format_monetary(balance_multiplicator * tax_detail_vals['tax_amount_currency'], record.currency_id)"/>
-                                <ram:TypeCode>VAT</ram:TypeCode>
+                                <ram:TypeCode t-translation="off">VAT</ram:TypeCode>
                                 <ram:ExemptionReason t-if="tax_detail_vals['unece_tax_category_code'] == 'E'" t-esc="tax_detail_vals['exemption_reason']"/>
                                 <ram:ExemptionReason t-if="tax_detail_vals['unece_tax_category_code'] == 'G'" t-esc="'Export outside the EU'"/>
                                 <ram:ExemptionReason t-if="tax_detail_vals['unece_tax_category_code'] == 'K'" t-esc="'Intra-community supply'"/>
@@ -297,32 +297,32 @@
                             <rdf:Bag>
                                 <rdf:li rdf:parseType="Resource">
                                     <pdfaSchema:schema>Factur-X PDFA Extension Schema</pdfaSchema:schema>
-                                    <pdfaSchema:namespaceURI>urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#</pdfaSchema:namespaceURI>
-                                    <pdfaSchema:prefix>fx</pdfaSchema:prefix>
+                                    <pdfaSchema:namespaceURI t-translation="off">urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#</pdfaSchema:namespaceURI>
+                                    <pdfaSchema:prefix t-translation="off">fx</pdfaSchema:prefix>
                                     <pdfaSchema:property>
                                         <rdf:Seq>
                                             <rdf:li rdf:parseType="Resource">
-                                                <pdfaProperty:name>DocumentFileName</pdfaProperty:name>
-                                                <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                                                <pdfaProperty:category>external</pdfaProperty:category>
+                                                <pdfaProperty:name t-translation="off">DocumentFileName</pdfaProperty:name>
+                                                <pdfaProperty:valueType t-translation="off">Text</pdfaProperty:valueType>
+                                                <pdfaProperty:category t-translation="off">external</pdfaProperty:category>
                                                 <pdfaProperty:description>name of the embedded XML invoice file</pdfaProperty:description>
                                             </rdf:li>
                                             <rdf:li rdf:parseType="Resource">
-                                                <pdfaProperty:name>DocumentType</pdfaProperty:name>
-                                                <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                                                <pdfaProperty:category>external</pdfaProperty:category>
+                                                <pdfaProperty:name t-translation="off">DocumentType</pdfaProperty:name>
+                                                <pdfaProperty:valueType t-translation="off">Text</pdfaProperty:valueType>
+                                                <pdfaProperty:category t-translation="off">external</pdfaProperty:category>
                                                 <pdfaProperty:description>INVOICE</pdfaProperty:description>
                                             </rdf:li>
                                             <rdf:li rdf:parseType="Resource">
-                                                <pdfaProperty:name>Version</pdfaProperty:name>
-                                                <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                                                <pdfaProperty:category>external</pdfaProperty:category>
+                                                <pdfaProperty:name t-translation="off">Version</pdfaProperty:name>
+                                                <pdfaProperty:valueType t-translation="off">Text</pdfaProperty:valueType>
+                                                <pdfaProperty:category t-translation="off">external</pdfaProperty:category>
                                                 <pdfaProperty:description>The actual version of the Factur-X XML schema</pdfaProperty:description>
                                             </rdf:li>
                                             <rdf:li rdf:parseType="Resource">
-                                                <pdfaProperty:name>ConformanceLevel</pdfaProperty:name>
-                                                <pdfaProperty:valueType>Text</pdfaProperty:valueType>
-                                                <pdfaProperty:category>external</pdfaProperty:category>
+                                                <pdfaProperty:name t-translation="off">ConformanceLevel</pdfaProperty:name>
+                                                <pdfaProperty:valueType t-translation="off">Text</pdfaProperty:valueType>
+                                                <pdfaProperty:category t-translation="off">external</pdfaProperty:category>
                                                 <pdfaProperty:description>The conformance level of the embedded Factur-X data</pdfaProperty:description>
                                             </rdf:li>
                                         </rdf:Seq>
@@ -332,10 +332,10 @@
                         </pdfaExtension:schemas>
                     </rdf:Description>
                     <rdf:Description xmlns:fx="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#" rdf:about="">
-                        <fx:ConformanceLevel>EN 16931</fx:ConformanceLevel>
-                        <fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
-                        <fx:DocumentType>INVOICE</fx:DocumentType>
-                        <fx:Version>1.0</fx:Version>
+                        <fx:ConformanceLevel t-translation="off">EN 16931</fx:ConformanceLevel>
+                        <fx:DocumentFileName t-translation="off">factur-x.xml</fx:DocumentFileName>
+                        <fx:DocumentType t-translation="off">INVOICE</fx:DocumentType>
+                        <fx:Version t-translation="off">1.0</fx:Version>
                     </rdf:Description>
                 </rdf:RDF>
             </x:xmpmeta>

--- a/addons/account_edi_facturx/i18n/account_edi_facturx.pot
+++ b/addons/account_edi_facturx/i18n/account_edi_facturx.pot
@@ -16,44 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -89,11 +59,6 @@ msgstr ""
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -111,42 +76,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ar.po
+++ b/addons/account_edi_facturx/i18n/ar.po
@@ -22,45 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "مستوى التوافق "
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "عرض العملة "
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "اسم المستند "
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "نوع المستند "
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "صيغة EDI "
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -95,11 +65,6 @@ msgstr "الضريبة"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "النص"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "النسخة الفعلية للمخطط بصيغة Factur-X XML "
 
@@ -119,42 +84,6 @@ msgstr ""
 "يرجى تنشيطها قبل محاولة الاستيراد مجدداً. "
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ضريبة القيمة المضافة"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "الإصدار"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "خارجي "
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "اسم ملف فاتورة XML المضمن "
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/az.po
+++ b/addons/account_edi_facturx/i18n/az.po
@@ -21,44 +21,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -94,11 +64,6 @@ msgstr "Vergi"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Mətn"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -116,42 +81,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ƏDV"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/bn.po
+++ b/addons/account_edi_facturx/i18n/bn.po
@@ -21,44 +21,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -94,11 +64,6 @@ msgstr "কর"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -116,42 +81,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "সংস্করণ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ca.po
+++ b/addons/account_edi_facturx/i18n/ca.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "Nivell de conformitat"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Mostra la moneda"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "Nom del document"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "Tipus document"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Format Edi"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Impost"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "La versió actual de l'esquema XML de Factur-X"
 
@@ -121,42 +86,6 @@ msgstr ""
 "Si us plau activeu-la abans de tornar a intentar importar."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "CIF/NIF"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versió"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "extern"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nom de l'arxiu de factura XML incrustat"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/cs.po
+++ b/addons/account_edi_facturx/i18n/cs.po
@@ -25,45 +25,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Zobrazovaná měna"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI format"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -98,11 +68,6 @@ msgstr "Daň"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "Aktuální verze XML schématu Factur-X"
 
@@ -122,42 +87,6 @@ msgstr ""
 "Prosím aktivujte ji před tím, než se pokusíte o import."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "DIČ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Verze"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "název vloženého souboru XML faktury"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/da.po
+++ b/addons/account_edi_facturx/i18n/da.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI format"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "Moms"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -118,42 +83,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "Moms"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Version"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/de.po
+++ b/addons/account_edi_facturx/i18n/de.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Währung anzeigen"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "Dokumententyp"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI-Format"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -99,11 +69,6 @@ msgstr "Steuer"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "Die aktuelle Version des Factur-X XML-Schemas"
 
@@ -123,42 +88,6 @@ msgstr ""
 "Bitte aktivieren Sie sie, bevor Sie erneut versuchen zu importieren."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "MwSt."
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Version"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "external"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "Name der eingebetteten XML-Rechnungsdatei"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/el.po
+++ b/addons/account_edi_facturx/i18n/el.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Ηλεκτρονική ανταλλαγή δεδομένων"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr ""
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "Φόρος"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Κείμενο"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -118,42 +83,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ΦΠΑ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Έκδοση"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/es.po
+++ b/addons/account_edi_facturx/i18n/es.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "Nivel de conformidad"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Mostrar la divisa"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "Nombre del archivo de documento"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "Tipo de documento"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Formato EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Impuesto"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Texto"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "La versión actual del Schema de Factur-X XML"
 
@@ -121,42 +86,6 @@ msgstr ""
 "Por favor, actívelo antes de intentar de nuevo la importación."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "NIF"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versión"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "externo"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nombre del archivo de factura XML insertado"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/es_MX.po
+++ b/addons/account_edi_facturx/i18n/es_MX.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "Nivel de conformidad"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Mostrar la divisa"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "Nombre del archivo de documento"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "Tipo de documento"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Formato EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "Impuesto"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Texto"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "La versión actual del Schema de Factur-X XML"
 
@@ -120,42 +85,6 @@ msgstr ""
 "Actívela antes de volver a importar."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "NIF"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versión"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "externo"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nombre del archivo de factura XML insertado"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/et.po
+++ b/addons/account_edi_facturx/i18n/et.po
@@ -26,45 +26,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI kuju"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -99,11 +69,6 @@ msgstr "Tulumaks"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -121,42 +86,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "KMKR nr"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versioon"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/fa.po
+++ b/addons/account_edi_facturx/i18n/fa.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "فرمت EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "مالیات"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "متن"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -118,42 +83,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ارزش افزوده"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "نگارش"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/fi.po
+++ b/addons/account_edi_facturx/i18n/fi.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Näytä valuutta"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI-muoto"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Vero"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Teksti"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ALV"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versio"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/fr.po
+++ b/addons/account_edi_facturx/i18n/fr.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Afficher la devise"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "DocumentType"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "format EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Taxe"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Texte"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "La version actuelle du schéma XML Factur-X"
 
@@ -121,42 +86,6 @@ msgstr ""
 "Veuillez l'activer avant de réessayer d'importer."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "TVA"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Version"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "externe"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nom du fichier de facture XML intégré"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/he.po
+++ b/addons/account_edi_facturx/i18n/he.po
@@ -24,44 +24,14 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "הצגת סוג מטבע"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "DocumentType"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -97,11 +67,6 @@ msgstr "מס"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "טקסט"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -121,42 +86,6 @@ msgstr ""
 "יש לאשר אותו לפני נסיון הייבוא הבא."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ח.פ / ע.מ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "גירסה"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "חיצוני"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "שם קובץ ה-XML שהוטמע בקובץ החשבונית "
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/hr.po
+++ b/addons/account_edi_facturx/i18n/hr.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI format"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr ""
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Porez"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "PDV"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Verzija"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/hu.po
+++ b/addons/account_edi_facturx/i18n/hu.po
@@ -22,44 +22,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -95,11 +65,6 @@ msgstr "Adó"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Szöveg"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "Adószám"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Verzió"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/id.po
+++ b/addons/account_edi_facturx/i18n/id.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Tampilkan mata uang"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Format EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Pajak"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Teks"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "PPN"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versi"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/it.po
+++ b/addons/account_edi_facturx/i18n/it.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Visualizza valuta"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "DocumentType"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Formato EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -98,11 +68,6 @@ msgstr "Imposta"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Testo"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "La versione attuale dello schema XML di Factur-X"
 
@@ -122,42 +87,6 @@ msgstr ""
 "Attivarla prima di ritentare l'importazione."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "Partita IVA"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versione"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "esterno"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nome del file di fattura XML incorporato"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/ja.po
+++ b/addons/account_edi_facturx/i18n/ja.po
@@ -25,45 +25,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI フォーマット"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -98,11 +68,6 @@ msgstr "税"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "テキスト"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -120,42 +85,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "VAT（Value Added Tax）"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "バージョン"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/ka.po
+++ b/addons/account_edi_facturx/i18n/ka.po
@@ -22,44 +22,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -95,11 +65,6 @@ msgstr "გადასახადი"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "ტექსტი"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "ვერსია"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/ko.po
+++ b/addons/account_edi_facturx/i18n/ko.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "통화 표시"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI 양식"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "세금"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "문자"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "부가가치세"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "버전"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/lo.po
+++ b/addons/account_edi_facturx/i18n/lo.po
@@ -22,45 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ລະດັບການປະຕິບັດຕາມ"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "ສະແດງສະກຸນເງີນ"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "ຊື່ຟາຍເອກະສານ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "ປະເພດເອກະສານ"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "ຮູບແບບ ອີດີໄອ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "ອີເອັນ 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -95,11 +65,6 @@ msgstr "ອາກອນ"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ອມພ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/lt.po
+++ b/addons/account_edi_facturx/i18n/lt.po
@@ -24,44 +24,14 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -97,11 +67,6 @@ msgstr "Mokesčiai"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekstas"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "PVM mok. kodas"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versija"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/lv.po
+++ b/addons/account_edi_facturx/i18n/lv.po
@@ -22,44 +22,14 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -95,11 +65,6 @@ msgstr "Nodoklis"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "PVN"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Version"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/mn.po
+++ b/addons/account_edi_facturx/i18n/mn.po
@@ -21,44 +21,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -94,11 +64,6 @@ msgstr "Татвар"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Текст"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -116,42 +81,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "НӨАТ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Хувилбар"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/nb.po
+++ b/addons/account_edi_facturx/i18n/nb.po
@@ -21,44 +21,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -94,11 +64,6 @@ msgstr "Avgift"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -116,42 +81,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "MVA"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versjon"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/nl.po
+++ b/addons/account_edi_facturx/i18n/nl.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Toon valuta"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "DocumentType"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI formaat"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "BTW"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "De daadwerkelijke versie van het Factur-X XML-schema"
 
@@ -121,42 +86,6 @@ msgstr ""
 "Activeer het voordat u opnieuw probeert te importeren."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "BTW"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versie"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "extern"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "naam van het ingesloten XML-factuurbestand"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/pl.po
+++ b/addons/account_edi_facturx/i18n/pl.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Wyświetlanie waluty"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Format EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "Podatek"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Tekst"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -118,42 +83,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "NIP"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Wersja"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/pt.po
+++ b/addons/account_edi_facturx/i18n/pt.po
@@ -22,45 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "NívelDeConformidade"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "NomeDoFicheiroDoDocumento"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "TipoDeDocumento"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "FormatoEDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -95,11 +65,6 @@ msgstr "Imposto"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Texto"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "A versão factual do esquema Factur-X XML"
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "NIF"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versão"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "externo"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "nome do ficheiro de factura embebido XML"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/pt_BR.po
+++ b/addons/account_edi_facturx/i18n/pt_BR.po
@@ -22,45 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Formato para EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -95,11 +65,6 @@ msgstr "Imposto"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Texto"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -117,42 +82,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "CPF/CNPJ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versão"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/ro.po
+++ b/addons/account_edi_facturx/i18n/ro.po
@@ -25,45 +25,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Format EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -98,11 +68,6 @@ msgstr "Taxă"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -120,42 +85,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "TVA"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Versiune"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/ru.po
+++ b/addons/account_edi_facturx/i18n/ru.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI формат"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Налог"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Текст"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "НДС"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Версия"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/sk.po
+++ b/addons/account_edi_facturx/i18n/sk.po
@@ -23,45 +23,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI formát"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr ""
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -96,11 +66,6 @@ msgstr "Daň"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -118,42 +83,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "IČ DPH"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Verzia"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/sl.po
+++ b/addons/account_edi_facturx/i18n/sl.po
@@ -21,44 +21,14 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
 msgstr ""
 
 #. module: account_edi_facturx
@@ -94,11 +64,6 @@ msgstr "Davek"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Besedilo"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -116,42 +81,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ID DDV/DŠ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Različica"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
 msgstr ""

--- a/addons/account_edi_facturx/i18n/sv.po
+++ b/addons/account_edi_facturx/i18n/sv.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Visa valuta"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI-format"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Skatt"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Text"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "Skattenummer"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Version"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/th.po
+++ b/addons/account_edi_facturx/i18n/th.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "รูปแบบ EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "ภาษี"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "ข้อความ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ภาษีมูลค่าเพิ่ม (VAT)"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "เวอร์ชัน"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/tr.po
+++ b/addons/account_edi_facturx/i18n/tr.po
@@ -25,45 +25,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "UygunlukDüzeyi"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Para birimini göster"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "BelgeDosyaAdı"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "Belge Türü"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI biçimi"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -98,11 +68,6 @@ msgstr "Vergi"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Metin"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "Factur-X XML şemasının gerçek sürümü"
 
@@ -122,42 +87,6 @@ msgstr ""
 "Lütfen tekrar içe aktarmayı denemeden önce etkinleştirin."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "VKN/TCKN"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Sürüm"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "harici"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "gömülü XML fatura dosyasının adı"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0 #"

--- a/addons/account_edi_facturx/i18n/uk.po
+++ b/addons/account_edi_facturx/i18n/uk.po
@@ -22,45 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "ConformanceLevel"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "Відобразити валюту"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "DocumentFileName"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "DocumentType"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Формат EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -95,11 +65,6 @@ msgstr "Податок"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Текст"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "Фактична версія XML-схеми Factur-X"
 
@@ -119,42 +84,6 @@ msgstr ""
 "Будь ласка, активуйте його перед повторною спробою імпортувати."
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "ПДВ"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Версія"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "зовнішній"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "ім'я вбудованого файлу рахунка-фактури XML"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/vi.po
+++ b/addons/account_edi_facturx/i18n/vi.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "Định dạng EDI"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "Thuế"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "Văn bản"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -119,42 +84,6 @@ msgid ""
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "Thuế GTGT"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "Phiên bản"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/zh_CN.po
+++ b/addons/account_edi_facturx/i18n/zh_CN.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr "符合性等级(ConformanceLevel)"
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr "显示无效币种警告"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr "文档文件名"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr "文件类型"
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI 格式"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "税项"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "文字"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr "Factur-X XML模式的实际版本"
 
@@ -121,42 +86,6 @@ msgstr ""
 "请先激活它，然后再尝试导入。"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "增值税"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "版本"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr "外部"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "特效"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr "嵌入式XML结算单文件的名称"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"

--- a/addons/account_edi_facturx/i18n/zh_TW.po
+++ b/addons/account_edi_facturx/i18n/zh_TW.po
@@ -24,45 +24,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "1.0"
-msgstr "1.0"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "42"
-msgstr "42"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "ConformanceLevel"
-msgstr ""
-
-#. module: account_edi_facturx
 #: code:addons/account_edi_facturx/models/account_edi_format.py:0
 #, python-format
 msgid "Display the currency"
 msgstr ""
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentFileName"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "DocumentType"
-msgstr ""
-
-#. module: account_edi_facturx
 #: model:ir.model,name:account_edi_facturx.model_account_edi_format
 msgid "EDI format"
 msgstr "EDI 格式"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "EN 16931"
-msgstr "EN 16931"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
@@ -97,11 +67,6 @@ msgstr "稅金"
 
 #. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Text"
-msgstr "文字"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "The actual version of the Factur-X XML schema"
 msgstr ""
 
@@ -121,42 +86,6 @@ msgstr ""
 "請先啟用貨幣，然後再嘗試匯入。"
 
 #. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_line_facturx_export
-msgid "VAT"
-msgstr "增值稅"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "Version"
-msgstr "版本"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "external"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "factur-x.xml"
-msgstr "factur-x.xml"
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "fx"
-msgstr "fx"
-
-#. module: account_edi_facturx
 #: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
 msgid "name of the embedded XML invoice file"
 msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_facturx_export
-msgid "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
-msgstr ""
-
-#. module: account_edi_facturx
-#: model_terms:ir.ui.view,arch_db:account_edi_facturx.account_invoice_pdfa_3_facturx_metadata
-msgid "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
-msgstr "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"


### PR DESCRIPTION
This fix sets several static values as not-translatable and removes them from translation files. Successor of #1296.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
