### PR TITLE
[18.0][IMP] account_add_gln: Disable auto_install

### DIFF
--- a/addons/account_add_gln/__manifest__.py
+++ b/addons/account_add_gln/__manifest__.py
@@ -5,7 +5,7 @@
     'version': '1.0',
     'depends': ['account'],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'data': [
         'views/res_partner_views.xml',
     ],


### PR DESCRIPTION
This module has been added recently with auto_install=True and only account as dependency, so it's installed in every DB even if you don't have inventory (which is related).

@Tecnativa