### PR TITLE
[17.0][IMP] *: More auto-install disablings

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -32,6 +32,6 @@ Pro rules and show the errors.
         'wizard/account_move_send_views.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -12,7 +12,7 @@ for customization purpose.
     'category': 'Hidden/Tools',
     'depends': ['web'],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'views/base_import_module_view.xml',

--- a/addons/iap_crm/__manifest__.py
+++ b/addons/iap_crm/__manifest__.py
@@ -13,6 +13,6 @@
         'iap_mail',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -20,7 +20,7 @@ Auto-complete partner companies' data
         'views/res_config_settings_views.xml',
         'data/cron.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'partner_autocomplete/static/src/scss/*',

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -38,7 +38,7 @@ The service is provided by the In App Purchase Odoo platform.
         'data/mail_demo.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sms/static/src/**/*',


### PR DESCRIPTION
Follow-up of #1242 and #1247

- account_edi_ubl_cii: As of now EDI export format is auto-selected depending on countries, it's useless as is in the countries where there's no EDI flavor pre-configured, so auto-installing has no sense. If you want some EDI export, then install and configure it.
- base_import_module: Almost no one wants this useless feature...
- iap_crm: It only makes sense if you install extra extensions like crm_iap_enrich, and that one already has this one as dependency.
- sms/partner_autocomplete: If you need iap installed by other dependency, then auto-installing these other modules is not advisable.

@Tecnativa