### PR TITLE
[18.0][FIX] point_of_sale: search_read with elevated access

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -16,6 +16,6 @@ class IrModuleModule(models.Model):
         domain = self._load_pos_data_domain()
         fields = self._load_pos_data_fields()
         return {
-            'data': self.search_read(domain, fields, load=False),
+            'data': self.sudo().search_read(domain, fields, load=False),
             'fields': self._load_pos_data_fields(),
         }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In the repository OCA/POS PR `test with OCB` have been failing since PR #1301  was merged.
You can see an example of the failing test here: https://github.com/OCA/pos/actions/runs/16340188713/job/46160658528?pr=1406#step:8:147.

<img width="1281" height="424" alt="image" src="https://github.com/user-attachments/assets/8b2db3e7-a3e9-475b-aeb8-5eba4153846e" />

The failures occur because PR#1301 disables the `base_install_request` auto-install mechanism, which previously granted implicit read access to the `ir.module.module` model for users in the `base.group_user` group. With that mechanism turned off, these users now receive an `AccessError` when attempting to read `ir.module.module` in code paths such as:

(pos.session.load_data)[https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/models/pos_session.py#L185]

**Desired behavior after PR is merged:**
This PR adds `sudo` to elevated access to `search_read` method in the `ir.module.module` model.

**Related Works**
In parallel, I have submitted PR #219367 to the Odoo main repository to address this issues with the same changes in the same context.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
