### PR TITLE
[16.0][FIX] base: fixed origin column width in report_stockpicking_operations

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -48,7 +48,7 @@
                             <br/>
                             <h1 t-field="o.name" class="mt0"/>
                             <div class="row mt48 mb32">
-                                <div t-if="o.origin" class="col-auto" name="div_origin">
+                                <div t-if="o.origin" class="col-auto" name="div_origin" style="max-width:40%">
                                     <strong>Order:</strong>
                                     <p t-field="o.origin"/>
                                 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When printing a picking, the "Order" column can push all the other columns to the side and make it unreadable.

Current behavior before PR:
<img width="1134" height="204" alt="image" src="https://github.com/user-attachments/assets/3500f8d0-e8f3-467f-b174-daac047ef375" />

Desired behavior after PR is merged:
<img width="1134" height="204" alt="image" src="https://github.com/user-attachments/assets/b595c02a-1b89-43a6-b4ec-2a3fa312dab1" />

I achieved this by setting a limit to the max width of the column.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
