### PR TITLE
[15.0][FIX] stock: stock_warehouse_orderpoint unlink method domain

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -475,7 +475,7 @@ class StockWarehouseOrderpoint(models.Model):
             ('qty_to_order', '<=', 0)
         ]
         if self.ids:
-            expression.AND([domain, [('ids', 'in', self.ids)]])
+            domain = expression.AND([domain, [('id', 'in', self.ids)]])
         orderpoints_to_remove = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(domain)
         # Remove previous automatically created orderpoint that has been refilled.
         orderpoints_to_remove.unlink()

--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -54,3 +54,4 @@ Victor Vermot-Petit-Outhenin victor.vermot@camptocamp.com https://github.com/vic
 Sarah Jallon sarah.jallon@camptocamp.com https://github.com/sarsurgithub
 Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/ricardoalso
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
+Paolo Yammouni paolo.yammouni@camptocamp.com https://github.com/paoloyam


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fixes an incorrect domain construction when restricting records to the current recordset.
The existing code attempted to combine domains using expression.AND() but did not apply the result, and referenced an invalid domain field.

Current behavior before PR:

- expression.AND() was called without assigning its return value, so the combined domain was never applied.
- The domain condition used ('ids', 'in', self.ids), which is not a valid searchable field.
- As a result, the intended filtering by the current recordset was silently ignored.

Desired behavior after PR is merged:

- The domain is correctly rebuilt and assigned using expression.AND().
- The filter uses the valid field instead of ids
- Records are properly restricted to the current recordset

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
