### PR TITLE
[19.0][PERF] orm: add explicit JOIN-promotion hint for many2one LEFT JOINs

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1853,6 +1853,7 @@ class TestQueries(TransactionCase):
                     )
                     AND (
                         "res_partner_category"."parent_id" IS NOT NULL
+                        AND "res_partner_category__parent_id"."id" IS NOT NULL
                         AND "res_partner_category__parent_id"."name" ->> %s ILIKE %s
                     )
                 )
@@ -1976,7 +1977,9 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id"
             ON ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.name', 'like', self.company.name)])
@@ -1988,7 +1991,9 @@ class TestMany2one(TransactionCase):
             ON ("res_partner"."company_id" = "res_partner__company_id"."id")
             LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id"
             ON ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2001,8 +2006,12 @@ class TestMany2one(TransactionCase):
             LEFT JOIN "res_country" AS "res_partner__country_id"
             ON ("res_partner"."country_id" = "res_partner__country_id"."id")
             WHERE (
-                ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
-                OR ("res_partner"."country_id" IS NOT NULL AND "res_partner__country_id"."code" LIKE %s)
+                ("res_partner"."company_id" IS NOT NULL
+                    AND "res_partner__company_id"."id" IS NOT NULL
+                    AND "res_partner__company_id"."name" LIKE %s)
+                OR ("res_partner"."country_id" IS NOT NULL
+                    AND "res_partner__country_id"."id" IS NOT NULL
+                    AND "res_partner__country_id"."code" LIKE %s)
             )
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -2115,7 +2124,9 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id" ON
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.name', 'like', self.company.name)])
@@ -2127,7 +2138,9 @@ class TestMany2one(TransactionCase):
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
             LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
                 ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2137,7 +2150,9 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id" ON
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."parent_id" IS NULL)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id"."parent_id" IS NULL)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.parent_id', '=', False)])
@@ -2154,7 +2169,9 @@ class TestMany2one(TransactionCase):
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
             LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
                 ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2171,7 +2188,9 @@ class TestMany2one(TransactionCase):
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
             LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
                 ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2193,8 +2212,12 @@ class TestMany2one(TransactionCase):
             LEFT JOIN "res_country" AS "res_partner__country_id" ON
                 ("res_partner"."country_id" = "res_partner__country_id"."id")
             WHERE (
-                ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
-                OR ("res_partner"."country_id" IS NOT NULL AND "res_partner__country_id"."code" LIKE %s)
+                ("res_partner"."company_id" IS NOT NULL
+                    AND "res_partner__company_id"."id" IS NOT NULL
+                    AND "res_partner__company_id"."name" LIKE %s)
+                OR ("res_partner"."country_id" IS NOT NULL
+                    AND "res_partner__country_id"."id" IS NOT NULL
+                    AND "res_partner__country_id"."code" LIKE %s)
             )
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -2212,7 +2235,9 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id"
             ON ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
