### PR TITLE
[16.0][FIX] account_edi_ubl_cii: Wrong argument schemeid on tag EmailURIUniversalCommunication

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -108,7 +108,7 @@
                         <ram:CompleteNumber t-esc="partner.phone or partner.mobile"/>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication t-if="partner.email">
-                        <ram:URIID schemeID='SMTP' t-esc="partner.email"/>
+                        <ram:URIID t-esc="partner.email"/>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -244,7 +244,7 @@ class AccountEdiXmlCII(models.AbstractModel):
 
         role = invoice.journal_id.type == 'purchase' and 'SellerTradeParty' or 'BuyerTradeParty'
         name = self._find_value(f"//ram:{role}/ram:Name", tree)
-        mail = self._find_value(f"//ram:{role}//ram:URIID[@schemeID='SMTP']", tree)
+        mail = self._find_value(f"//ram:{role}//ram:URIID", tree)
         vat = self._find_value(f"//ram:{role}/ram:SpecifiedTaxRegistration/ram:ID[string-length(text()) > 5]", tree)
         phone = self._find_value(f"//ram:{role}/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber", tree)
         country_code = self._find_value(f'//ram:{role}/ram:PostalTradeAddress//ram:CountryID', tree)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_factur-x_doc/facturx_credit_note_type380.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_factur-x_doc/facturx_credit_note_type380.xml
@@ -95,7 +95,7 @@
             <ram:CompleteNumber>+33 4 72 07 08 56</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">tony.dubois@aubonmoulin.fr</ram:URIID>
+            <ram:URIID>tony.dubois@aubonmoulin.fr</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>
@@ -119,7 +119,7 @@
             <ram:CompleteNumber>+33 4 72 07 08 67</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">alexandre.payet@majolieboutique.net</ram:URIID>
+            <ram:URIID>alexandre.payet@majolieboutique.net</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_factur-x_doc/facturx_credit_note_type381.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_factur-x_doc/facturx_credit_note_type381.xml
@@ -95,7 +95,7 @@
             <ram:CompleteNumber>+33 4 72 07 08 56</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">tony.dubois@aubonmoulin.fr</ram:URIID>
+            <ram:URIID>tony.dubois@aubonmoulin.fr</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>
@@ -119,7 +119,7 @@
             <ram:CompleteNumber>+33 4 72 07 08 67</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">alexandre.payet@majolieboutique.net</ram:URIID>
+            <ram:URIID>alexandre.payet@majolieboutique.net</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case1.xml
@@ -65,7 +65,7 @@
                         <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+                        <ram:URIID>partner1@yourcompany.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
                 <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case2.xml
@@ -73,7 +73,7 @@
                         <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+                        <ram:URIID>partner1@yourcompany.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
                 <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_ecotaxes_case3.xml
@@ -65,7 +65,7 @@
                         <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+                        <ram:URIID>partner1@yourcompany.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
                 <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice.xml
@@ -119,7 +119,7 @@
             <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+            <ram:URIID>partner1@yourcompany.com</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice_tax_incl.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_invoice_tax_incl.xml
@@ -154,7 +154,7 @@
             <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+            <ram:URIID>partner1@yourcompany.com</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_out_refund.xml
@@ -119,7 +119,7 @@
             <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
           </ram:TelephoneUniversalCommunication>
           <ram:EmailURIUniversalCommunication>
-            <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+            <ram:URIID>partner1@yourcompany.com</ram:URIID>
           </ram:EmailURIUniversalCommunication>
         </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_test_import_partner.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/facturx_test_import_partner.xml
@@ -51,7 +51,7 @@
                         <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+                        <ram:URIID>partner1@yourcompany.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
                 <ram:PostalTradeAddress>
@@ -72,7 +72,7 @@
                         <ram:CompleteNumber>1111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">buyer@yahoo.com</ram:URIID>
+                        <ram:URIID>buyer@yahoo.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
                 <ram:SpecifiedTaxRegistration>
@@ -92,7 +92,7 @@
                         <ram:CompleteNumber>1111</ram:CompleteNumber>
                     </ram:TelephoneUniversalCommunication>
                     <ram:EmailURIUniversalCommunication>
-                        <ram:URIID schemeID="SMTP">buyer@yahoo.com</ram:URIID>
+                        <ram:URIID>buyer@yahoo.com</ram:URIID>
                     </ram:EmailURIUniversalCommunication>
                 </ram:DefinedTradeContact>
             </ram:ShipToTradeParty>


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/201623 to 16.0, which wasn't considered.

-------

Original PR text:

Our facturx XML are not correct, they are raising
"/rsm:CrossIndustryInvoice[1]/rsm:SupplyChainTradeTransaction[1] /ram:ApplicableHeaderTradeAgreement[1]/ram:BuyerTradeParty[1]/ ram:DefinedTradeContact[1]/ram:EmailURIUniversalCommunication[1]/ram:URIID[1]" "Attribute @schemeID' marked as not used in the given context." errors (for both `BuyerTradeParty`and `SellerTradeParty`).

Which in other words means the parameter `@shemeID` should not be there in the tag EmailURIUniversalCommunication.

-------

@Tecnativa TT57980