### PR TITLE
Add setuptools<82 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel pac
 requests==2.25.1 ;  python_version < '3.12' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 requests==2.31.0 ; python_version >= '3.12' # (Noble) Compatibility with i
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package
+setuptools<82  # Odoo needs pkg_resources which is in setuptools<82
 urllib3==1.26.5 ;  python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1


### PR DESCRIPTION
Because Odoo needs pkg_resources, which is in setuptools, but Odoo does not declare that dependency explicitly.

This should fix the Odoo 15.0 Python 3.9 build issuesin oca/oca-ci.