### PR TITLE
[18.0][IMP] *: More auto-install disablings

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -34,6 +34,6 @@ Pro rules and show the errors.
         ],
     },
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -12,7 +12,7 @@ for customization purpose.
     'category': 'Hidden/Tools',
     'depends': ['web'],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'views/base_import_module_view.xml',

--- a/addons/iap_crm/__manifest__.py
+++ b/addons/iap_crm/__manifest__.py
@@ -13,6 +13,6 @@
         'iap_mail',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -21,7 +21,7 @@ Auto-complete partner companies' data
         'data/cron.xml',
         'data/iap_service_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'partner_autocomplete/static/src/scss/*',

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -43,7 +43,7 @@ The service is provided by the In App Purchase Odoo platform.
         'data/mail_demo.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sms/static/src/**/*',


### PR DESCRIPTION
Forward-port of #1309

- account_edi_ubl_cii: As of now EDI export format is auto-selected depending on countries, it's useless as is in the countries where there's no EDI flavor pre-configured, so auto-installing has no sense. If you want some EDI export, then install and configure it.
- base_import_module: Almost no one wants this useless feature...
- iap_crm: It only makes sense if you install extra extensions like crm_iap_enrich, and that one already has this one as dependency.
- sms/partner_autocomplete: If you need iap installed by other dependency, then auto-installing these other modules is not advisable.

@Tecnativa