+            WHERE ("res_partner"."company_id" IS NOT NULL
+                AND "res_partner__company_id"."id" IS NOT NULL
+                AND "res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id', 'like', self.company.name)])
@@ -2426,7 +2451,9 @@ class TestOne2many(TransactionCase):
                 WHERE (
                     "res_partner"."active" IS TRUE
                     AND "res_partner"."parent_id" IS NOT NULL
-                    AND ("res_partner"."state_id" IS NOT NULL AND "res_partner__state_id__country_id"."code" LIKE %s)
+                    AND ("res_partner"."state_id" IS NOT NULL
+                        AND "res_partner__state_id"."id" IS NOT NULL
+                        AND "res_partner__state_id__country_id"."code" LIKE %s)
                 )
             ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -1,6 +1,7 @@
-from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.fields import Command, Domain
 from odoo.tests import TransactionCase
+
+from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 
 
 class TestSubqueries(TransactionCase):
@@ -13,9 +14,11 @@ class TestSubqueries(TransactionCase):
             FROM "test_orm_multi"
             LEFT JOIN "res_partner" AS "test_orm_multi__partner"
             ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
-            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
-                "test_orm_multi__partner"."name" LIKE %s
-                AND "test_orm_multi__partner"."phone" LIKE %s
+            WHERE (
+                "test_orm_multi"."partner" IS NOT NULL AND
+                "test_orm_multi__partner"."id" IS NOT NULL AND (
+                    "test_orm_multi__partner"."name" LIKE %s
+                    AND "test_orm_multi__partner"."phone" LIKE %s
             ))
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -30,9 +33,11 @@ class TestSubqueries(TransactionCase):
             FROM "test_orm_multi"
             LEFT JOIN "res_partner" AS "test_orm_multi__partner"
             ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
-            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
-                "test_orm_multi__partner"."name" LIKE %s
-                OR "test_orm_multi__partner"."phone" LIKE %s
+            WHERE (
+                "test_orm_multi"."partner" IS NOT NULL AND
+                "test_orm_multi__partner"."id" IS NOT NULL AND (
+                    "test_orm_multi__partner"."name" LIKE %s
+                    OR "test_orm_multi__partner"."phone" LIKE %s
             ))
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -87,9 +92,11 @@ class TestSubqueries(TransactionCase):
             FROM "test_orm_multi"
             LEFT JOIN "res_partner" AS "test_orm_multi__partner"
                 ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
-            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
-                "test_orm_multi__partner"."name" LIKE %s
-                OR "test_orm_multi__partner"."phone" LIKE %s
+            WHERE (
+                "test_orm_multi"."partner" IS NOT NULL AND
+                "test_orm_multi__partner"."id" IS NOT NULL AND (
+                    "test_orm_multi__partner"."name" LIKE %s
+                    OR "test_orm_multi__partner"."phone" LIKE %s
             ))
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -123,12 +130,14 @@ class TestSubqueries(TransactionCase):
             FROM "test_orm_multi"
             LEFT JOIN "res_partner" AS "test_orm_multi__partner"
             ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
-            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
-                "test_orm_multi__partner"."email" LIKE %s
-                AND (
-                    "test_orm_multi__partner"."name" LIKE %s
-                    OR "test_orm_multi__partner"."phone" LIKE %s
-                )
+            WHERE (
+                "test_orm_multi"."partner" IS NOT NULL AND
+                "test_orm_multi__partner"."id" IS NOT NULL AND (
+                    "test_orm_multi__partner"."email" LIKE %s
+                    AND (
+                        "test_orm_multi__partner"."name" LIKE %s
+                        OR "test_orm_multi__partner"."phone" LIKE %s
+                    )
             ))
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -146,7 +155,7 @@ class TestSubqueries(TransactionCase):
             LEFT JOIN "res_partner" AS "test_orm_multi__partner"
             ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
             WHERE (
-                ({many2one} IS NOT NULL AND (
+                ({many2one} IS NOT NULL AND "test_orm_multi__partner"."id" IS NOT NULL AND (
                     "test_orm_multi__partner"."email" LIKE %s
                     OR "test_orm_multi__partner"."name" LIKE %s
                 ))
@@ -155,7 +164,11 @@ class TestSubqueries(TransactionCase):
                     WHERE "res_partner"."website" LIKE %s
                 ))
                 AND (
-                    ({many2one} IS NOT NULL AND "test_orm_multi__partner"."function" LIKE %s)
+                    (
+                        {many2one} IS NOT NULL AND
+                        "test_orm_multi__partner"."id" IS NOT NULL AND
+                        "test_orm_multi__partner"."function" LIKE %s
+                    )
                     OR ({many2one} IS NULL OR {many2one} NOT IN (
                         {subselect}
                         WHERE "res_partner"."phone" LIKE %s
@@ -451,8 +464,11 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" IN %s)
-            AND "test_orm_related"."id" < %s
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                AND "test_orm_related__foo_id"."name" IN %s
+            ) AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name_sudo', '=', 'a')])
@@ -520,6 +536,7 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."bar_id" IN %s
             )
             AND "test_orm_related"."id" < %s
@@ -533,6 +550,7 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."bar_id" IN (
                     SELECT "test_orm_related_bar"."id"
                     FROM "test_orm_related_bar"
@@ -602,7 +620,7 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND EXISTS (
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."id" IS NOT NULL AND EXISTS (
                 SELECT 1
                 FROM "test_orm_related_bar_test_orm_related_foo_rel" AS "test_orm_related__foo_id__bar_ids"
                 WHERE "test_orm_related__foo_id__bar_ids"."test_orm_related_foo_id" = "test_orm_related__foo_id"."id"
@@ -618,7 +636,7 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND EXISTS (
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."id" IS NOT NULL AND EXISTS (
                 SELECT 1
                 FROM "test_orm_related_bar_test_orm_related_foo_rel" AS "test_orm_related__foo_id__bar_ids"
                 WHERE "test_orm_related__foo_id__bar_ids"."test_orm_related_foo_id" = "test_orm_related__foo_id"."id"
@@ -686,13 +704,15 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL
-                AND EXISTS(SELECT FROM (
-                    SELECT "test_orm_related"."foo_id" AS __inverse
-                    FROM "test_orm_related"
-                    WHERE "test_orm_related"."id" IN %s
-                    AND "test_orm_related"."foo_id" IS NOT NULL
-                ) AS __sub WHERE __inverse = "test_orm_related__foo_id"."id")
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                    AND EXISTS(SELECT FROM (
+                        SELECT "test_orm_related"."foo_id" AS __inverse
+                        FROM "test_orm_related"
+                        WHERE "test_orm_related"."id" IN %s
+                        AND "test_orm_related"."foo_id" IS NOT NULL
+                    ) AS __sub WHERE __inverse = "test_orm_related__foo_id"."id")
             )
             AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
@@ -705,6 +725,7 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND EXISTS(SELECT FROM (
                     SELECT "test_orm_related"."foo_id" AS __inverse
                     FROM "test_orm_related"
@@ -759,7 +780,6 @@ class TestSearchRelated(TransactionCase):
         model.search([('foo_binary_att_sudo', '!=', False)])
         model.search([('foo_binary_att_sudo', '=', False)])
         model.search([('foo_binary_bin_sudo', '!=', False)])
-
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
@@ -816,6 +836,7 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND EXISTS (
                     SELECT 1 FROM ir_attachment WHERE res_model = %s AND res_field = %s
                     AND res_id = "test_orm_related__foo_id"."id"
@@ -835,6 +856,7 @@ class TestSearchRelated(TransactionCase):
                 "test_orm_related"."foo_id" IS NULL
                 OR (
                     "test_orm_related"."foo_id" IS NOT NULL
+                    AND "test_orm_related__foo_id"."id" IS NOT NULL
                     AND NOT EXISTS (
                         SELECT 1 FROM ir_attachment WHERE res_model = %s AND res_field = %s
                         AND res_id = "test_orm_related__foo_id"."id"
@@ -853,6 +875,7 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."binary_bin" IS NOT NULL
             )
             AND "test_orm_related"."id" < %s
@@ -877,10 +900,15 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
                 ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND (
-                "test_orm_related__foo_id"."bar_id" IS NOT NULL
-                AND "test_orm_related__foo_id__bar_id"."name" IN %s
-            ))
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                AND (
+                    "test_orm_related__foo_id"."bar_id" IS NOT NULL
+                    AND "test_orm_related__foo_id__bar_id"."id" IS NOT NULL
+                    AND "test_orm_related__foo_id__bar_id"."name" IN %s
+                )
+            )
             AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
         """]):
@@ -950,6 +978,7 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."bar_id" IN (
                     SELECT "test_orm_related_bar"."id"
                     FROM "test_orm_related_bar"
@@ -1067,7 +1096,11 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" IN %s)
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                AND "test_orm_related__foo_id"."name" IN %s
+            )
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', '=', 'a')])
@@ -1093,6 +1126,7 @@ class TestSearchRelated(TransactionCase):
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NULL OR (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND ("test_orm_related__foo_id"."name" IN %s OR "test_orm_related__foo_id"."name" IS NULL)
             ))
             ORDER BY "test_orm_related"."id"
@@ -1104,7 +1138,11 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" NOT IN %s)
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                AND "test_orm_related__foo_id"."name" NOT IN %s
+            )
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', '!=', False)])
@@ -1114,7 +1152,10 @@ class TestSearchRelated(TransactionCase):
             FROM "test_orm_related"
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" IN %s)
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
+                AND "test_orm_related__foo_id"."name" IN %s)
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', 'in', ['a', 'b'])])
@@ -1140,7 +1181,8 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NULL OR (
-                "test_orm_related"."foo_id" IS NOT NULL AND (
+                "test_orm_related"."foo_id" IS NOT NULL AND
+                "test_orm_related__foo_id"."id" IS NOT NULL AND (
                     "test_orm_related__foo_id"."name" IN %s
                     OR "test_orm_related__foo_id"."name" IS NULL
                 )
@@ -1156,6 +1198,7 @@ class TestSearchRelated(TransactionCase):
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."name" NOT IN %s
             )
             ORDER BY "test_orm_related"."id"
@@ -1180,7 +1223,8 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NULL OR (
-                "test_orm_related"."foo_id" IS NOT NULL AND (
+                "test_orm_related"."foo_id" IS NOT NULL AND
+                "test_orm_related__foo_id"."id" IS NOT NULL AND (
                     "test_orm_related__foo_id"."name" IN %s
                     OR "test_orm_related__foo_id"."name" IS NULL
                 )
@@ -1198,11 +1242,15 @@ class TestSearchRelated(TransactionCase):
             ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NULL
-                OR ("test_orm_related"."foo_id" IS NOT NULL AND (
-                    "test_orm_related__foo_id"."bar_id" IS NULL
-                    OR ("test_orm_related__foo_id"."bar_id" IS NOT NULL AND (
-                        "test_orm_related__foo_id__bar_id"."name" IN %s
-                        OR "test_orm_related__foo_id__bar_id"."name" IS NULL
+                OR (
+                    "test_orm_related"."foo_id" IS NOT NULL AND
+                    "test_orm_related__foo_id"."id" IS NOT NULL AND (
+                        "test_orm_related__foo_id"."bar_id" IS NULL
+                        OR (
+                            "test_orm_related__foo_id"."bar_id" IS NOT NULL AND
+                            "test_orm_related__foo_id__bar_id"."id" IS NOT NULL AND (
+                                "test_orm_related__foo_id__bar_id"."name" IN %s
+                                OR "test_orm_related__foo_id__bar_id"."name" IS NULL
                     ))
                 ))
             )
@@ -1217,9 +1265,12 @@ class TestSearchRelated(TransactionCase):
             ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
             ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND (
-                "test_orm_related__foo_id"."bar_id" IS NOT NULL
-                AND "test_orm_related__foo_id__bar_id"."name" NOT IN %s
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL AND
+                "test_orm_related__foo_id"."id" IS NOT NULL AND (
+                    "test_orm_related__foo_id"."bar_id" IS NOT NULL
+                    AND "test_orm_related__foo_id__bar_id"."id" IS NOT NULL
+                    AND "test_orm_related__foo_id__bar_id"."name" NOT IN %s
             ))
             ORDER BY "test_orm_related"."id"
         """]):
@@ -1233,9 +1284,10 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
                 ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
             WHERE ("test_orm_related"."foo_id" IS NULL OR (
-                "test_orm_related"."foo_id" IS NOT NULL AND (
+                "test_orm_related"."foo_id" IS NOT NULL AND
+                "test_orm_related__foo_id"."id" IS NOT NULL AND (
                     "test_orm_related__foo_id"."bar_id" IS NULL
-                    OR ("test_orm_related__foo_id"."bar_id" IS NOT NULL AND (
+                    OR ("test_orm_related__foo_id"."bar_id" IS NOT NULL AND "test_orm_related__foo_id__bar_id"."id" IS NOT NULL AND (
                         "test_orm_related__foo_id__bar_id"."name" IN %s
                         OR "test_orm_related__foo_id__bar_id"."name" IS NULL
                     ))
@@ -1252,8 +1304,9 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
                 ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
-            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND (
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."id" IS NOT NULL AND (
                 "test_orm_related__foo_id"."bar_id" IS NOT NULL
+                AND "test_orm_related__foo_id__bar_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id__bar_id"."name" NOT IN %s
             ))
             ORDER BY "test_orm_related"."id"
@@ -1292,6 +1345,7 @@ class TestSearchRelated(TransactionCase):
                 ON ("test_orm_related_inherits__base_id"."foo_id" = "test_orm_related_inherits__base_id__foo_id"."id")
             WHERE (
                 "test_orm_related_inherits__base_id"."foo_id" IS NOT NULL
+                AND "test_orm_related_inherits__base_id__foo_id"."id" IS NOT NULL
                 AND "test_orm_related_inherits__base_id__foo_id"."name" IN %s
             )
             AND "test_orm_related_inherits__base_id"."id" < %s
@@ -1325,8 +1379,10 @@ class TestSearchRelated(TransactionCase):
             LEFT JOIN "test_orm_related_bar" AS "test_orm_related_inherits__base_id__foo_id__bar_id"
                 ON ("test_orm_related_inherits__base_id__foo_id"."bar_id" = "test_orm_related_inherits__base_id__foo_id__bar_id"."id")
             WHERE (
-                "test_orm_related_inherits__base_id"."foo_id" IS NOT NULL AND (
+                "test_orm_related_inherits__base_id"."foo_id" IS NOT NULL AND
+                "test_orm_related_inherits__base_id__foo_id"."id" IS NOT NULL AND (
                     "test_orm_related_inherits__base_id__foo_id"."bar_id" IS NOT NULL
+                    AND "test_orm_related_inherits__base_id__foo_id__bar_id"."id" IS NOT NULL
                     AND "test_orm_related_inherits__base_id__foo_id__bar_id"."name" IN %s
                 )
             )
@@ -1419,6 +1475,7 @@ class TestSearchAny(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."name" IN %s
             ) AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
@@ -1432,6 +1489,7 @@ class TestSearchAny(TransactionCase):
                 ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."id" IS NOT NULL
                 AND "test_orm_related__foo_id"."bar_id" IN (
                     SELECT "test_orm_related_bar"."id"
                     FROM "test_orm_related_bar"
@@ -1614,7 +1672,11 @@ class TestFlushSearch(TransactionCase):
             FROM "test_orm_city"
             LEFT JOIN "test_orm_country" AS "test_orm_city__country_id"
             ON ("test_orm_city"."country_id" = "test_orm_city__country_id"."id")
-            WHERE ("test_orm_city"."country_id" IS NOT NULL AND "test_orm_city__country_id"."name" LIKE %s)
+            WHERE (
+                "test_orm_city"."country_id" IS NOT NULL
+                AND "test_orm_city__country_id"."id" IS NOT NULL
+                AND "test_orm_city__country_id"."name" LIKE %s
+            )
             ORDER BY "test_orm_city"."id"
         ''']):
             self.brussels.country_id = self.france
@@ -1632,7 +1694,11 @@ class TestFlushSearch(TransactionCase):
             FROM "test_orm_city"
             LEFT JOIN "test_orm_country" AS "test_orm_city__country_id"
             ON ("test_orm_city"."country_id" = "test_orm_city__country_id"."id")
-            WHERE ("test_orm_city"."country_id" IS NOT NULL AND "test_orm_city__country_id"."name" LIKE %s)
+            WHERE (
+                "test_orm_city"."country_id" IS NOT NULL
+                AND "test_orm_city__country_id"."id" IS NOT NULL
+                AND "test_orm_city__country_id"."name" LIKE %s
+            )
             ORDER BY "test_orm_city"."id"
         ''']):
             self.belgium.name = "Belgique"
@@ -1653,7 +1719,11 @@ class TestFlushSearch(TransactionCase):
             FROM "test_orm_city"
             LEFT JOIN "test_orm_country" AS "test_orm_city__country_id"
                 ON ("test_orm_city"."country_id" = "test_orm_city__country_id"."id")
-            WHERE ("test_orm_city"."country_id" IS NOT NULL AND "test_orm_city__country_id"."name" LIKE %s)
+            WHERE (
+                "test_orm_city"."country_id" IS NOT NULL
+                AND "test_orm_city__country_id"."id" IS NOT NULL
+                AND "test_orm_city__country_id"."name" LIKE %s
+            )
             ORDER BY "test_orm_city"."id"
         ''']):
             self.brussels.country_id = self.france

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -514,7 +514,9 @@ class Many2one(_Relational):
                 sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)
             if can_be_null:
                 if positive:
-                    sql = SQL("(%s IS NOT NULL AND %s)", sql_field, sql)
+                    # PERF: Explicitly rejecting NULLs on the joined primary key allows PostgreSQL
+                    # to reduce the LEFT JOIN to an INNER JOIN and potentially choose a better plan.
+                    sql = SQL("(%s IS NOT NULL AND %s IS NOT NULL AND %s)", sql_field, SQL.identifier(coalias, 'id'), sql)
                 else:
                     sql = SQL("(%s IS NULL OR %s)", sql_field, sql)
             return sql


### PR DESCRIPTION
This is a backport of https://github.com/odoo/odoo/pull/269564 to v19.0, this backport is proposed to Odoo https://github.com/odoo/odoo/pull/287712 


Odoo uses a LEFT JOIN when traversing an optional many2one field, since the FK can be unset. For positive conditions, the SQL already included `fk_col IS NOT NULL` to exclude records where the relation is empty, which logically makes the LEFT JOIN equivalent to an INNER JOIN, but does not trigger PostgreSQL's join promotion.

To decide whether to promote, PostgreSQL scans the WHERE clause for predicates that cannot return TRUE when the right-side table's columns are all NULL (as they would be on an unmatched row). `fk_col IS NOT NULL` is a predicate on the left table, so it is invisible to that check. Table constraints do not help either: the promotion logic (`reduce_outer_joins()`) is purely predicate-based and does not consult them.

Adding `joined_table.id IS NOT NULL` gives the planner exactly what it needs: a null-rejecting predicate on the right side. Once promoted to an INNER JOIN, the planner can reorder the join freely, typically choosing to start from the smaller lookup table rather than being forced to drive from the large fact table and discard most rows afterward.

The predicate is a semantic no-op and acts purely as a hint: if the join matched, the right-side `id` is by definition not NULL, so query results are identical and there is no behavioral risk.

The `fk_col IS NOT NULL` is kept, even if there is an equivalence class between the `id` and the `fk_col` post-promotion, because PG doesn't evaluate cost estimation with equivalence class evaluated, only based on the initial predicate on the table. This is impactful if the `fk_col` predicate is highly selective.

task-6296255


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
