### PR TITLE
[FIX] hr: fix "Time Off Management" section underline in README

### DIFF
--- a/addons/hr/README.md
+++ b/addons/hr/README.md
@@ -46,7 +46,7 @@ timesheets or check attendances for each employee. Get your analytic accounting
 posted automatically based on time spent on your projects.
 
 Time Off Management
------------------
+-------------------
 
 Keep track of the vacation days accrued by each employee. Employees enter their
 requests (paid time off, sick time off, etc), for managers to approve and


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The README.md of the hr module contains a malformed reStructuredText-style section underline. The heading "Time Off Management" (19 characters) was underlined with only 18 dashes (------------------), making it one character too short. This causes a RST warning:

Current behavior before PR:

The "Time Off Management" section heading in addons/hr/README.md has an underline of 18 dashes, which is shorter than the title length (19 chars), producing a docutils WARNING/2: Title underline too short when the file is parsed.

Desired behavior after PR is merged:

The underline is corrected to 19 dashes (-------------------), matching the title length exactly. No more RST parsing warning for this section.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
