### PR TITLE
[19.0][FIX] Fix building wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include README.md
 include pyproject.toml
 include setup/pep517_odoo.py
 graft odoo
+prune addons
 recursive-exclude * *.py[co]
 recursive-exclude .git *

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     classifiers=[c for c in classifiers.split('\n') if c],
     license=license,
     scripts=['setup/odoo'],
-    packages=find_namespace_packages(),
+    packages=find_namespace_packages(include=("odoo", "odoo.*")),
     package_dir={'%s' % lib_name: 'odoo'},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
- Fixes #1315

I’ve tested both using the built wheel and an editable install.

With the argument changes in find_namespace_packages, a doc and setup namespace package ends up in the wheel, which is not desirable. That part might need to be sent upstream. The upstream built wheel is broken so more than this fix is needed.