### PR TITLE
[19.0][IMP] *: disable auto-install

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -36,7 +36,7 @@ Pro rules and show the errors.
         ],
     },
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'uninstall_hook': 'uninstall_hook',

--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -12,7 +12,7 @@ This module adds support for SEPA Credit Transfer QR-code generation.
     # any module necessary for this one to work correctly
     'depends': ['account', 'base_iban'],
 
-    'auto_install': True,
+    'auto_install': False,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -12,7 +12,7 @@ for customization purpose.
     'category': 'Hidden/Tools',
     'depends': ['web'],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'views/base_import_module_view.xml',

--- a/addons/base_install_request/__manifest__.py
+++ b/addons/base_install_request/__manifest__.py
@@ -9,7 +9,7 @@
 Allow internal users requesting a module installation
 =====================================================
     """,
-    'auto_install': True,
+    'auto_install': False,
     'data':[
         'security/ir.model.access.csv',
         'wizard/base_module_install_request_views.xml',

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -20,7 +20,7 @@ to support In-App purchases inside Odoo. """,
         'views/iap_views.xml',
         'views/res_config_settings.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'iap/static/src/**/*.js',

--- a/addons/iap_crm/__manifest__.py
+++ b/addons/iap_crm/__manifest__.py
@@ -13,7 +13,7 @@
         'iap_mail',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -38,7 +38,7 @@ for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
     ],
     'post_init_hook': '_l10n_es_edi_facturae_post_init_hook',
     'installable': True,
-    'auto_install': ['l10n_es'],
+    'auto_install': False,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'uninstall_hook': 'uninstall_hook',

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -8,7 +8,7 @@
     'summary': 'Add OdooBot in discussions',
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True,
     'data': [
         'views/res_users_views.xml',

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -18,7 +18,7 @@ Auto-complete partner companies' data
         'views/res_config_settings_views.xml',
         'data/iap_service_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'partner_autocomplete/static/src/scss/*',

--- a/addons/privacy_lookup/__manifest__.py
+++ b/addons/privacy_lookup/__manifest__.py
@@ -12,7 +12,7 @@
         'security/ir.model.access.csv',
         'data/ir_actions_server_data.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -26,7 +26,7 @@
     'demo': [
         'data/sale_pdf_quote_builder_demo.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sale_pdf_quote_builder/static/src/js/**/*',

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -42,7 +42,7 @@ The service is provided by the In App Purchase Odoo platform.
         'data/mail_demo.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sms/static/src/**/*',


### PR DESCRIPTION
Odoo chooses to auto-install some modules that are debatable, so here in OCB we can revert this decission and let the Odoo admin to decide about them:
- account_edi_ubl_cii: As of now EDI export format is auto-selected depending on countries, it's useless as is in the countries where there's no EDI flavor pre-configured, so auto-installing has no sense. If you want some EDI export, then install and configure it.
- account_qr_code_sepa: this is just some tooling with no UI, so only modules using this tooling should depend and install it.
- base_import_module: Almost no one wants this useless feature...
- base_install_request: Feature for asking to install a module that doesn't make too much sense to be auto-installed in on premise maintained installations for avoiding false expectations.
- iap: Odoo in-app purchases services should be optional, and more having a lot of dependant modules also being auto-installed (sms, snailmail, partner_autocomplete...). This way, we stop the chain from the beginning.
- l10n_es_edi_facturae: Not everyone in Spain requires Facturae, and even if so, the OCA implementation is more suitable.
- l10n_es_pos: The implementation of this need is faulty (creating one journal entry per PoS order), so the OCA one should be used instead.
- mail_bot: It doesn't bring any real feature per se (only the annoying "Write an emoji" initial conversation).
- privacy_lookup: Privacy tool that not everyone uses.
- sale_pdf_quote_builder: Optional feature.

FWP of https://github.com/OCA/OCB/pull/1242 & https://github.com/OCA/OCB/pull/1310

cc @Tecnativa TT64349 
ping @pedrobaeza 
