### PR TITLE
[17.0][FIX] l10n_it migrate from 16.0 without l10n_it_exempt_reason column

### DIFF
--- a/addons/l10n_it/migrations/0.8/pre-migrate.py
+++ b/addons/l10n_it/migrations/0.8/pre-migrate.py
@@ -1,11 +1,15 @@
+from odoo.tools.sql import column_exists
+
+
 def migrate(cr, version):
 
-    cr.execute("""
-        UPDATE account_tax
-           SET l10n_it_exempt_reason = CASE
-               WHEN l10n_it_exempt_reason = 'N2' THEN 'N2.2'
-               WHEN l10n_it_exempt_reason = 'N3' THEN 'N3.6'
-               WHEN l10n_it_exempt_reason = 'N6' THEN 'N6.9'
-               END
-          WHERE l10n_it_exempt_reason IN ('N2', 'N3', 'N6')
-    """)
+    if column_exists(cr, "account_tax", "l10n_it_exempt_reason"):
+        cr.execute("""
+            UPDATE account_tax
+               SET l10n_it_exempt_reason = CASE
+                   WHEN l10n_it_exempt_reason = 'N2' THEN 'N2.2'
+                   WHEN l10n_it_exempt_reason = 'N3' THEN 'N3.6'
+                   WHEN l10n_it_exempt_reason = 'N6' THEN 'N6.9'
+                   END
+              WHERE l10n_it_exempt_reason IN ('N2', 'N3', 'N6')
+        """)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: migration from 16.0 fails because l10n_it_exempt_reason column does not exist

Current behavior before PR: migration fails

Desired behavior after PR is merged: migration works




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr