### PR TITLE
[18.0][FIX] project: pass groups argument to super._unlinkGroups

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -23,7 +23,7 @@ export class ProjectTaskKanbanDynamicGroupList extends RelationalModel.DynamicGr
                 });
             });
         }
-        return super._unlinkGroups();
+        return super._unlinkGroups(groups);
     }
 }
 


### PR DESCRIPTION
When deleting a column in the To-Do app (grouped by personal_stage_type_id), _unlinkGroups fell through to super._unlinkGroups() without passing the groups argument, causing: TypeError: can't access property "map", groups is undefined


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
