### PR TITLE
Draft: [18.0][FIX] change membership product on invoice line

### DIFF
--- a/addons/membership/models/account_move.py
+++ b/addons/membership/models/account_move.py
@@ -42,6 +42,22 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
+    def _prepare_membership_line_data(self):
+        self.ensure_one()
+        date_from = self.product_id.membership_date_from
+        date_to = self.product_id.membership_date_to
+        if (date_from and date_from < (self.move_id.invoice_date or date.min) < (date_to or date.min)):
+            date_from = self.move_id.invoice_date
+        return {
+            'partner': self.move_id.partner_id.id,
+            'membership_id': self.product_id.id,
+            'member_price': self.price_unit,
+            'date': fields.Date.today(),
+            'date_from': date_from,
+            'date_to': date_to,
+            'account_invoice_line': self.id,
+        }
+
     def write(self, vals):
         # OVERRIDE
         res = super(AccountMoveLine, self).write(vals)
@@ -54,28 +70,18 @@ class AccountMoveLine(models.Model):
 
         existing_memberships = self.env['membership.membership_line'].search([
             ('account_invoice_line', 'in', to_process.ids)])
-        to_process = to_process - existing_memberships.mapped('account_invoice_line')
-
-        # All memberships already exist, break.
-        if not to_process:
-            return res
+        to_create = to_process - existing_memberships.mapped('account_invoice_line')
 
         memberships_vals = []
-        for line in to_process:
-            date_from = line.product_id.membership_date_from
-            date_to = line.product_id.membership_date_to
-            if (date_from and date_from < (line.move_id.invoice_date or date.min) < (date_to or date.min)):
-                date_from = line.move_id.invoice_date
-            memberships_vals.append({
-                'partner': line.move_id.partner_id.id,
-                'membership_id': line.product_id.id,
-                'member_price': line.price_unit,
-                'date': fields.Date.today(),
-                'date_from': date_from,
-                'date_to': date_to,
-                'account_invoice_line': line.id,
-            })
-        self.env['membership.membership_line'].create(memberships_vals)
+        for line in to_create:
+            memberships_vals.append(line._prepare_membership_line_data())
+
+        if memberships_vals:
+            self.env['membership.membership_line'].create(memberships_vals)
+
+        for membership in existing_memberships:
+            membership.write(membership.account_invoice_line._prepare_membership_line_data())
+
         return res
 
     @api.model_create_multi
@@ -111,5 +117,5 @@ class AccountMoveLine(models.Model):
                 'date_to': date_to,
                 'account_invoice_line': line.id,
             })
-        self.env['membership.membership_line'].create(memberships_vals)
+        memberships_vals.append(line._prepare_membership_line_data())
         return lines

--- a/addons/membership/tests/common.py
+++ b/addons/membership/tests/common.py
@@ -12,6 +12,15 @@ class TestMembershipCommon(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.membership = cls.env['product.product'].create({
+            'membership': True,
+            'membership_date_from': datetime.date.today() + relativedelta(months=-1),
+            'membership_date_to': datetime.date.today() + relativedelta(days=-2),
+            'name': 'Basic Limited',
+            'type': 'service',
+            'list_price': 90.00,
+        })
+
         # Test memberships
         cls.membership_1 = cls.env['product.product'].create({
             'membership': True,

--- a/addons/membership/tests/test_membership.py
+++ b/addons/membership/tests/test_membership.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import time
 from odoo.addons.membership.tests.common import TestMembershipCommon
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 from odoo import fields
 
 
@@ -158,3 +158,37 @@ class TestMembership(TestMembershipCommon):
         self.partner_1._compute_membership_state()
         self.assertEqual(invoice.state, 'cancel')
         self.assertEqual(self.partner_1.membership_state, 'canceled')
+
+    def test_change_membership_on_account_move_line(self):
+        invoice = self.partner_1.create_membership_invoice(
+            self.membership, self.membership.list_price
+        )
+        with Form(invoice) as invoice_form:
+            line_form = invoice_form.invoice_line_ids.edit(0)
+            line_form.product_id = self.membership_1
+            line_form.save()
+
+        invoice_line = invoice.invoice_line_ids[0]
+        self.assertEqual(
+            invoice_line.price_unit,
+            self.membership_1.list_price
+        )
+        membership_line = self.env["membership.membership_line"].search(
+            [("account_invoice_line", "=", invoice_line.id)]
+        )
+        self.assertEqual(
+            membership_line.membership_id,
+            self.membership_1
+        )
+        self.assertEqual(
+            membership_line.member_price,
+            self.membership_1.list_price
+        )
+        self.assertEqual(
+            membership_line.date_from,
+            self.membership_1.membership_date_from
+        )
+        self.assertEqual(
+            membership_line.date_to,
+            self.membership_1.membership_date_to
+        )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This is a ported fix from [
petrus-v fix for v14.0](https://github.com/OCA/OCB/pull/1299) for Odoo v18.0.
While changing information on invoice line, the related membership line is not updated.

This is done as part of OCA Internal Working Group: [task 871862](https://odoo-community.org/my/task/871862)

Current behavior before PR:

create 2 membership products
create an invoice with one membership product and save the draft invoice
(you can see the mebership line is already created with proper information)
go back to the invoice and use the other product
💥 member ship line is not updated
(So, this also happen while duplicating an invoice from previous year changing the membership product.)

Desired behavior after PR is merged:

The member ship line is updated with fresh informations changed on the invoice:

price
start /end date (used to compute the membership state)
...
