### PR TITLE
[14.0][FIX] change membership product on invoice line

### DIFF
--- a/addons/membership/tests/common.py
+++ b/addons/membership/tests/common.py
@@ -13,6 +13,14 @@ class TestMembershipCommon(AccountTestInvoicingCommon):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
         # Test memberships
+        cls.membership = cls.env['product.product'].create({
+            'membership': True,
+            'membership_date_from': datetime.date.today() + relativedelta(months=-1),
+            'membership_date_to': datetime.date.today() + relativedelta(days=-2),
+            'name': 'Basic Limited',
+            'type': 'service',
+            'list_price': 90.00,
+        })
         cls.membership_1 = cls.env['product.product'].create({
             'membership': True,
             'membership_date_from': datetime.date.today() + relativedelta(days=-2),

--- a/addons/membership/tests/test_membership.py
+++ b/addons/membership/tests/test_membership.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import time
 from odoo.addons.membership.tests.common import TestMembershipCommon
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 from odoo import fields
 
 
@@ -178,3 +178,37 @@ class TestMembership(TestMembershipCommon):
         })
         invoice = self.partner_1.create_membership_invoice(self.membership_1, 100.0)
         self.assertEqual(invoice.invoice_payment_term_id, pay_term_15_days_after_today)
+
+    def test_change_membership_on_account_move_line(self):
+        invoice = self.partner_1.create_membership_invoice(
+            self.membership, self.membership.list_price
+        )
+        with Form(invoice) as invoice_form:
+            line_form = invoice_form.invoice_line_ids.edit(0)
+            line_form.product_id = self.membership_1
+            line_form.save()
+
+        invoice_line = invoice.invoice_line_ids[0]
+        self.assertEqual(
+            invoice_line.price_unit,
+            self.membership_1.list_price
+        )
+        membership_line = self.env["membership.membership_line"].search(
+            [("account_invoice_line", "=", invoice_line.id)]
+        )
+        self.assertEqual(
+            membership_line.membership_id,
+            self.membership_1
+        )
+        self.assertEqual(
+            membership_line.member_price,
+            self.membership_1.list_price
+        )
+        self.assertEqual(
+            membership_line.date_from,
+            self.membership_1.membership_date_from
+        )
+        self.assertEqual(
+            membership_line.date_to,
+            self.membership_1.membership_date_to
+        )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

While changing information on invoice line, the related membership line is not updated.

This is done as part of OCA Internal Working Group: [task 871862](https://odoo-community.org/my/task/871862)

Current behavior before PR:

* create 2 membership products
* create an invoice with one membership product and save the draft invoice
* (you can see the mebership line is already created with proper information)
* go back to the invoice and use the other product
* :boom: member ship line is not updated

(So, this also happen while duplicating an invoice from previous year changing the membership product.)

Desired behavior after PR is merged:

The member ship line is updated with fresh informations changed on the invoice:
* price
* start /end date (used to compute the membership state)
* ...

