### PR TITLE
[16.0][FIX] event_sale: event_date_begin/end truncated in UTC, not event's …

### DIFF
--- a/addons/event_sale/report/event_sale_report.py
+++ b/addons/event_sale/report/event_sale_report.py
@@ -88,8 +88,8 @@ SELECT
     event_registration.is_paid AS is_paid,
     
     event_event.event_type_id AS event_type_id,
-    event_event.date_begin AS event_date_begin,
-    event_event.date_end AS event_date_end,
+    (event_event.date_begin AT TIME ZONE 'UTC' AT TIME ZONE COALESCE(event_event.date_tz, 'UTC'))::date AS event_date_begin,
+    (event_event.date_end AT TIME ZONE 'UTC' AT TIME ZONE COALESCE(event_event.date_tz, 'UTC'))::date AS event_date_end,
 
     event_event_ticket.price AS event_ticket_price,
 


### PR DESCRIPTION
…own tz

event.sale.report exposes event_date_begin and event_date_end as Date fields, populated directly from event.event's date_begin/ date_end (Datetime, stored UTC), with no timezone conversion.

Since the fields are typed Date, the ORM's read_group never applies a timezone conversion when grouping by day (a Date has no time component to convert) - it truncates whatever value the view returns. As a result, for any event whose local timezone is far enough from UTC, records get bucketed under the wrong calendar day. For example, an event starting at 14:00 in a UTC-10 timezone is 14:00 - (-10:00) = 00:00 UTC the next day, so it appears one day later than expected once grouped.

event.event already carries its own local timezone via date_tz (required, defaults from the event type or user), used by the model itself to compute date_begin_located/date_end_located. Use that same column to localize date_begin/date_end before truncating to a date, instead of leaving the raw UTC instant.

The fix follows the same pattern already used in
hr_attendance_report (AT TIME ZONE via a related tz column, not a hardcoded zone), so behavior stays correct regardless of which timezone a given event is configured in.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
