### PR TITLE
[FIX] base: trans_implied_ids recursive computation

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1026,7 +1026,7 @@ class GroupsImplied(models.Model):
     implied_ids = fields.Many2many('res.groups', 'res_groups_implied_rel', 'gid', 'hid',
         string='Inherits', help='Users of this group automatically inherit those groups')
     trans_implied_ids = fields.Many2many('res.groups', string='Transitively inherits',
-        compute='_compute_trans_implied')
+        compute='_compute_trans_implied', recursive=True)
 
     @api.depends('implied_ids.trans_implied_ids')
     def _compute_trans_implied(self):


### PR DESCRIPTION
**Steps**
1. Install `sale` module
2. In the Odoo shell execute: `env["res.groups"].get_groups_by_application()`

**Actual result**
`[...,  (ir.module.category(52,), 'boolean', res.groups(22, 21, 20), (100, 'Other')) , ...]`

**Expected result**
`[...,  (ir.module.category(52,), 'selection', res.groups(20, 21, 22), (5, 'Sales')) , ...]`

**Additional info**
The result of `get_groups_by_application` is correct if the computation of `res.groups.trans_implied_ids` is called executing: `env["res.groups"].search([])._compute_trans_implied()`

Moved here from https://github.com/OCA/server-tools/pull/3320.
I tried to add a test in `sale` module but didn't manage to add a test that would fail without this change.

This is already present in `15.0` and following versions of Odoo thanks to https://github.com/odoo/odoo/commit/34d6f87d5497182d8ce395a8c90277f5ddde8a95.