### PR TITLE
[16.0][FIX] mrp_subcontracting: delete unreferenced move lines

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -43,7 +43,10 @@ class MrpProduction(models.Model):
             for line in production.move_line_raw_ids:
                 line_by_product[line.product_id] |= line
             for move in production.move_raw_ids:
-                move.move_line_ids = line_by_product.pop(move.product_id, self.env['stock.move.line'])
+                lines = line_by_product.pop(move.product_id, self.env['stock.move.line'])
+                lines_to_delete = move.move_line_ids - lines
+                move.move_line_ids = lines
+                lines_to_delete.unlink()
             for product_id, lines in line_by_product.items():
                 qty = sum(line.product_uom_id._compute_quantity(line.qty_done, product_id.uom_id) for line in lines)
                 move = production._get_move_raw_values(product_id, qty, product_id.uom_id)

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -45,7 +45,6 @@ class MrpProduction(models.Model):
             for move in production.move_raw_ids:
                 lines = line_by_product.pop(move.product_id, self.env['stock.move.line'])
                 lines_to_delete = move.move_line_ids - lines
-                move.move_line_ids = lines
                 lines_to_delete.unlink()
             for product_id, lines in line_by_product.items():
                 qty = sum(line.product_uom_id._compute_quantity(line.qty_done, product_id.uom_id) for line in lines)

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1151,6 +1151,36 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         cmp1_consumed_qty = sum(productions.move_raw_ids.filtered(lambda m: m.state == 'done').mapped("quantity_done"))
         self.assertEqual(cmp1_consumed_qty, 2)
 
+    def test_subcontracting_component_line_deletion(self):
+        '''
+        Ensure lines manually deleted are correctly unlinked.
+        '''
+        self.bom.consumption = 'flexible'
+        # Subcontractor has the components in stock
+        self.env['stock.quant']._update_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, 1)
+        self.env['stock.quant']._update_available_quantity(self.comp2, self.subcontractor_partner1.property_stock_subcontractor, 1)
+        # Create the picking
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'partner_id': self.subcontractor_partner1.id,
+            'move_ids': [Command.create({
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_uom_qty': 1,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.warehouse.lot_stock_id.id,
+            })],
+        })
+        receipt.action_confirm()
+        # Change consumption by removing the second line
+        action = receipt.move_ids.action_show_details()
+        mo = self.env['mrp.production'].browse(action['res_id'])
+        line_to_remove = mo.move_line_raw_ids[1]
+        with Form(mo.with_context(action['context']), view=action['view_id']) as mo_form:
+            mo_form.move_line_raw_ids.remove(1)
+        mo.subcontracting_record_component()
+        self.assertFalse(line_to_remove.exists())
+
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1175,9 +1175,14 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         # Change consumption by removing the second line
         action = receipt.move_ids.action_show_details()
         mo = self.env['mrp.production'].browse(action['res_id'])
+        subcontract_location = self.subcontractor_partner1.property_stock_subcontractor
+        reserved_before = sum(self.env['stock.quant']._gather(self.comp2, subcontract_location, strict=True).mapped('reserved_quantity'))
+        self.assertEqual(reserved_before, 1)
         line_to_remove = mo.move_line_raw_ids[1]
         with Form(mo.with_context(action['context']), view=action['view_id']) as mo_form:
             mo_form.move_line_raw_ids.remove(1)
+        reserved_after = sum(self.env['stock.quant']._gather(self.comp2, subcontract_location, strict=True).mapped('reserved_quantity'))
+        self.assertEqual(reserved_after, 0)
         mo.subcontracting_record_component()
         self.assertFalse(line_to_remove.exists())
 


### PR DESCRIPTION
First commit addresses the initial fixes, and the second commit is needed to make additional changes based on those fixes, so the commits are split.


First commit is a backport of https://github.com/odoo/odoo/pull/229310 to 16.0.

First commit explanation:
Wizard update writes move_line_raw_ids, which triggers the inverse. The inverse
rebuilds move_line_ids from the remaining lines, so the removed line gets
unlinked from the move without being deleted (no ondelete='cascade'), leaving a
phantom pending move.

Keep the removed lines in a separate recordset and unlink them after
move_line_ids is updated, so the SML is actually deleted.


Second commit is a backport of https://github.com/odoo/odoo/pull/243958 to 16.0.

Second commit explanation:
Writing move_line_raw_ids goes through the inverse. The inverse rebuilds
move_line_ids from the remaining lines, and if we unlink the removed lines
after clearing their move_id, the corresponding stock.quant reservation is
not updated and stays reserved.

Keep the move/line link until unlink is called, then delete the removed
lines so the reservation is properly cleared.

@qrtl QT6196