### PR TITLE
[18.0][FIX] new_get_soap_client's signature

### DIFF
--- a/odoo/_monkeypatches/stdnum.py
+++ b/odoo/_monkeypatches/stdnum.py
@@ -3,7 +3,7 @@
 _soap_clients = {}
 
 
-def new_get_soap_client(wsdlurl, timeout=30):
+def new_get_soap_client(wsdlurl, timeout=30, **kwargs):
     # stdnum library does not set the timeout for the zeep Transport class correctly
     # (timeout is to fetch the wsdl and operation_timeout is to perform the call),
     # requiring us to monkey patch the get_soap_client function.


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Added support for additional keyword arguments in new_get_soap_client function.

Current behavior before PR: Data migration fails with parse error during own company's VAT ID is verification.

Desired behavior after PR is merged: Data migration passes without error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
