### PR TITLE
[19.0][FIX] account_edi_ubl_cii: Avoid problems in community edition

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_cii.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_cii.py
@@ -683,9 +683,11 @@ class AccountEdiCii(models.AbstractModel):
     def _cii_get_billing_specified_period_node(self, vals):
         invoice = vals['invoice']
         billing_start_dates = [invoice.invoice_date] if invoice.invoice_date else []
-        billing_start_dates += [move_line.deferred_start_date for move_line in invoice.invoice_line_ids if move_line.deferred_start_date]
         billing_end_dates = [invoice.invoice_date_due] if invoice.invoice_date_due else []
-        billing_end_dates += [move_line.deferred_end_date for move_line in invoice.invoice_line_ids if move_line.deferred_end_date]
+        if "deferred_start_date" in invoice.invoice_line_ids._fields:
+            # only checking the existence of the first of the enterprise fields
+            billing_start_dates += [move_line.deferred_start_date for move_line in invoice.invoice_line_ids if move_line.deferred_start_date]
+            billing_end_dates += [move_line.deferred_end_date for move_line in invoice.invoice_line_ids if move_line.deferred_end_date]
         start_date = end_date = None
         if billing_start_dates:
             start_date = min(billing_start_dates)
@@ -1298,8 +1300,10 @@ class AccountEdiCii(models.AbstractModel):
         end_date_str = line_tree.findtext('.//{*}BillingSpecifiedPeriod/{*}EndDateTime/{*}DateTimeString')
         if start_date_str and end_date_str:
             to_write = collected_values['to_write']
-            to_write['deferred_start_date'] = datetime.strptime(start_date_str.strip(), DEFAULT_CII_DATE_FORMAT)
-            to_write['deferred_end_date'] = datetime.strptime(end_date_str.strip(), DEFAULT_CII_DATE_FORMAT)
+            if "deferred_start_date" in self.env["account.move.line"]._fields:
+                # only checking the existence of the first of the enterprise fields
+                to_write['deferred_start_date'] = datetime.strptime(start_date_str.strip(), DEFAULT_CII_DATE_FORMAT)
+                to_write['deferred_end_date'] = datetime.strptime(end_date_str.strip(), DEFAULT_CII_DATE_FORMAT)
 
     def _import_cii_invoice_line_add_product_values(self, collected_values):
         line_tree = collected_values['line_tree']

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -3170,8 +3170,10 @@ class AccountEdiUBL(models.AbstractModel):
         end_date_str = line_tree.findtext('./{*}InvoicePeriod/{*}EndDate')
         if start_date_str and end_date_str:
             to_write = collected_values['to_write']
-            to_write['deferred_start_date'] = fields.Date.from_string(start_date_str)
-            to_write['deferred_end_date'] = fields.Date.from_string(end_date_str)
+            if "deferred_start_date" in self.env["account.move.line"]._fields:
+                # only checking the existence of the first of the enterprise fields
+                to_write['deferred_start_date'] = fields.Date.from_string(start_date_str)
+                to_write['deferred_end_date'] = fields.Date.from_string(end_date_str)
 
     def _import_ubl_invoice_line_prepare_classified_tax_category_tax_values(self, collected_values, tax_category_tree):
         percentage = tax_category_tree.findtext('./{*}Percent')


### PR DESCRIPTION
Forward-port of #1348, meanwhile #286365 is merged.

The fields `deferred_start_date` and `deferred_end_date` are created by the enterprise addon `account_accountant`, so not having it installed, this crashes with:

```
  File "/opt/odoo/auto/addons/account_edi_ubl_cii/models/account_edi_cii.py", line 684, in <listcomp>
    billing_start_dates += [move_line.deferred_start_date for move_line in invoice.invoice_line_ids if move_line.deferred_start_date]
AttributeError: 'account.move.line' object has no attribute 'deferred_start_date'
```

This PR protects the access to these fields checking first if they exist.

Bug introduced in the refactoring in #261572.

@Tecnativa TT64384