### PR TITLE
[18.0][IMP] *: disable auto-install 

### DIFF
--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -12,6 +12,6 @@ This module adds support for SEPA Credit Transfer QR-code generation.
     # any module necessary for this one to work correctly
     'depends': ['account', 'base_iban'],
 
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/base_install_request/__manifest__.py
+++ b/addons/base_install_request/__manifest__.py
@@ -9,7 +9,7 @@
 Allow internal users requesting a module installation
 =====================================================
     """,
-    'auto_install': True,
+    'auto_install': False,
     'data':[
         'security/ir.model.access.csv',
         'wizard/base_module_install_request_views.xml',

--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -14,7 +14,7 @@
         "views/ir_mail_server_views.xml",
         "views/res_config_settings_views.xml",
     ],
-    "auto_install": True,
+    "auto_install": False,
     "license": "LGPL-3",
     "assets": {
         "web.assets_backend": [

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -20,7 +20,7 @@ to support In-App purchases inside Odoo. """,
         'views/iap_views.xml',
         'views/res_config_settings.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'iap/static/src/**/*.js',

--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -38,6 +38,6 @@ for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
     ],
     'post_init_hook': '_l10n_es_edi_facturae_post_init_hook',
     'installable': True,
-    'auto_install': ['l10n_es'],
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': 'Add OdooBot in discussions',
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True,
     'data': [
         'views/res_users_views.xml',

--- a/addons/pos_epson_printer/__manifest__.py
+++ b/addons/pos_epson_printer/__manifest__.py
@@ -19,7 +19,7 @@ Use Epson ePOS Printers without the IoT Box in the Point of Sale
         'views/pos_printer_views.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'point_of_sale._assets_pos': [
             'pos_epson_printer/static/src/**/*',

--- a/addons/privacy_lookup/__manifest__.py
+++ b/addons/privacy_lookup/__manifest__.py
@@ -12,6 +12,6 @@
         'security/ir.model.access.csv',
         'data/ir_actions_server_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -25,7 +25,7 @@
     'demo': [
         'data/sale_pdf_quote_builder_demo.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sale_pdf_quote_builder/static/src/js/**/*',

--- a/addons/web_unsplash/__manifest__.py
+++ b/addons/web_unsplash/__manifest__.py
@@ -10,7 +10,7 @@
     'data': [
         'views/res_config_settings_view.xml',
         ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_frontend': [
             'web_unsplash/static/src/frontend/unsplash_beacon.js',


### PR DESCRIPTION
Cherry-pick of commits from previous versions : https://github.com/OCA/OCB/pull/1242 and https://github.com/OCA/OCB/pull/1247

I take over the description from the first PR from @pedrobaeza : 

 Odoo chooses to auto-install some modules that are debatable, so here in OCB we can revert this decission and let the Odoo admin to decide about them:
- account_qr_code_sepa: this is just some tooling with no UI, so only modules using this tooling should depend and install it.
- base_install_request: Feature for asking to install a module that doesn't make too much sense to be auto-installed in on premise maintained installations for avoiding false expectations.
- iap: Odoo in-app purchases services should be optional, and more having a lot of dependant modules also being auto-installed (sms, snailmail, partner_autocomplete...). This way, we stop the chain from the beginning.
- l10n_es_edi_facturae: Not everyone in Spain requires Facturae, and even if so, the OCA implementation is more suitable.
- l10n_es_pos: The implementation of this need is faulty (creating one journal entry per PoS order), so the OCA one should be used instead.
- mail_bot: It doesn't bring any real feature per se (only the annoying "Write an emoji" initial conversation).
- pos_epson_printer: Not everyone using PoS has an Epson printer.
- privacy_lookup: Privacy tool that not everyone uses.
- sale_pdf_quote_builder: Optional feature.

(I removed sale_product_configurator which has been merged in sale in v18 with https://github.com/odoo/odoo/pull/155449)

And 2 more modules from the second PR :
-    google_gmail : all users are not using GMail, it should be installed only when needed
-    web_unsplash : same here, you may not want Odoo to call Unsplash library unwillingly

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
