### PR TITLE
[FIX] orm: avoid unsafe iteration over `transaction.envs` during registry initialization (Python 3.14.4)

### DIFF
--- a/doc/cla/individual/marwanlk.md
+++ b/doc/cla/individual/marwanlk.md
@@ -1,0 +1,11 @@
+France, 2026-04-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Marwan LAKRADI lakradimarwan@gmail.com https://github.com/MarwanLk

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -583,7 +583,8 @@ class Environment(Mapping):
             transaction = cr.transaction = Transaction(Registry(cr.dbname))
 
         # if env already exists, return it
-        for env in transaction.envs:
+        # (convert to list to avoid modifying the `WeakSet` while iterating)
+        for env in list(transaction.envs):
             if (env.cr, env.uid, env.su, env.uid_origin, env.context) == (cr, uid, su, uid_origin, context):
                 return env
 


### PR DESCRIPTION
- Type: ORM
- Impact: stability / Python 3.14.4 compatibility

### Purpose

This fix prevents intermittent runtime errors occurring during registry initialization when iterating over `transaction.envs`.
Under Python 3.14.4, `WeakSet` iteration may fail if the set is modified during traversal, leading to:

`RuntimeError: dictionary changed size during iteration`

- Relevant stack trace:

```bash
File ".../odoo/api.py", line 586, in __new__
  for env in transaction.envs:
File ".../python3.14/_weakrefset.py", line 25, in __iter__
  for itemref in self.data.copy():
File ".../odoo/tools/misc.py", line 1069, in __init__
  self._map: dict[T, None] = dict.fromkeys(elems)
RuntimeError: dictionary changed size during iteration
```

### Root cause

Unsafe iteration over `transaction.envs` (`WeakSet`) while it may be mutated during Environment creation/destruction. Possibly related to changes in Python 3.14.4 `_weakrefset` behavior

`transaction.envs` is a `WeakSet` that can be modified during iteration due to:

- `Environment` creation during ORM calls
- `WeakRef` cleanup during registry bootstrap
- re-entrant calls to `Environment.__new__`

### Why this is safe

- `WeakSet` is not safe for concurrent mutation during iteration
- `list()` snapshot prevents runtime mutation issues
- No behavioral change in normal single-env execution

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
