### PR TITLE
[18.0][FIX] access rights inconsistencies

### DIFF
--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record model="ir.module.category" id="base.module_category_human_resources_contracts">
+        <field name="description">Enable the user to see and manage the contracts from Employee application.</field>
+        <field name="sequence">10</field>
+    </record>
+
+    <record id="hr_contract.group_hr_contract_employee_manager" model="res.groups">
+        <field name="name">Employee Manager</field>
+        <field name="category_id" ref="base.module_category_human_resources_contracts"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="hr_contract.group_hr_contract_manager" model="res.groups">
+        <field name="name">Administrator</field>
+        <field name="category_id" ref="base.module_category_human_resources_contracts"/>
+        <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager')), (4, ref('hr.group_hr_user'))]"/>
+        <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+    </record>
+
     <data noupdate="1">
-        <record model="ir.module.category" id="base.module_category_human_resources_contracts">
-            <field name="description">Enable the user to see and manage the contracts from Employee application.</field>
-            <field name="sequence">10</field>
-        </record>
-
-        <record id="hr_contract.group_hr_contract_employee_manager" model="res.groups">
-            <field name="name">Employee Manager</field>
-            <field name="category_id" ref="base.module_category_human_resources_contracts"/>
-            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
-        </record>
-
-        <record id="hr_contract.group_hr_contract_manager" model="res.groups">
-            <field name="name">Administrator</field>
-            <field name="category_id" ref="base.module_category_human_resources_contracts"/>
-            <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager')), (4, ref('hr.group_hr_user'))]"/>
-            <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
-        </record>
-
         <record id="base.default_user" model="res.users">
             <field name="groups_id" eval="[(4,ref('hr_contract.group_hr_contract_manager'))]"/>
         </record>

--- a/addons/loyalty/models/res_partner.py
+++ b/addons/loyalty/models/res_partner.py
@@ -8,8 +8,7 @@ class ResPartner(models.Model):
     loyalty_card_count = fields.Integer(
         string="Active loyalty cards",
         compute='_compute_count_active_cards',
-        compute_sudo=True,
-        groups='base.group_user')
+        compute_sudo=True)
 
     def _compute_count_active_cards(self):
         loyalty_groups = self.env['loyalty.card']._read_group(


### PR DESCRIPTION
This PR fixes the following warning (similar ones with different XMLID) which occurred during system update.

```
WARNING ? odoo.addons.base.models.ir_ui_view: <b>Access Rights Inconsistency</b><br/>This view may not work for all users: some users may have a combination of
 groups where the elements <b><tt>&lt;button&gt;</tt></b> are displayed, but they depend on the field <b><tt>loyalty_card_count</tt></b> that is not accessible. You might fix this by mo
difying user groups to make sure that all users who have access to those elements also have access to the field, typically via group implications. Alternatively, you could adjust the “<
i>groups</i>” or “<i>invisible</i>” attributes for these fields, to make sure they are always available together.<br/>Debugging information:<br/>- field “loyalty_card_count” is accessib
le for groups: &#39;base.group_user&#39;<br/>- element “&lt;button name=&#34;action_view_loyalty_cards&#34; type=&#34;object&#34; class=&#34;oe_stat_button&#34; icon=&#34;fa-money&#34; 
groups=&#34;base.group_system,sales_team.group_sale_salesman&#34; invisible=&#34;loyalty_card_count == 0&#34;/&gt;” is shown in the view for groups: (&#39;base.group_portal&#39; &amp; &
#39;base.group_system&#39;) | (&#39;base.group_public&#39; &amp; &#39;base.group_system&#39;) | (&#39;base.group_system&#39; &amp; &#39;base.group_user&#39;) | (&#39;base.group_system&#
39; &amp; &#39;base.group_partner_manager&#39;) | &#39;sales_team.group_sale_salesman&#39;
View error context:
{'file': '/tmp/addons/account_invoice_import_simple_pdf/views/res_partner.xml',
 'line': 1,
 'name': 'res.partner form',
 'view': ir.ui.view(15203,),
 'view.model': 'res.partner',
 'view.parent': ir.ui.view(15202,),
 'xmlid': 'view_partner_property_form_move'} 
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
