### PR TITLE
[18.0][FIX] web: preserve report header top padding in PDF

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -33,6 +33,10 @@ body {
     }
 }
 
+#minimal_layout_report_headers .header {
+    padding-top: $o-default-report-margins;
+}
+
 span.o_force_ltr {
     display: inline;
 }


### PR DESCRIPTION
## Description

Odoo 18.0 commit `0184f2236804` moved report margins into CSS and added `.header { padding-top: 11mm; }` inside `.o_body_pdf.o_css_margins`. However, when wkhtmltopdf renders the header through `web.minimal_layout`, the header is wrapped in `#minimal_layout_report_headers`, so the 11 mm top padding is silently dropped. The result is that the company logo sits flush against the top edge of the page in PDF output.

This patch applies the same `padding-top` to `#minimal_layout_report_headers .header`, restoring the intended spacing in generated PDFs.

## Steps to reproduce

1. Install a fresh Odoo 18.0 database.
2. Upload a company logo and print any standard PDF report (e.g. a quotation or invoice) using the default A4 paperformat.
3. Observe that the logo is clipped / touching the top page margin.

## Fix

Add the missing SCSS rule:

```scss
#minimal_layout_report_headers .header {
    padding-top: $o-default-report-margins;
}
```